### PR TITLE
v1.3.5 release

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -4,7 +4,7 @@ Tags: polls, forms, surveys, gutenberg, block
 Requires at least: 5.0
 Requires PHP: 5.6.20
 Tested up to: 5.6
-Stable tag: 1.3.4
+Stable tag: 1.3.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -67,6 +67,10 @@ Compare our [simple and affordable plans](https://crowdsignal.com/pricing/) or t
 
 == Changelog ==
 
+= 1.3.5 =
+* Show branding on editor and a message when free signals are exhausted (#11)
+* Remove redirect URL feature (#12)
+
 = 1.3.4 =
 * Escape the redirect address to avoid XSS. (#7)
 * Bump tested version to 5.6 (#8)
@@ -106,8 +110,8 @@ Compare our [simple and affordable plans](https://crowdsignal.com/pricing/) or t
 
 == Upgrade Notice ==
 
-= 1.3.4 =
-Style and security fixes. Please update.
+= 1.3.5 =
+Stability and security fixes. Please update.
 
 = 0.9 =
 Initial release

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+= 1.3.5 =
+* Show branding on editor and a message when free signals are exhausted (#11)
+* Remove redirect URL feature (#12)
+
 = 1.3.4 =
 * Escape the redirect address to avoid XSS. (#7)
 * Bump tested version to 5.6 (#8)

--- a/client/components/poll/style.scss
+++ b/client/components/poll/style.scss
@@ -488,7 +488,7 @@ div.crowdsignal-forms-poll__answer-label-wrapper {
 	text-decoration: none;
 	text-transform: uppercase;
 	vertical-align: middle;
-	border-bottom: 0px solid var(--crowdsignal-forms-text-color) !important;
+	border-bottom: 0 solid var(--crowdsignal-forms-text-color) !important;
 
 	&:not(:hover) {
 		color: var(--crowdsignal-forms-text-color);

--- a/client/components/poll/style.scss
+++ b/client/components/poll/style.scss
@@ -488,6 +488,7 @@ div.crowdsignal-forms-poll__answer-label-wrapper {
 	text-decoration: none;
 	text-transform: uppercase;
 	vertical-align: middle;
+	border-bottom: 0px solid var(--crowdsignal-forms-text-color) !important;
 
 	&:not(:hover) {
 		color: var(--crowdsignal-forms-text-color);

--- a/crowdsignal-forms.php
+++ b/crowdsignal-forms.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Crowdsignal Forms
  * Plugin URI:        https://crowdsignal.com/crowdsignal-forms/
  * Description:       Crowdsignal Form Blocks
- * Version:           1.3.4
+ * Version:           1.3.5
  * Author:            Automattic
  * Author URI:        https://automattic.com/
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die;
 }
 
-define( 'CROWDSIGNAL_FORMS_VERSION', '1.3.4' );
+define( 'CROWDSIGNAL_FORMS_VERSION', '1.3.5' );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_FILE', __FILE__ );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 

--- a/includes/admin/class-crowdsignal-forms-settings.php
+++ b/includes/admin/class-crowdsignal-forms-settings.php
@@ -42,7 +42,7 @@ class Crowdsignal_Forms_Settings {
 	 * Enqueues scripts for setup page.
 	 */
 	public function admin_enqueue_scripts() {
-		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.3.4' );
+		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.3.5' );
 	}
 
 	/**

--- a/includes/admin/class-crowdsignal-forms-setup.php
+++ b/includes/admin/class-crowdsignal-forms-setup.php
@@ -65,7 +65,7 @@ class Crowdsignal_Forms_Setup {
 	 * Enqueues scripts for setup page.
 	 */
 	public function admin_enqueue_scripts() {
-		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.3.4' );
+		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.3.5' );
 		wp_enqueue_script( 'videopress', 'https://videopress.com/videopress-iframe.js', array(), '1.0', false );
 	}
 

--- a/includes/gateways/class-api-gateway.php
+++ b/includes/gateways/class-api-gateway.php
@@ -372,7 +372,7 @@ class Api_Gateway implements Api_Gateway_Interface {
 	/**
 	 * Get the account's summary.
 	 *
-	 * @since [next-version-number]
+	 * @since 1.3.5
 	 *
 	 * @return bool|\WP_Error
 	 */

--- a/includes/rest-api/controllers/class-account-controller.php
+++ b/includes/rest-api/controllers/class-account-controller.php
@@ -116,7 +116,7 @@ class Account_Controller {
 	/**
 	 * Gets a summary of the Crowdsignal account for the user.
 	 *
-	 * @since [next-version-number]
+	 * @since 1.3.5
 	 *
 	 * @return \WP_REST_Response|\WP_Error
 	 */

--- a/languages/crowdsignal-forms.pot
+++ b/languages/crowdsignal-forms.pot
@@ -2,16 +2,16 @@
 # This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Crowdsignal Forms 1.3.4\n"
+"Project-Id-Version: Crowdsignal Forms 1.3.5\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/crowdsignal-forms\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2020-12-09T15:49:25+00:00\n"
+"POT-Creation-Date: 2020-12-28T21:46:24+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.5.0-alpha-75cb7e3\n"
+"X-Generator: WP-CLI 2.5.0-alpha-59d879d\n"
 "X-Domain: crowdsignal-forms\n"
 
 #. Plugin Name of the plugin
@@ -224,11 +224,11 @@ msgstr ""
 msgid "Large"
 msgstr ""
 
-#: client/blocks/applause/edit.js:32
+#: client/blocks/applause/edit.js:34
 msgid "Untitled Applause"
 msgstr ""
 
-#: client/blocks/applause/edit.js:40
+#: client/blocks/applause/edit.js:53
 msgid "Crowdsignal Applause"
 msgstr ""
 
@@ -303,88 +303,88 @@ msgstr ""
 msgid "voting"
 msgstr ""
 
-#: client/blocks/applause/sidebar.js:65
-#: client/blocks/poll/sidebar.js:152
-#: client/blocks/vote/sidebar.js:56
+#: client/blocks/applause/sidebar.js:72
+#: client/blocks/poll/sidebar.js:160
+#: client/blocks/vote/sidebar.js:63
 msgid "Results"
 msgstr ""
 
-#: client/blocks/applause/sidebar.js:70
-#: client/blocks/poll/sidebar.js:157
-#: client/blocks/vote/sidebar.js:61
+#: client/blocks/applause/sidebar.js:77
+#: client/blocks/poll/sidebar.js:165
+#: client/blocks/vote/sidebar.js:68
 msgid "Manage results on "
 msgstr ""
 
-#: client/blocks/applause/sidebar.js:71
-#: client/blocks/poll/sidebar.js:158
-#: client/blocks/vote/sidebar.js:62
+#: client/blocks/applause/sidebar.js:78
+#: client/blocks/poll/sidebar.js:166
+#: client/blocks/vote/sidebar.js:69
 msgid "Publish this post to enable results on "
 msgstr ""
 
-#: client/blocks/applause/sidebar.js:92
-#: client/blocks/poll/sidebar.js:179
-#: client/blocks/vote/sidebar.js:83
+#: client/blocks/applause/sidebar.js:99
+#: client/blocks/poll/sidebar.js:187
+#: client/blocks/vote/sidebar.js:90
 msgid "View results"
 msgstr ""
 
-#: client/blocks/applause/sidebar.js:98
+#: client/blocks/applause/sidebar.js:105
 msgid "Title of the applause block"
 msgstr ""
 
-#: client/blocks/applause/sidebar.js:105
-#: client/blocks/vote/sidebar.js:96
+#: client/blocks/applause/sidebar.js:115
+#: client/blocks/vote/sidebar.js:106
 msgid "Status"
 msgstr ""
 
-#: client/blocks/applause/sidebar.js:108
-#: client/blocks/poll/sidebar.js:260
-#: client/blocks/vote/sidebar.js:99
+#: client/blocks/applause/sidebar.js:118
+#: client/blocks/poll/sidebar.js:272
+#: client/blocks/vote/sidebar.js:109
 msgid "Currently"
 msgstr ""
 
-#: client/blocks/applause/sidebar.js:111
-#: client/blocks/poll/sidebar.js:263
-#: client/blocks/vote/sidebar.js:102
+#: client/blocks/applause/sidebar.js:121
+#: client/blocks/poll/sidebar.js:275
+#: client/blocks/vote/sidebar.js:112
 msgid "Open"
 msgstr ""
 
-#: client/blocks/applause/sidebar.js:115
-#: client/blocks/poll/sidebar.js:267
-#: client/blocks/vote/sidebar.js:106
+#: client/blocks/applause/sidebar.js:125
+#: client/blocks/poll/sidebar.js:279
+#: client/blocks/vote/sidebar.js:116
 msgid "Closed after"
 msgstr ""
 
-#: client/blocks/applause/sidebar.js:119
-#: client/blocks/poll/sidebar.js:271
-#: client/blocks/vote/sidebar.js:110
+#: client/blocks/applause/sidebar.js:129
+#: client/blocks/poll/sidebar.js:283
+#: client/blocks/vote/sidebar.js:120
 msgid "Closed"
 msgstr ""
 
-#: client/blocks/applause/sidebar.js:128
+#: client/blocks/applause/sidebar.js:138
 msgid "Close applause block on"
 msgstr ""
 
-#: client/blocks/applause/sidebar.js:138
+#: client/blocks/applause/sidebar.js:148
 #: client/blocks/vote-item/sidebar.js:24
 msgid "Styling"
 msgstr ""
 
-#: client/blocks/applause/sidebar.js:144
-#: client/blocks/poll/sidebar.js:325
-#: client/blocks/poll/sidebar.js:509
+#: client/blocks/applause/sidebar.js:154
+#: client/blocks/poll/sidebar.js:337
+#: client/blocks/poll/sidebar.js:521
 #: client/blocks/vote-item/sidebar.js:30
 msgid "Text color"
 msgstr ""
 
-#: client/blocks/applause/sidebar.js:149
-#: client/blocks/poll/sidebar.js:330
-#: client/blocks/poll/sidebar.js:514
+#: client/blocks/applause/sidebar.js:159
+#: client/blocks/poll/sidebar.js:342
+#: client/blocks/poll/sidebar.js:526
 #: client/blocks/vote-item/sidebar.js:35
 msgid "Background color"
 msgstr ""
 
-#: client/blocks/applause/sidebar.js:154
-#: client/blocks/poll/sidebar.js:335
+#: client/blocks/applause/sidebar.js:164
+#: client/blocks/poll/sidebar.js:347
 #: client/blocks/vote-item/sidebar.js:40
 msgid "Border color"
 msgstr ""
@@ -395,13 +395,13 @@ msgid "Change block size"
 msgstr ""
 
 #: client/blocks/applause/toolbar.js:80
-#: client/blocks/poll/sidebar.js:482
+#: client/blocks/poll/sidebar.js:494
 #: client/blocks/vote/toolbar.js:97
 msgid "Border thickness"
 msgstr ""
 
 #: client/blocks/applause/toolbar.js:90
-#: client/blocks/poll/sidebar.js:489
+#: client/blocks/poll/sidebar.js:501
 #: client/blocks/vote/toolbar.js:107
 msgid "Corner radius"
 msgstr ""
@@ -421,17 +421,17 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: client/blocks/poll/edit.js:145
+#: client/blocks/poll/edit.js:162
 msgid "Crowdsignal Poll"
 msgstr ""
 
-#: client/blocks/poll/edit.js:188
-#: client/blocks/poll/edit.js:200
+#: client/blocks/poll/edit.js:210
+#: client/blocks/poll/edit.js:222
 msgid "Enter your question"
 msgstr ""
 
-#: client/blocks/poll/edit.js:212
-#: client/blocks/poll/edit.js:224
+#: client/blocks/poll/edit.js:234
+#: client/blocks/poll/edit.js:246
 msgid "Add a note (optional)"
 msgstr ""
 
@@ -504,117 +504,113 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:187
+#: client/blocks/poll/sidebar.js:195
 msgid "Title of the poll block"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:195
+#: client/blocks/poll/sidebar.js:206
 msgid "Confirmation message"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:200
+#: client/blocks/poll/sidebar.js:211
 msgid "On submission"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:203
-#: client/blocks/poll/sidebar.js:296
+#: client/blocks/poll/sidebar.js:214
+#: client/blocks/poll/sidebar.js:308
 msgid "Show results"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:207
+#: client/blocks/poll/sidebar.js:218
 msgid "Show \"Thank You\" message"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:214
+#: client/blocks/poll/sidebar.js:225
 msgid "Show a custom text message"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:221
-msgid "Redirect to another webpage"
-msgstr ""
-
-#: client/blocks/poll/sidebar.js:235
+#: client/blocks/poll/sidebar.js:247
 msgid "Message text"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:236
+#: client/blocks/poll/sidebar.js:248
 #: client/components/poll/submit-message.js:71
 msgid "Thanks for voting!"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:249
+#: client/blocks/poll/sidebar.js:261
 msgid "Redirect address"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:255
+#: client/blocks/poll/sidebar.js:267
 msgid "Poll status"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:281
+#: client/blocks/poll/sidebar.js:293
 msgid "Close poll on"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:290
+#: client/blocks/poll/sidebar.js:302
 msgid "When poll is closed"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:303
+#: client/blocks/poll/sidebar.js:315
 msgid "Show poll with \"Closed\" banner"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:310
+#: client/blocks/poll/sidebar.js:322
 msgid "Hide poll"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:319
+#: client/blocks/poll/sidebar.js:331
 msgid "Block styling"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:347
+#: client/blocks/poll/sidebar.js:359
 msgid "Choose font"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:350
+#: client/blocks/poll/sidebar.js:362
 msgid "Default theme font"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:467
+#: client/blocks/poll/sidebar.js:479
 msgid "Width (%)"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:476
+#: client/blocks/poll/sidebar.js:488
 msgid "Reset"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:497
+#: client/blocks/poll/sidebar.js:509
 msgid "Drop shadow"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:503
+#: client/blocks/poll/sidebar.js:515
 msgid "Button styling"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:529
+#: client/blocks/poll/sidebar.js:541
 msgid "Alignment"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:533
+#: client/blocks/poll/sidebar.js:545
 msgid "List"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:537
+#: client/blocks/poll/sidebar.js:549
 msgid "Inline"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:545
+#: client/blocks/poll/sidebar.js:557
 msgid "Answer settings"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:550
+#: client/blocks/poll/sidebar.js:562
 msgid "One response per computer"
 msgstr ""
 
-#: client/blocks/poll/sidebar.js:558
+#: client/blocks/poll/sidebar.js:570
 msgid "Randomize answer order"
 msgstr ""
 
@@ -639,11 +635,11 @@ msgstr ""
 msgid "Allow your audience to rate your work or express their opinion — powered by Crowdsignal."
 msgstr ""
 
-#: client/blocks/vote/edit.js:31
+#: client/blocks/vote/edit.js:33
 msgid "Untitled Vote"
 msgstr ""
 
-#: client/blocks/vote/edit.js:60
+#: client/blocks/vote/edit.js:73
 msgid "Crowdsignal Vote"
 msgstr ""
 
@@ -703,11 +699,11 @@ msgstr ""
 msgid "thumbs"
 msgstr ""
 
-#: client/blocks/vote/sidebar.js:89
+#: client/blocks/vote/sidebar.js:96
 msgid "Title of the vote block"
 msgstr ""
 
-#: client/blocks/vote/sidebar.js:119
+#: client/blocks/vote/sidebar.js:129
 msgid "Close vote block on"
 msgstr ""
 
@@ -758,11 +754,15 @@ msgstr ""
 msgid "Thanks For Voting!"
 msgstr ""
 
-#: client/components/poll/footer-branding.js:14
+#: client/components/poll/footer-branding.js:33
 msgid "Create your own poll with Crowdsignal"
 msgstr ""
 
-#: client/components/poll/index.js:65
+#: client/components/poll/footer-branding.js:46
+msgid "Hide"
+msgstr ""
+
+#: client/components/poll/index.js:71
 #: client/data/poll/index.js:90
 msgid "Server error. Please try again."
 msgstr ""
@@ -773,3 +773,35 @@ msgid "%s total vote"
 msgid_plural "%s total votes"
 msgstr[0] ""
 msgstr[1] ""
+
+#: client/components/sidebar-promote/index.js:15
+msgid "Upgrade"
+msgstr ""
+
+#: client/components/sidebar-promote/index.js:20
+msgid "Your free Crowdsignal account has "
+msgstr ""
+
+#: client/components/sidebar-promote/index.js:26
+msgid "reached the signals limit."
+msgstr ""
+
+#: client/components/sidebar-promote/index.js:37
+msgid "Hide Crowdsignal branding and get "
+msgstr ""
+
+#: client/components/sidebar-promote/index.js:42
+msgid "unlimited signals"
+msgstr ""
+
+#: client/components/signal-warning/index.js:19
+msgid "Your free Crowdsignal account has exceeded "
+msgstr ""
+
+#: client/components/signal-warning/index.js:24
+msgid "the limit of 2500 signals."
+msgstr ""
+
+#: client/components/signal-warning/index.js:29
+msgid "Please upgrade."
+msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/crowdsignal-forms",
-	"version": "1.3.4",
+	"version": "1.3.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/crowdsignal-forms",
-	"version": "1.3.4",
+	"version": "1.3.5",
 	"description": "Crowdsignal powered forms for WordPress",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
This PR bumps version to v1.3.5 prior to release.

## Test instructions

v1.3.5 includes:

  - Crowdsignal branding on editor for free users
  - A "Hide" label on branding with a tooltip and a link to crowdsignal.com/pricing
  - A warning for free users who have exhausted their signals
  - A section on the sidebar promoting to upgrade and a link to "What is a Signal"
  - A notice on sidebar when free signals have been exhausted
  - Removal of the "Redirect to URL" option upon voting