### PR TITLE
Integrate the NPS block with the Crowdsignal API

### DIFF
--- a/client/blocks/nps/attributes.js
+++ b/client/blocks/nps/attributes.js
@@ -5,13 +5,25 @@
  */
 
 export default {
+	feedbackQuestion: {
+		type: 'string',
+		default: '',
+	},
 	hideBranding: {
 		type: 'boolean',
 		default: false,
 	},
+	ratingQuestion: {
+		type: 'string',
+		default: '',
+	},
 	surveyId: {
 		type: 'string',
 		default: null,
+	},
+	title: {
+		type: 'string',
+		default: '',
 	},
 	viewThreshold: {
 		type: 'string',

--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -6,6 +6,7 @@ import React from 'react';
 /**
  * WordPress dependencies
  */
+import { RichText } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -15,13 +16,64 @@ import ConnectToCrowdsignal from 'components/connect-to-crowdsignal';
 import Sidebar from './sidebar';
 
 const EditNpsBlock = ( props ) => {
+	const { attributes, setAttributes } = props;
+
+	const handleChangeTitle = ( title ) => setAttributes( { title } );
+
+	const handleChangeRatingQuestion = ( ratingQuestion ) =>
+		setAttributes( {
+			ratingQuestion,
+		} );
+
+	const handleChangeFeedbackQuestion = ( feedbackQuestion ) =>
+		setAttributes( {
+			feedbackQuestion,
+		} );
+
 	return (
 		<ConnectToCrowdsignal
 			blockIcon={ null }
 			blockName={ __( 'Crowdsignal NPS', 'crowdsignal-forms' ) }
 		>
 			<Sidebar { ...props } />
-			One NPS please!
+
+			<div className="crowdsignal-forms-nps">
+				<RichText
+					tagName="h3"
+					className="crowdsignal-forms-nps__title"
+					placeholder={ __(
+						'Title',
+						'crowdsignal-forms'
+					) }
+					onChange={ handleChangeTitle }
+					value={ attributes.title }
+					allowedFormats={ [] }
+				/>
+
+				<RichText
+					tagName="p"
+					className="crowdsignal-forms-nps__question"
+					placeholder={ __(
+						'Enter your rating question',
+						'crowdsignal-forms'
+					) }
+					onChange={ handleChangeRatingQuestion }
+					value={ attributes.ratingQuestion }
+					allowedFormats={ [] }
+				/>
+
+				<RichText
+					tagName="p"
+					className="crowdsignal-forms-nps__question"
+					placeholder={ __(
+						'Enter your feedback question',
+						'crowdsignal-forms'
+					) }
+					onChange={ handleChangeFeedbackQuestion }
+					value={ attributes.feedbackQuestion }
+					allowedFormats={ [] }
+				/>
+			</div>
 		</ConnectToCrowdsignal>
 	);
 };

--- a/client/blocks/poll/hooks.js
+++ b/client/blocks/poll/hooks.js
@@ -1,31 +1,18 @@
 /**
  * External dependencies
  */
+import { useEffect, useState } from 'react';
 import { map } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { useEffect, useState } from 'react';
 import { useEntityId } from '@wordpress/core-data';
 
-const withTimeout = ( timeout, promise ) => {
-	let timeoutId;
-	return new Promise( ( resolve, reject ) => {
-		timeoutId = setTimeout(
-			() => reject( new Error( 'request timeout' ) ),
-			timeout
-		);
-		promise
-			.then( resolve, reject )
-			.finally( () => clearTimeout( timeoutId ) );
-	} );
-};
+import { withRequestTimeout } from 'data/util';
 
 const defaultAnswer = { text: '' };
-
-const API_REQUEST_TIMEOUT = 10000;
 
 const toApi = ( { pollId, answers, note, question, ...settings }, postId ) => {
 	const timestamp = Date.parse( settings.closedAfterDateTime ) || Date.now();
@@ -68,8 +55,7 @@ const toApi = ( { pollId, answers, note, question, ...settings }, postId ) => {
 };
 
 const createPoll = ( data ) =>
-	withTimeout(
-		API_REQUEST_TIMEOUT,
+	withRequestTimeout(
 		apiFetch( {
 			path: '/crowdsignal-forms/v1/polls',
 			method: 'POST',
@@ -78,8 +64,7 @@ const createPoll = ( data ) =>
 	);
 
 const getPoll = ( pollId ) =>
-	withTimeout(
-		API_REQUEST_TIMEOUT,
+	withRequestTimeout(
 		apiFetch( {
 			path: `/crowdsignal-forms/v1/polls/${ pollId }`,
 			method: 'GET',
@@ -87,8 +72,7 @@ const getPoll = ( pollId ) =>
 	);
 
 const updatePoll = ( pollId, data ) =>
-	withTimeout(
-		API_REQUEST_TIMEOUT,
+	withRequestTimeout(
 		apiFetch( {
 			path: `/crowdsignal-forms/v1/polls/${ pollId }`,
 			method: 'POST',
@@ -97,8 +81,7 @@ const updatePoll = ( pollId, data ) =>
 	);
 
 export const archivePoll = ( pollId ) =>
-	withTimeout(
-		API_REQUEST_TIMEOUT,
+	withRequestTimeout(
 		apiFetch( {
 			path: `/crowdsignal-forms/v1/polls/${ pollId }/archive`,
 			method: 'POST',

--- a/client/components/nps/index.js
+++ b/client/components/nps/index.js
@@ -3,8 +3,21 @@
  */
 import React from 'react';
 
-const Nps = () => {
-	return <div className="crowdsignal-forms-nps">Here be dragons</div>;
+const Nps = ( { attributes } ) => {
+	return (
+		<div className="crowdsignal-forms-nps">
+			<h3 className="crowdsignal-forms-nps__title">
+				{ attributes.title }
+			</h3>
+
+			<p className="crowdsignal-forms-nps__question">
+				{ attributes.ratingQuestion }
+			</p>
+			<p className="crowdsignal-forms-nps__question">
+				{ attributes.feedbackQuestion }
+			</p>
+		</div>
+	);
 };
 
 export default Nps;

--- a/client/data/nps/index.js
+++ b/client/data/nps/index.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { trimEnd } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { withRequestTimeout } from 'data/util';
+
+export const updateNps = ( data ) =>
+	withRequestTimeout(
+		apiFetch( {
+			path: trimEnd(
+				`/crowdsignal-forms/v1/nps/${ data.surveyId || '' }`,
+				'/'
+			),
+			method: 'POST',
+			data,
+		} )
+	);

--- a/client/data/util.js
+++ b/client/data/util.js
@@ -1,0 +1,18 @@
+const WP_API_REQUEST_TIMEOUT = 10000;
+
+/**
+ * Wraps a promise in a timeout that will reject
+ * when it fails to complite within given time.
+ *
+ * @param  {Promise} promise Promise
+ * @return {Promise}         Promise wrapped in a request timeout
+ */
+export const withRequestTimeout = ( promise ) =>
+	new Promise( ( resolve, reject ) => {
+		const timer = setTimeout(
+			() => reject( new Error( 'Request timed out' ) ),
+			WP_API_REQUEST_TIMEOUT
+		);
+
+		promise.then( resolve, reject ).finally( () => clearTimeout( timer ) );
+	} );

--- a/client/nps.js
+++ b/client/nps.js
@@ -36,8 +36,6 @@ window.addEventListener( 'load', () =>
 				element.removeAttribute( 'data-crowdsignal-nps' );
 
 				if ( viewCount !== viewThreshold ) {
-					console.log( viewCount );
-					console.log( viewThreshold );
 					return;
 				}
 

--- a/client/nps.js
+++ b/client/nps.js
@@ -19,9 +19,9 @@ window.addEventListener( 'load', () =>
 		( element ) => {
 			try {
 				const attributes = JSON.parse( element.dataset.crowdsignalNps );
-				const { surveyId, viewThreshold } = attributes;
+				const viewThreshold = parseInt( attributes.viewThreshold, 10 );
 
-				const key = `${ NPS_VIEWS_STORAGE_PREFIX }${ surveyId }`;
+				const key = `${ NPS_VIEWS_STORAGE_PREFIX }${ attributes.surveyId }`;
 				const viewCount =
 					1 + parseInt( window.localStorage.getItem( key ) || 0, 10 );
 
@@ -36,6 +36,8 @@ window.addEventListener( 'load', () =>
 				element.removeAttribute( 'data-crowdsignal-nps' );
 
 				if ( viewCount !== viewThreshold ) {
+					console.log( viewCount );
+					console.log( viewThreshold );
 					return;
 				}
 

--- a/includes/class-crowdsignal-forms.php
+++ b/includes/class-crowdsignal-forms.php
@@ -14,6 +14,7 @@ use Crowdsignal_Forms\Gateways\Api_Gateway_Interface;
 use Crowdsignal_Forms\Gateways\Api_Gateway;
 use Crowdsignal_Forms\Gateways\Post_Poll_Meta_Gateway;
 use Crowdsignal_Forms\Logging\Webservice_Logger;
+use Crowdsignal_Forms\Rest_Api\Controllers\Nps_Controller;
 use Crowdsignal_Forms\Rest_Api\Controllers\Polls_Controller;
 use Crowdsignal_Forms\Rest_Api\Controllers\Account_Controller;
 use Crowdsignal_Forms\Admin\Admin_Hooks;
@@ -72,6 +73,13 @@ final class Crowdsignal_Forms {
 	 * @var Polls_Controller
 	 */
 	public $rest_api_polls_controller;
+
+	/**
+	 * The nps controller.
+	 *
+	 * @var Nps_Controller
+	 */
+	public $rest_api_nps_controller;
 
 	/**
 	 * The api gateway.
@@ -200,8 +208,9 @@ final class Crowdsignal_Forms {
 	public function bootstrap() {
 		$this->blocks                      = new Crowdsignal_Forms_Blocks();
 		$this->blocks_assets               = new Crowdsignal_Forms_Blocks_Assets();
-		$this->rest_api_polls_controller   = new Polls_Controller();
 		$this->rest_api_account_controller = new Account_Controller();
+		$this->rest_api_nps_controller     = new Nps_Controller();
+		$this->rest_api_polls_controller   = new Polls_Controller();
 		$this->admin_hooks                 = new Admin_Hooks();
 		$this->webservice_logger           = new Webservice_Logger();
 
@@ -245,8 +254,9 @@ final class Crowdsignal_Forms {
 	 * @since 0.9.0
 	 */
 	public function register_rest_api_routes() {
-		$this->rest_api_polls_controller->register_routes();
 		$this->rest_api_account_controller->register_routes();
+		$this->rest_api_nps_controller->register_routes();
+		$this->rest_api_polls_controller->register_routes();
 
 		/**
 		 * Any additional controllers from companion plugins can be registered using this hook.

--- a/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
@@ -97,15 +97,27 @@ class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 	 */
 	private function attributes() {
 		return array(
-			'hideBranding'  => array(
+			'feedbackQuestion' => array(
+				'type'    => 'string',
+				'default' => '',
+			),
+			'hideBranding'     => array(
 				'type'    => 'boolean',
 				'default' => false,
 			),
-			'surveyId'      => array(
+			'ratingQuestion'   => array(
+				'type'    => 'string',
+				'default' => '',
+			),
+			'surveyId'         => array(
 				'type'    => 'string',
 				'default' => null,
 			),
-			'viewThreshold' => array(
+			'title'            => array(
+				'type'    => 'string',
+				'default' => '',
+			),
+			'viewThreshold'    => array(
 				'type'    => 'string',
 				'default' => 3,
 			),

--- a/includes/models/class-nps-survey.php
+++ b/includes/models/class-nps-survey.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * File containing the model \Crowdsignal_Forms\Models\Nps_Survey.
+ *
+ * @package crowdsignal-forms/Models
+ * @since 1.4.0
+ */
+
+namespace Crowdsignal_Forms\Models;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Nps_Survey
+ */
+class Nps_Survey {
+
+	/**
+	 * Survey Id.
+	 *
+	 * @since 1.4.0
+	 * @var int
+	 */
+	private $id = 0;
+
+	/**
+	 * Title.
+	 *
+	 * @since 1.4.0
+	 * @var string
+	 */
+	private $title = '';
+
+	/**
+	 * Rating question.
+	 *
+	 * @since 1.4.0
+	 * @var string
+	 */
+	private $rating_question = '';
+
+	/**
+	 * Feedback question.
+	 *
+	 * @since 1.4.0
+	 * @var string
+	 */
+	private $feedback_question = '';
+
+	/**
+	 * Creates a new Nps_Survey object from an array of params.
+	 *
+	 * @param  array $data An array containing the survey data.
+	 * @return Nps_Survey
+	 */
+	public static function from_array( $data ) {
+		return new Nps_Survey(
+			$data['id'],
+			$data['title'],
+			$data['rating_text'],
+			$data['feedback_text']
+		);
+	}
+
+	/**
+	 * Creates a new Nps_Survey object from an array of NPS block attributes.
+	 *
+	 * @param  array $attributes An array containing the block attributes.
+	 * @return Nps_Survey
+	 */
+	public static function from_block_attributes( $attributes ) {
+		return new Nps_Survey(
+			$attributes['surveyId'],
+			$attributes['title'],
+			$attributes['ratingQuestion'],
+			$attributes['feedbackQuestion']
+		);
+	}
+
+
+	/**
+	 * NPS Survey constructor.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param int    $id                Survey ID.
+	 * @param string $title             Survey title.
+	 * @param string $rating_question   Rating question.
+	 * @param string $feedback_question Feedback question.
+	 */
+	public function __construct( $id, $title, $rating_question, $feedback_question ) {
+		$this->id                = $id;
+		$this->title             = $title;
+		$this->rating_question   = $rating_question;
+		$this->feedback_question = $feedback_question;
+	}
+
+	/**
+	 * Returns the survey ID.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return int
+	 */
+	public function get_id() {
+		return $this->id;
+	}
+
+	/**
+	 * Transform the NPS survey to an array for the API.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return array
+	 */
+	public function to_array() {
+		$data = array(
+			'title'         => $this->title,
+			'rating_text'   => $this->rating_question,
+			'feedback_text' => $this->feedback_question,
+		);
+
+		if ( $this->id ) {
+			$data['id'] = $this->id;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Transforms the NPS Survey to an array matching NPS block attributes.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return array
+	 */
+	public function to_block_attributes() {
+		return array(
+			'surveyId'         => $this->id,
+			'title'            => $this->title,
+			'ratingQuestion'   => $this->rating_question,
+			'feedbackQuestion' => $this->feedback_question,
+		);
+	}
+}

--- a/includes/rest-api/controllers/class-nps-controller.php
+++ b/includes/rest-api/controllers/class-nps-controller.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Contains the NPS Controller Class
+ *
+ * @since 1.4.0
+ * @package Crowdsignal_Forms\Rest_Api
+ */
+
+namespace Crowdsignal_Forms\Rest_Api\Controllers;
+
+use Crowdsignal_Forms\Crowdsignal_Forms;
+use Crowdsignal_Forms\Models\Nps_Survey;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+/**
+ * NPS Controller Class
+ *
+ * @since 1.4.0
+ */
+class Nps_Controller {
+	/**
+	 * The namespace
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'crowdsignal-forms/v1';
+
+	/**
+	 * The rest api base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'nps';
+
+	/**
+	 * Register the routes for manipulating NPS blocks
+	 *
+	 * @since 1.4.0
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'upsert_nps' ),
+					'permission_callback' => array( $this, 'create_or_update_nps_permissions_check' ),
+				),
+			)
+		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<survey_id>\d+)',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'upsert_nps' ),
+					'permission_callback' => array( $this, 'create_or_update_nps_permissions_check' ),
+					'args'                => $this->get_nps_fetch_params(),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Updates an NPS Survey. Creates one if no ID is given.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param  \WP_REST_Request $request The API Request.
+	 * @return \WP_REST_RESPONSE|WP_Error
+	 */
+	public function upsert_nps( \WP_REST_Request $request ) {
+		$data   = $request->get_json_params();
+		$survey = Nps_Survey::from_block_attributes( $data );
+
+		$result = Crowdsignal_Forms::instance()->get_api_gateway()->update_nps( $survey );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return rest_ensure_response( $result->to_block_attributes() );
+	}
+
+	/**
+	 * The permission check for creating a new poll.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return bool
+	 */
+	public function create_or_update_nps_permissions_check() {
+		return current_user_can( 'publish_posts' );
+	}
+
+	/**
+	 * Returns a validator array for the NPS endpoints params.
+	 *
+	 * @since 1.4.0
+	 * @see https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-custom-endpoints/
+	 *
+	 * @return array
+	 */
+	protected function get_nps_fetch_params() {
+		return array(
+			'survey_id' => array(
+				'validate_callback' => function ( $param, $request, $key ) {
+					return is_numeric( $param );
+				},
+			),
+		);
+	}
+}


### PR DESCRIPTION
This patch adds the capability to save changes made inside an NPS block to Crowdsignal.com.

For the time being, it's just through a simple (and ugly) save button at the top of the block.  
This is only a temporary solution while we continue discussions around synchronizing in pabtAt-1a5-p2. The button is a bare minimum and as such all of its code will be required by any of the proposed solutions which keeps our options open but allows us to move forward.

# Testing

- Create a new NPS block or open an existing one. You'll see a difficult to miss 'save' button.
- Click the save button, the block should now appear in the dashboard as a survey and a `surveyId` attribute should be set on the block.
- Change the block content, click the button again, Crowdsignal.com dashboard should be updated accordingly.