### PR TITLE
Remove redirect URL feature

### DIFF
--- a/client/blocks/poll/sidebar.js
+++ b/client/blocks/poll/sidebar.js
@@ -146,6 +146,11 @@ const SideBar = ( {
 
 	const answerStyle = getAnswerStyle( attributes, className );
 
+	// Force redirect into simple THANK_YOU until some workaround to prevent phishing
+	if ( ConfirmMessageType.REDIRECT === attributes.confirmMessageType ) {
+		attributes.confirmMessageType = ConfirmMessageType.THANK_YOU;
+	}
+
 	return (
 		<InspectorControls>
 			<PanelBody

--- a/client/blocks/poll/sidebar.js
+++ b/client/blocks/poll/sidebar.js
@@ -146,7 +146,7 @@ const SideBar = ( {
 
 	const answerStyle = getAnswerStyle( attributes, className );
 
-	// Force redirect into simple THANK_YOU until some workaround to prevent phishing
+	// https://github.com/Automattic/crowdsignal-forms/issues/14
 	if ( ConfirmMessageType.REDIRECT === attributes.confirmMessageType ) {
 		attributes.confirmMessageType = ConfirmMessageType.THANK_YOU;
 	}
@@ -222,7 +222,7 @@ const SideBar = ( {
 							),
 							value: ConfirmMessageType.CUSTOM_TEXT,
 						},
-						// Suspended until some workaround to prevent phishing
+						// https://github.com/Automattic/crowdsignal-forms/issues/14
 						// {
 						// 	label: __(
 						// 		'Redirect to another webpage',

--- a/client/blocks/poll/sidebar.js
+++ b/client/blocks/poll/sidebar.js
@@ -222,13 +222,14 @@ const SideBar = ( {
 							),
 							value: ConfirmMessageType.CUSTOM_TEXT,
 						},
-						{
-							label: __(
-								'Redirect to another webpage',
-								'crowdsignal-forms'
-							),
-							value: ConfirmMessageType.REDIRECT,
-						},
+						// Suspended until some workaround to prevent phishing
+						// {
+						// 	label: __(
+						// 		'Redirect to another webpage',
+						// 		'crowdsignal-forms'
+						// 	),
+						// 	value: ConfirmMessageType.REDIRECT,
+						// },
 					] }
 					onChange={ handleChangeConfirmMessageType }
 				/>

--- a/client/components/poll/index.js
+++ b/client/components/poll/index.js
@@ -57,11 +57,12 @@ const Poll = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 
 			await vote( selectedAnswerIds );
 
-			if (
-				ConfirmMessageType.REDIRECT === attributes.confirmMessageType
-			) {
-				window.open( attributes.redirectAddress );
-			}
+			// Suspended until some workaround to prevent phishing
+			// if (
+			// 	ConfirmMessageType.REDIRECT === attributes.confirmMessageType
+			// ) {
+			// 	window.open( attributes.redirectAddress );
+			// }
 		} catch ( ex ) {
 			if ( ex instanceof CrowdsignalFormsError ) {
 				setErrorMessage( ex.message );
@@ -89,10 +90,9 @@ const Poll = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 			ConfirmMessageType.RESULTS === attributes.confirmMessageType );
 
 	const showSubmitMessage =
-		hasVoted &&
-		! showResults &&
-		! dismissSubmitMessage &&
-		ConfirmMessageType.REDIRECT !== attributes.confirmMessageType;
+		hasVoted && ! showResults && ! dismissSubmitMessage;
+	// Suspended until some workaround to prevent phishing
+	// && ConfirmMessageType.REDIRECT !== attributes.confirmMessageType;
 
 	const hasDefaultThankyou =
 		ConfirmMessageType.THANK_YOU === attributes.confirmMessageType;

--- a/client/components/poll/index.js
+++ b/client/components/poll/index.js
@@ -45,7 +45,7 @@ const Poll = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 		attributes.hasOneResponsePerComputer
 	);
 
-	// Force redirect into simple THANK_YOU until some workaround to prevent phishing
+	// https://github.com/Automattic/crowdsignal-forms/issues/14
 	if ( ConfirmMessageType.REDIRECT === attributes.confirmMessageType ) {
 		attributes.confirmMessageType = ConfirmMessageType.THANK_YOU;
 	}
@@ -57,7 +57,7 @@ const Poll = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 
 			await vote( selectedAnswerIds );
 
-			// Suspended until some workaround to prevent phishing
+			// https://github.com/Automattic/crowdsignal-forms/issues/14
 			// if (
 			// 	ConfirmMessageType.REDIRECT === attributes.confirmMessageType
 			// ) {

--- a/client/components/poll/index.js
+++ b/client/components/poll/index.js
@@ -45,6 +45,11 @@ const Poll = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 		attributes.hasOneResponsePerComputer
 	);
 
+	// Force redirect into simple THANK_YOU until some workaround to prevent phishing
+	if ( ConfirmMessageType.REDIRECT === attributes.confirmMessageType ) {
+		attributes.confirmMessageType = ConfirmMessageType.THANK_YOU;
+	}
+
 	const handleSubmit = async ( selectedAnswerIds ) => {
 		try {
 			setErrorMessage( '' );


### PR DESCRIPTION
This PR removes the "redirect to URL after voting" feature until further notice.

Existent polls with this option are now being forced into *thank you* message. The option is no longer available on the sidebar.

## Test instructions

Checkout and `make client`

Visit a post with some poll block with redirect option set. After voting, you should see the default "Thank you" message.

Create a post and add a poll block to it. You should not see the "Redirect to URL" option on the sidebar.

Closes #14 