### PR TITLE
Update the Makefile to include the NPS block build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ client:
 	npm run build:poll
 	npm run build:vote
 	npm run build:applause
+	npm run build:nps
 
 # Package for release
 release: clean-release install-node pot client


### PR DESCRIPTION
Small fix to include `npm run build:nps` in `make client`.

# Testing

Run `make client` and verify it builds `build/npm.js`.