### PR TITLE
Fix applause count style

### DIFF
--- a/client/components/applause/style.scss
+++ b/client/components/applause/style.scss
@@ -16,7 +16,7 @@
 	--webkit-user-select: none;
 
 	.crowdsignal-forms-applause__count {
-		margin: 0;
+		margin: unset !important;
 	}
 
 	&.size-small {


### PR DESCRIPTION
Applause count style is being overridden on P2s:
![image](https://user-images.githubusercontent.com/157240/100897305-51fdd980-349e-11eb-8e8e-58480cf3700c.png)

This PR adds a `margin: unset important!` to the count wrapper.
![image](https://user-images.githubusercontent.com/157240/100897476-7bb70080-349e-11eb-8353-982be5d61e2a.png)

## Test instructions
Checkout and `make client`
See that the applause blocks look ok on local docker and on P2s