### PR TITLE
Use default theme font for Applause count

### DIFF
--- a/client/components/applause/index.js
+++ b/client/components/applause/index.js
@@ -95,9 +95,9 @@ const Applause = ( props ) => {
 				tabIndex={ 0 }
 			>
 				<ApplauseAnimation active={ animationActiveState } />
-				<span className="crowdsignal-forms-applause__count">
+				<p className="crowdsignal-forms-applause__count">
 					{ formatVoteCount( displayedVoteCount ) } Claps
-				</span>
+				</p>
 				{ renderStyleProbe() }
 			</div>
 			<BrandLink

--- a/client/components/applause/style.scss
+++ b/client/components/applause/style.scss
@@ -11,6 +11,10 @@
 	user-select: none;
 	--webkit-user-select: none;
 
+	.crowdsignal-forms-applause__count {
+		margin: 0;
+	}
+
 	&.size-small {
 		padding: 20px 16px 18px 12px;
 		height: 0.7em;


### PR DESCRIPTION
This PR changes the Applause count tag so it inherits the editor styles. It also compensates the margin assigned to `p` tags.

Tested well on:

  - Twenty Twenty Theme
  - Twenty Nineteen Theme
  - Twenty Seventeen Theme
  - Neve Theme
  - Seedlet Theme
  - Astra Theme

## Test instructions

Checkout and run `make client`. Add/edit a post with an Applause block. Verify the clap count text shows the default theme font both in the editor and in the public frontend
