### PR TITLE
Refactor withClientId

### DIFF
--- a/client/blocks/applause/edit.js
+++ b/client/blocks/applause/edit.js
@@ -46,6 +46,7 @@ const EditApplauseBlock = ( props ) => {
 	);
 };
 
-export default compose( [ withPollBase ] )(
-	withClientId( EditApplauseBlock, [ 'pollId', 'answerId' ] )
-);
+export default compose( [
+	withPollBase,
+	withClientId( [ 'pollId', 'answerId' ] ),
+] )( EditApplauseBlock );

--- a/client/blocks/vote-item/edit.js
+++ b/client/blocks/vote-item/edit.js
@@ -38,6 +38,7 @@ const EditVoteItemBlock = ( props ) => {
 	);
 };
 
-export default compose( [ withFallbackStyles( VoteStyles, getVoteStyles ) ] )(
-	withClientId( EditVoteItemBlock, 'answerId' )
-);
+export default compose( [
+	withFallbackStyles( VoteStyles, getVoteStyles ),
+	withClientId( [ 'answerId' ] ),
+] )( EditVoteItemBlock );

--- a/client/blocks/vote/edit.js
+++ b/client/blocks/vote/edit.js
@@ -81,6 +81,6 @@ const EditVoteBlock = ( props ) => {
 	);
 };
 
-export default compose( [ withPollBase ] )(
-	withClientId( EditVoteBlock, 'pollId' )
+export default compose( [ withPollBase, withClientId( [ 'pollId' ] ) ] )(
+	EditVoteBlock
 );

--- a/client/components/with-client-id/index.js
+++ b/client/components/with-client-id/index.js
@@ -2,26 +2,24 @@
  * External dependencies
  */
 import React, { useEffect } from 'react';
-import { v4 as uuidv4 } from 'uuid';
-import { isArray, map } from 'lodash';
+import { v4 as uuid } from 'uuid';
+import { forEach } from 'lodash';
 
-const withClientId = ( Element, clientIdAttributeNames ) => {
+const withClientId = ( clientIdAttributes ) => ( Element ) => {
 	return ( props ) => {
 		const { attributes, setAttributes } = props;
-		const clientIdNames = isArray( clientIdAttributeNames )
-			? clientIdAttributeNames
-			: [ clientIdAttributeNames ];
-		useEffect( () => {
-			map( clientIdNames, ( name ) => {
-				if ( ! attributes[ name ] ) {
-					const clientId = uuidv4();
-					const newAttribute = {};
-					newAttribute[ name ] = clientId;
 
-					setAttributes( newAttribute );
+		useEffect( () => {
+			forEach( clientIdAttributes, ( key ) => {
+				if ( attributes[ key ] ) {
+					return;
 				}
+
+				setAttributes( {
+					[ key ]: uuid(),
+				} );
 			} );
-		} );
+		}, [] );
 
 		return <Element { ...props } />;
 	};


### PR DESCRIPTION
I refactored this component as part of my initial effort to persist NPS block surveys.  
Although it seems like we'll be going in a different direction and it's no longer required for that, I feel like it's still worth including it.

I updated the signature so it always expects an array instead of an array or a string (varargs would be another solution) and moved it up a level so it can now be used correctly with `compose` or `flowRight` - the HoC signature should only ever accept one argument which is the component.

# Testing

This is a core change but it's quite easy to test.

- Create a post with some new poll, applause and vote blocks.
- Verify the blocks save correctly to the dashboard
- Publish the post and add some responses
- Verify the responses are recorded correctly as well