### PR TITLE
Add popup & dialog logic for the NPS block

### DIFF
--- a/assets/stylesheets/nps.scss
+++ b/assets/stylesheets/nps.scss
@@ -1,3 +1,7 @@
 // Shared
 @import "./shared/animations.scss";
 @import "./shared/variables.scss";
+
+// Components
+@import "components/dialog-wrapper/style.scss";
+@import "components/nps/style.scss";

--- a/client/blocks/nps/attributes.js
+++ b/client/blocks/nps/attributes.js
@@ -13,4 +13,8 @@ export default {
 		type: 'string',
 		default: null,
 	},
+	viewThreshold: {
+		type: 'string',
+		default: 3,
+	},
 };

--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -12,13 +12,15 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import ConnectToCrowdsignal from 'components/connect-to-crowdsignal';
+import Sidebar from './sidebar';
 
-const EditNpsBlock = () => {
+const EditNpsBlock = ( props ) => {
 	return (
 		<ConnectToCrowdsignal
 			blockIcon={ null }
 			blockName={ __( 'Crowdsignal NPS', 'crowdsignal-forms' ) }
 		>
+			<Sidebar { ...props } />
 			One NPS please!
 		</ConnectToCrowdsignal>
 	);

--- a/client/blocks/nps/sidebar.js
+++ b/client/blocks/nps/sidebar.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { PanelBody, TextControl } from '@wordpress/components';
+import { InspectorControls } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+
+const Sidebar = ( { attributes, setAttributes } ) => {
+	const handleChangeViewThreshold = ( viewThreshold ) =>
+		setAttributes( {
+			viewThreshold,
+		} );
+
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={ __( 'NPS Settings', 'crowdsignal-forms' ) }
+				initialOpen={ true }
+			>
+				<TextControl
+					label={ __( 'View threshold', 'crowdsignal-forms' ) }
+					value={ attributes.viewThreshold }
+					onChange={ handleChangeViewThreshold }
+					type="number"
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+};
+
+export default Sidebar;

--- a/client/components/dialog-wrapper/index.js
+++ b/client/components/dialog-wrapper/index.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import React, { useRef } from 'react';
+
+const DialogWrapper = ( { children, onClose } ) => {
+	const wrapper = useRef( null );
+
+	const handleClose = ( event ) =>
+		event.target === wrapper.current && onClose();
+
+	return (
+		// eslint-disable-next-line
+		<div
+			ref={ wrapper }
+			role="dialog"
+			aria-modal="true"
+			className="crowdsignal-forms-dialog-wrapper"
+			onClick={ handleClose }
+		>
+			{ children }
+		</div>
+	);
+};
+
+export default DialogWrapper;

--- a/client/components/dialog-wrapper/style.scss
+++ b/client/components/dialog-wrapper/style.scss
@@ -1,0 +1,12 @@
+.crowdsignal-forms-dialog-wrapper {
+	align-items: center;
+	background: rgba(0, 0, 0, 0.3);
+	display: flex;
+	justify-content: center;
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	top: 0;
+	z-index: 10000;
+}

--- a/client/components/nps/index.js
+++ b/client/components/nps/index.js
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const Nps = () => {
+	return <div className="crowdsignal-forms-nps">Here be dragons</div>;
+};
+
+export default Nps;

--- a/client/components/nps/style.scss
+++ b/client/components/nps/style.scss
@@ -1,0 +1,10 @@
+/* Public NPS block styles */
+
+.crowdsignal-forms-nps {
+	border: 0;
+	border-top: 5px solid #002c40;
+	background-color: #fff;
+	height: auto;
+	padding: 50px;
+	width: 600px;
+}

--- a/client/nps.js
+++ b/client/nps.js
@@ -1,2 +1,56 @@
-// eslint-disable-next-line no-console
-console.log( 'Here be dragons' );
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render } from 'react-dom';
+import { forEach } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import DialogWrapper from 'components/dialog-wrapper';
+import NpsBlock from 'components/nps';
+
+const NPS_VIEWS_STORAGE_PREFIX = `cs-nps-views-`;
+
+window.addEventListener( 'load', () =>
+	forEach(
+		document.querySelectorAll( `div[data-crowdsignal-nps]` ),
+		( element ) => {
+			try {
+				const attributes = JSON.parse( element.dataset.crowdsignalNps );
+				const { surveyId, viewThreshold } = attributes;
+
+				const key = `${ NPS_VIEWS_STORAGE_PREFIX }${ surveyId }`;
+				const viewCount =
+					1 + parseInt( window.localStorage.getItem( key ) || 0, 10 );
+
+				window.localStorage.setItem( key, viewCount );
+
+				// eslint-disable-next-line no-console
+				console.log(
+					`NPS block: Current view count: ${ viewCount }. Threshold: ${ viewThreshold }.` +
+						`Use "localStorage.setItem( '${ key }', 0 );" to reset the counter.`
+				);
+
+				element.removeAttribute( 'data-crowdsignal-nps' );
+
+				if ( viewCount !== viewThreshold ) {
+					return;
+				}
+
+				const closeDialog = () => element.remove();
+
+				render(
+					<DialogWrapper onClose={ closeDialog }>
+						<NpsBlock attributes={ attributes } />
+					</DialogWrapper>,
+					element
+				);
+			} catch ( error ) {
+				// eslint-disable-next-line no-console
+				console.error( error );
+			}
+		}
+	)
+);

--- a/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
@@ -59,7 +59,7 @@ class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 	/**
 	 * Renders the NPS dynamic block
 	 *
-	 * @param  array $attributes The block's attributes.
+	 * @param  array $attributes The block's attributes.2
 	 * @return string
 	 */
 	public function render( $attributes ) {
@@ -84,7 +84,7 @@ class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 	 * @return bool
 	 */
 	private function should_hide_block() {
-		return ! $this->is_cs_connected();
+		return ! $this->is_cs_connected() || ! is_single();
 	}
 
 	/**
@@ -104,6 +104,10 @@ class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 			'surveyId'     => array(
 				'type'    => 'string',
 				'default' => null,
+			),
+			'viewThreshold' => array(
+				'type'    => 'string',
+				'default' => 3,
 			),
 		);
 	}

--- a/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
@@ -97,11 +97,11 @@ class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 	 */
 	private function attributes() {
 		return array(
-			'hideBranding' => array(
+			'hideBranding'  => array(
 				'type'    => 'boolean',
 				'default' => false,
 			),
-			'surveyId'     => array(
+			'surveyId'      => array(
 				'type'    => 'string',
 				'default' => null,
 			),

--- a/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
@@ -59,7 +59,7 @@ class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 	/**
 	 * Renders the NPS dynamic block
 	 *
-	 * @param  array $attributes The block's attributes.2
+	 * @param  array $attributes The block's attributes.
 	 * @return string
 	 */
 	public function render( $attributes ) {

--- a/includes/frontend/class-crowdsignal-forms-block.php
+++ b/includes/frontend/class-crowdsignal-forms-block.php
@@ -70,7 +70,7 @@ abstract class Crowdsignal_Forms_Block {
 
 		try {
 			$capabilities  = Crowdsignal_Forms::instance()->get_api_gateway()->get_capabilities();
-			$hide_branding = false !== array_search( 'hide-branding', $capabilities, true )
+			$hide_branding = is_wp_error( $capabilities) || false !== array_search( 'hide-branding', $capabilities, true )
 				? self::HIDE_BRANDING_YES
 				: self::HIDE_BRANDING_NO;
 		} catch ( \Exception $ex ) {

--- a/includes/frontend/class-crowdsignal-forms-block.php
+++ b/includes/frontend/class-crowdsignal-forms-block.php
@@ -70,7 +70,7 @@ abstract class Crowdsignal_Forms_Block {
 
 		try {
 			$capabilities  = Crowdsignal_Forms::instance()->get_api_gateway()->get_capabilities();
-			$hide_branding = is_wp_error( $capabilities) || false !== array_search( 'hide-branding', $capabilities, true )
+			$hide_branding = false !== array_search( 'hide-branding', $capabilities, true )
 				? self::HIDE_BRANDING_YES
 				: self::HIDE_BRANDING_NO;
 		} catch ( \Exception $ex ) {


### PR DESCRIPTION
This patch adds the necessary logic for the block/dialog to be rendered on the frontend.

I've defined a new `viewThreshold` attribute which we'll be using to trigger the dialog at the right time. The setting might not save correctly right now due to there not being a `surveyId` (which will be addressed in another PR that integrates it with the Crowdsignal API), but the default value should be good enough for testing.

Another thing worth noting is, I've updated the server side `Crowdsignal_Forms_Nps_Block::should_hide_block()` to also hide the block unless it's a single page as it could become troublesome to manage if these started appearing on feeds.

The dialog is still a placeholder here and can be closed by clicking on the backdrop.

## Testing

- Add an 'NPS block' to your post and verify a dialog appears after visiting the page exactly three times.
- When viewing the post on a feed, the 'block' should be removed from the post content.