### PR TITLE
Fix applause branding styles

### DIFF
--- a/client/components/applause/style.scss
+++ b/client/components/applause/style.scss
@@ -1,4 +1,8 @@
 /* public Applause style */
+.crowdsignal-applause-wrapper {
+	margin-bottom: 3em;
+}
+
 .crowdsignal-forms-applause {
 	display: flex;
 	flex-direction: row;

--- a/client/components/brand-link/style.scss
+++ b/client/components/brand-link/style.scss
@@ -4,9 +4,14 @@
 	.crowdsignal-forms__branding-link {
 		font-family: $font-sans-serif;
 		font-size: 8px;
-		padding: 8px 20px 0;
+		padding: 8px 12px 0;
 		text-decoration: none !important;
 		text-transform: uppercase;
+		box-shadow: none;
+
+		&:hover {
+			box-shadow: none;
+		}
 
 		&.with-external-icon::after {
 			content: "\2197";

--- a/client/components/brand-link/style.scss
+++ b/client/components/brand-link/style.scss
@@ -8,6 +8,7 @@
 		text-decoration: none !important;
 		text-transform: uppercase;
 		box-shadow: none;
+		border: 0;
 
 		&:hover {
 			box-shadow: none;


### PR DESCRIPTION
This PR adjusts the brand link shown on free users so that it:

  - compensates width of the link to better align with the block
  - removes shadow and border as those strategies are used to *underline* the link on some themes

## Test instructions

Checkou and `make client`. Visit a post with an applause block created from a free Crowdsignal account. Once clapped, the block should show the brand link below.
Verify the link looks centered.
Verify the link is not underlined
