### PR TITLE
Implement public block views and voting interactions

### DIFF
--- a/assets/stylesheets/editor.scss
+++ b/assets/stylesheets/editor.scss
@@ -19,3 +19,7 @@
 // Applause
 @import "blocks/applause/edit.scss";
 @import "components/applause/style.scss";
+
+// NPS
+@import "blocks/nps/edit.scss";
+@import "components/nps/style.scss";

--- a/client/blocks/nps/attributes.js
+++ b/client/blocks/nps/attributes.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Note: Any changes made to the attributes definition need to be duplicated in
  *       Crowdsignal_Forms\Frontend\Blocks\Crowdsignal_Forms_Nps_Block::attributes()
  *       inside includes/frontend/blocks/class-crowdsignal-forms-nps-block.php.
@@ -13,9 +18,21 @@ export default {
 		type: 'boolean',
 		default: false,
 	},
+	highRatingLabel: {
+		type: 'string',
+		default: '',
+	},
+	lowRatingLabel: {
+		type: 'string',
+		default: '',
+	},
 	ratingQuestion: {
 		type: 'string',
 		default: '',
+	},
+	submitButtonLabel: {
+		type: 'string',
+		default: __( 'Submit', 'crowdsignal-forms' ),
 	},
 	surveyId: {
 		type: 'string',

--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { pick } from 'lodash';
+import { pick, times } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -21,16 +21,9 @@ import Sidebar from './sidebar';
 const EditNpsBlock = ( props ) => {
 	const { attributes, clientId, setAttributes } = props;
 
-	const handleChangeTitle = ( title ) => setAttributes( { title } );
-
-	const handleChangeRatingQuestion = ( ratingQuestion ) =>
+	const handleChangeAttribute = ( attribute ) => ( value ) =>
 		setAttributes( {
-			ratingQuestion,
-		} );
-
-	const handleChangeFeedbackQuestion = ( feedbackQuestion ) =>
-		setAttributes( {
-			feedbackQuestion,
+			[ attribute ]: value,
 		} );
 
 	const handleSaveNPS = async () => {
@@ -66,20 +59,20 @@ const EditNpsBlock = ( props ) => {
 		>
 			<Sidebar { ...props } />
 
+			<button onClick={ handleSaveNPS }>
+				{ __( 'Save', 'crowdsignal-forms' ) }
+			</button>
+
+			<RichText
+				tagName="h3"
+				className="crowdsignal-forms-nps__title"
+				placeholder={ __( 'Title', 'crowdsignal-forms' ) }
+				onChange={ handleChangeAttribute( 'title' ) }
+				value={ attributes.title }
+				allowedFormats={ [] }
+			/>
+
 			<div className="crowdsignal-forms-nps">
-				<button onClick={ handleSaveNPS }>
-					{ __( 'Save', 'crowdsignal-forms' ) }
-				</button>
-
-				<RichText
-					tagName="h3"
-					className="crowdsignal-forms-nps__title"
-					placeholder={ __( 'Title', 'crowdsignal-forms' ) }
-					onChange={ handleChangeTitle }
-					value={ attributes.title }
-					allowedFormats={ [] }
-				/>
-
 				<RichText
 					tagName="p"
 					className="crowdsignal-forms-nps__question"
@@ -87,22 +80,74 @@ const EditNpsBlock = ( props ) => {
 						'Enter your rating question',
 						'crowdsignal-forms'
 					) }
-					onChange={ handleChangeRatingQuestion }
+					onChange={ handleChangeAttribute( 'ratingQuestion' ) }
 					value={ attributes.ratingQuestion }
 					allowedFormats={ [] }
 				/>
 
-				<RichText
-					tagName="p"
-					className="crowdsignal-forms-nps__question"
-					placeholder={ __(
-						'Enter your feedback question',
-						'crowdsignal-forms'
-					) }
-					onChange={ handleChangeFeedbackQuestion }
-					value={ attributes.feedbackQuestion }
-					allowedFormats={ [] }
-				/>
+				<div className="crowdsignal-forms-nps__rating">
+					<div className="crowdsignal-forms-nps__rating-labels">
+						<RichText
+							tagName="span"
+							placeholder={ __( 'Low', 'crowdsignal-forms' ) }
+							onChange={ handleChangeAttribute(
+								'lowRatingLabel'
+							) }
+							value={ attributes.lowRatingLabel }
+							allowedFormats={ [] }
+						/>
+						<RichText
+							tagName="span"
+							placeholder={ __( 'High', 'crowdsignal-forms' ) }
+							onChange={ handleChangeAttribute(
+								'highRatingLabel'
+							) }
+							value={ attributes.highRatingLabel }
+							allowedFormats={ [] }
+						/>
+					</div>
+
+					<div className="crowdsignal-forms-nps__rating-scale">
+						{ times( 11, ( n ) => (
+							<div
+								key={ `rating-${ n }` }
+								className="crowdsignal-forms-nps__rating-button"
+							>
+								{ n }
+							</div>
+						) ) }
+					</div>
+				</div>
+			</div>
+
+			<div className="crowdsignal-forms-nps">
+				<div className="crowdsignal-forms-nps__feedback">
+					<RichText
+						tagName="p"
+						className="crowdsignal-forms-nps__question"
+						placeholder={ __(
+							'Enter your feedback question',
+							'crowdsignal-forms'
+						) }
+						onChange={ handleChangeAttribute( 'feedbackQuestion' ) }
+						value={ attributes.feedbackQuestion }
+						allowedFormats={ [] }
+					/>
+
+					<textarea
+						className="crowdsignal-forms-nps__feedback-text"
+						rows={ 6 }
+					/>
+
+					<RichText
+						className="wp-block-button__link crowdsignal-forms-nps__feedback-button"
+						onChange={ handleChangeAttribute(
+							'submitButtonLabel'
+						) }
+						value={ attributes.submitButtonLabel }
+						allowedFormats={ [] }
+					/>
+				</div>
 			</div>
 		</ConnectToCrowdsignal>
 	);

--- a/client/blocks/nps/edit.scss
+++ b/client/blocks/nps/edit.scss
@@ -1,0 +1,1 @@
+/* Editor styles */

--- a/client/components/nps/feedback.js
+++ b/client/components/nps/feedback.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const NpsFeedback = ( { attributes } ) => (
+	<div className="crowdsignal-forms-nps__feedback">
+		<textarea className="crowdsignal-forms-nps__feedback-text" rows={ 6 } />
+
+		<button className="wp-block-button__link crowdsignal-forms-nps__feedback-button">
+			{ attributes.submitButtonLabel }
+		</button>
+	</div>
+);
+
+export default NpsFeedback;

--- a/client/components/nps/index.js
+++ b/client/components/nps/index.js
@@ -1,21 +1,58 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState } from 'react';
 
-const Nps = ( { attributes } ) => {
+/**
+ * WordPress dependencies
+ */
+import { Icon } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import NpsFeedback from './feedback';
+import NpsRating from './rating';
+
+const views = {
+	RATING: 'rating',
+	FEEDBACK: 'feedback',
+};
+
+const Nps = ( { attributes, contentWidth, onClose } ) => {
+	const [ view, setView ] = useState( views.RATING );
+
+	const showRating = () => setView( views.FEEDBACK );
+
+	const questionText =
+		view === views.RATING
+			? attributes.ratingQuestion
+			: attributes.feedbackQuestion;
+
+	const style = {
+		width: `${ contentWidth }px`,
+	};
+
 	return (
-		<div className="crowdsignal-forms-nps">
-			<h3 className="crowdsignal-forms-nps__title">
-				{ attributes.title }
+		<div className="crowdsignal-forms-nps" style={ style }>
+			<h3 className="crowdsignal-forms-nps__question">
+				{ questionText }
 			</h3>
 
-			<p className="crowdsignal-forms-nps__question">
-				{ attributes.ratingQuestion }
-			</p>
-			<p className="crowdsignal-forms-nps__question">
-				{ attributes.feedbackQuestion }
-			</p>
+			<button
+				className="crowdsignal-forms-nps__close-button"
+				onClick={ onClose }
+			>
+				<Icon icon="no-alt" />
+			</button>
+
+			{ view === views.RATING && (
+				<NpsRating attributes={ attributes } onSubmit={ showRating } />
+			) }
+
+			{ view === views.FEEDBACK && (
+				<NpsFeedback attributes={ attributes } onSubmit={ onClose } />
+			) }
 		</div>
 	);
 };

--- a/client/components/nps/rating.js
+++ b/client/components/nps/rating.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import React, { useState } from 'react';
+import classnames from 'classnames';
+import { times } from 'lodash';
+
+const NpsRating = ( { attributes, onSubmit } ) => {
+	const [ selected, setSelected ] = useState( -1 );
+
+	const selectRating = ( n ) => () => {
+		setSelected( n );
+
+		setTimeout( () => onSubmit(), 1000 );
+	};
+
+	return (
+		<div className="crowdsignal-forms-nps__rating">
+			<div className="crowdsignal-forms-nps__rating-labels">
+				<span>{ attributes.lowRatingLabel }</span>
+				<span>{ attributes.highRatingLabel }</span>
+			</div>
+
+			<div className="crowdsignal-forms-nps__rating-scale">
+				{ times( 11, ( n ) => {
+					const classes = classnames(
+						'crowdsignal-forms-nps__rating-button',
+						{
+							'is-active': n === selected,
+						}
+					);
+
+					return (
+						<button
+							key={ `rating-${ n }` }
+							disabled={ 0 <= selected }
+							className={ classes }
+							onClick={ selectRating( n ) }
+						>
+							{ n }
+						</button>
+					);
+				} ) }
+			</div>
+		</div>
+	);
+};
+
+export default NpsRating;

--- a/client/components/nps/style.scss
+++ b/client/components/nps/style.scss
@@ -6,5 +6,82 @@
 	background-color: #fff;
 	height: auto;
 	padding: 50px;
-	width: 600px;
+	position: relative;
+}
+
+.crowdsignal-forms-nps__close-button {
+	align-items: center;
+	background-color: #002c40;
+	border-radius: 20px;
+	color: #fff;
+	display: flex;
+	height: 40px;
+	justify-content: center;
+	outline: 0;
+	padding: 0;
+	position: absolute;
+	right: -20px;
+	top: -20px;
+	width: 40px;
+}
+
+.crowdsignal-forms-nps__question {
+	margin-top: 0 !important;
+}
+
+.crowdsignal-forms-nps__rating {
+	display: flex;
+	flex-direction: column;
+}
+
+.crowdsignal-forms-nps__rating-labels {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+}
+
+.crowdsignal-forms-nps__rating-scale {
+	display: flex;
+	margin: 10px auto 0;
+	width: 100%;
+}
+
+.crowdsignal-forms-nps__rating-button {
+	background-color: #cd2653;
+	border: 1px solid #cd2653;
+	color: #fff;
+	display: inline-flex;
+	flex: 1;
+	font-size: 15px;
+	font-weight: 600;
+	height: 50px;
+	justify-content: center;
+	line-height: 50px;
+	margin: 0 0 0 0.7em;
+	padding: 0;
+	text-align: center;
+	transition: background-color 0.2s, color 0.2s;
+
+	&:first-child {
+		margin: 0;
+	}
+
+	&:disabled:not(.is-active) {
+		background-color: transparent;
+		color: #cd2653;
+	}
+}
+
+.crowdsignal-forms-nps__feedback {
+	display: flex;
+	flex-direction: column;
+}
+
+.crowdsignal-forms-nps__feedback-text {
+	margin-bottom: 25px;
+	width: 100%;
+}
+
+.crowdsignal-forms-nps__feedback-button {
+	align-self: flex-end;
 }

--- a/client/nps.js
+++ b/client/nps.js
@@ -43,7 +43,11 @@ window.addEventListener( 'load', () =>
 
 				render(
 					<DialogWrapper onClose={ closeDialog }>
-						<NpsBlock attributes={ attributes } />
+						<NpsBlock
+							attributes={ attributes }
+							contentWidth={ element.scrollWidth }
+							onClose={ closeDialog }
+						/>
 					</DialogWrapper>,
 					element
 				);

--- a/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
@@ -97,27 +97,39 @@ class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 	 */
 	private function attributes() {
 		return array(
-			'feedbackQuestion' => array(
+			'feedbackQuestion'  => array(
 				'type'    => 'string',
 				'default' => '',
 			),
-			'hideBranding'     => array(
+			'hideBranding'      => array(
 				'type'    => 'boolean',
 				'default' => false,
 			),
-			'ratingQuestion'   => array(
+			'highRatingLabel'   => array(
 				'type'    => 'string',
 				'default' => '',
 			),
-			'surveyId'         => array(
+			'lowRatingLabel'    => array(
+				'type'    => 'string',
+				'default' => '',
+			),
+			'ratingQuestion'    => array(
+				'type'    => 'string',
+				'default' => '',
+			),
+			'submitButtonLabel' => array(
+				'type'    => 'string',
+				'default' => __( 'Submit', 'crowdsignal-forms' ),
+			),
+			'surveyId'          => array(
 				'type'    => 'string',
 				'default' => null,
 			),
-			'title'            => array(
+			'title'             => array(
 				'type'    => 'string',
 				'default' => '',
 			),
-			'viewThreshold'    => array(
+			'viewThreshold'     => array(
 				'type'    => 'string',
 				'default' => 3,
 			),


### PR DESCRIPTION
This patch adds the initial public block views and voting interactions and updates the editor to allow for editing these elements as well.

Note that it's just the frontend. Actual vote recording will be implemented in a future patch.  
You should be able to edit all the strings on the public block except the rating buttons which are fixed.

The block will always take up 100% of the content width inside the editor and the dialog will match the theme's content width when displayed on a published post/page.

When you select a rating, the number should get highlighted briefly while the request is being handled (currently just a delay) and the feedback question should be shown soon after.  
The dialog should close itself after submitting the feedback question.

![Screen Shot 2021-01-12 at 9 41 33 PM](https://user-images.githubusercontent.com/8056203/104375441-aaa3a600-5523-11eb-80bd-9a72c09f89c6.png)
![Screen Shot 2021-01-12 at 9 41 47 PM](https://user-images.githubusercontent.com/8056203/104375446-abd4d300-5523-11eb-8d10-2fcc6c636b59.png)

![Screen Shot 2021-01-12 at 10 07 49 PM](https://user-images.githubusercontent.com/8056203/104375452-ad9e9680-5523-11eb-8bcd-10ab0b405916.png)

# Testing

Run `make client` to update the assets.

Add a new NPS block and fill in the different fields using some example values. The editable fields include: rating and feedback question, rating scale labels, feedback submit button.

For the purpose of testing this PR, it's not necessary to save the block to the dashboard.

Publish/preview the post and visit the page three times (or what you set using the view threshold setting), the dialog should be displayed.  
Validate that the strings match the editor values and the interactions work correctly.