### PR TITLE
Bump version to 1.3.4

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -4,7 +4,7 @@ Tags: polls, forms, surveys, gutenberg, block
 Requires at least: 5.0
 Requires PHP: 5.6.20
 Tested up to: 5.6
-Stable tag: 1.3.3
+Stable tag: 1.3.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -67,6 +67,11 @@ Compare our [simple and affordable plans](https://crowdsignal.com/pricing/) or t
 
 == Changelog ==
 
+= 1.3.4 =
+* Escape the redirect address to avoid XSS. (#7)
+* Bump tested version to 5.6 (#8)
+* Unset margins on applause count container (#6)
+
 = 1.3.3 =
 * Unwrap all i18n calls (#1)
 * Use default theme font for Applause count (#3)
@@ -99,32 +104,10 @@ Compare our [simple and affordable plans](https://crowdsignal.com/pricing/) or t
 * add support for syncing applause block type to crowdsignal (#318)
 * Add skeleton of applause block (#314)
 
-= 1.2.1 =
-* Center brand link with vote items (#336)
-* Fix CSS Animation for Voting Thumbs (#332)
-* Vote Block: Set focus Styling to hover styling (#329)
-* clean up attribute passing to vote-item (#323)
-* Add referral code to public Crowdsignal links (#330)
-
-= 1.2.0 =
-* add more keywords to vote and poll block (#310)
-* Show current account info on API key selection screen (#317)
-* refactor common code for poll based blocks (#311)
-* set mappings for missing meta values (#309)
-* Fix Default Title not syncing to platform (#253)
-* Consolidate Custom Mutation Observers Into Library Function (#244)
-* change Block interface into abstract class, move common helpers there. (#243)
-* Add Crowdsignal block category to house all blocks within the plugin (#246)
-* Vote block
-* Update admin notices style (#305)
-* Check API key is not empty before attempting to update connection settings
-* Adding a slight opacity change when hovering a button that has a custom bg color set. (#303)
-* Update/security fixes (#302)
-
 == Upgrade Notice ==
 
-= 1.3 =
-Introduces the Applause block
+= 1.3.4 =
+Style and security fixes. Please update.
 
 = 0.9 =
 Initial release

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+= 1.3.4 =
+* Escape the redirect address to avoid XSS. (#7)
+* Bump tested version to 5.6 (#8)
+* Unset margins on applause count container (#6)
+
 = 1.3.3 =
 * Unwrap all i18n calls (#1)
 * Use default theme font for Applause count (#3)

--- a/crowdsignal-forms.php
+++ b/crowdsignal-forms.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Crowdsignal Forms
  * Plugin URI:        https://crowdsignal.com/crowdsignal-forms/
  * Description:       Crowdsignal Form Blocks
- * Version:           1.3.3
+ * Version:           1.3.4
  * Author:            Automattic
  * Author URI:        https://automattic.com/
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die;
 }
 
-define( 'CROWDSIGNAL_FORMS_VERSION', '1.3.3' );
+define( 'CROWDSIGNAL_FORMS_VERSION', '1.3.4' );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_FILE', __FILE__ );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 

--- a/includes/admin/class-crowdsignal-forms-settings.php
+++ b/includes/admin/class-crowdsignal-forms-settings.php
@@ -42,7 +42,7 @@ class Crowdsignal_Forms_Settings {
 	 * Enqueues scripts for setup page.
 	 */
 	public function admin_enqueue_scripts() {
-		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.3.3' );
+		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.3.4' );
 	}
 
 	/**

--- a/includes/admin/class-crowdsignal-forms-setup.php
+++ b/includes/admin/class-crowdsignal-forms-setup.php
@@ -65,7 +65,7 @@ class Crowdsignal_Forms_Setup {
 	 * Enqueues scripts for setup page.
 	 */
 	public function admin_enqueue_scripts() {
-		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.3.3' );
+		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.3.4' );
 		wp_enqueue_script( 'videopress', 'https://videopress.com/videopress-iframe.js', array(), '1.0', false );
 	}
 

--- a/languages/crowdsignal-forms.pot
+++ b/languages/crowdsignal-forms.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Crowdsignal Forms 1.3.3\n"
+"Project-Id-Version: Crowdsignal Forms 1.3.4\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/crowdsignal-forms\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2020-11-17T18:55:51+00:00\n"
+"POT-Creation-Date: 2020-12-09T15:49:25+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.5.0-alpha-75cb7e3\n"
 "X-Domain: crowdsignal-forms\n"
@@ -181,7 +181,7 @@ msgstr ""
 msgid "<a href=\"%1s\" target=\"_blank\">Read more about us here.</a>"
 msgstr ""
 
-#: includes/frontend/blocks/class-crowdsignal-forms-poll-block.php:152
+#: includes/frontend/blocks/class-crowdsignal-forms-poll-block.php:153
 #: client/blocks/poll/attributes.js:62
 msgid "Submit"
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/crowdsignal-forms",
-	"version": "1.3.3",
+	"version": "1.3.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/crowdsignal-forms",
-	"version": "1.3.3",
+	"version": "1.3.4",
 	"description": "Crowdsignal powered forms for WordPress",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
This PR is the version bump on all our files. v1.3.4 includes the latest security fixes.

## Test instructions

Checkout `v1.3.4`, verify all blocks are working correctly.