### PR TITLE
Add support for submitting NPS responses

### DIFF
--- a/client/blocks/nps/attributes.js
+++ b/client/blocks/nps/attributes.js
@@ -35,7 +35,7 @@ export default {
 		default: __( 'Submit', 'crowdsignal-forms' ),
 	},
 	surveyId: {
-		type: 'string',
+		type: 'number',
 		default: null,
 	},
 	title: {

--- a/client/components/nps/feedback.js
+++ b/client/components/nps/feedback.js
@@ -1,16 +1,53 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState } from 'react';
 
-const NpsFeedback = ( { attributes } ) => (
-	<div className="crowdsignal-forms-nps__feedback">
-		<textarea className="crowdsignal-forms-nps__feedback-text" rows={ 6 } />
+/**
+ * Internal dependencies
+ */
+import { updateNpsResponse } from 'data/nps';
 
-		<button className="wp-block-button__link crowdsignal-forms-nps__feedback-button">
-			{ attributes.submitButtonLabel }
-		</button>
-	</div>
-);
+const NpsFeedback = ( { attributes, onFailure, onSubmit, responseMeta } ) => {
+	const [ feedback, setFeedback ] = useState( '' );
+	const [ submitting, setSubmitting ] = useState( false );
+
+	const handleFeedbackChange = ( event ) => setFeedback( event.target.value );
+
+	const handleSubmit = async () => {
+		setSubmitting( true );
+
+		try {
+			await updateNpsResponse( attributes.surveyId, {
+				nonce: attributes.nonce,
+				feedback,
+				...responseMeta,
+			} );
+
+			onSubmit();
+		} catch ( error ) {
+			onFailure();
+		}
+	};
+
+	return (
+		<form className="crowdsignal-forms-nps__feedback">
+			<textarea
+				className="crowdsignal-forms-nps__feedback-text"
+				disabled={ submitting }
+				rows={ 6 }
+				onChange={ handleFeedbackChange }
+			/>
+
+			<button
+				className="wp-block-button__link crowdsignal-forms-nps__feedback-button"
+				disabled={ submitting }
+				onClick={ handleSubmit }
+			>
+				{ attributes.submitButtonLabel }
+			</button>
+		</form>
+	);
+};
 
 export default NpsFeedback;

--- a/client/components/nps/feedback.js
+++ b/client/components/nps/feedback.js
@@ -31,7 +31,7 @@ const NpsFeedback = ( { attributes, onFailure, onSubmit, responseMeta } ) => {
 	};
 
 	return (
-		<form className="crowdsignal-forms-nps__feedback">
+		<div className="crowdsignal-forms-nps__feedback">
 			<textarea
 				className="crowdsignal-forms-nps__feedback-text"
 				disabled={ submitting }
@@ -47,7 +47,7 @@ const NpsFeedback = ( { attributes, onFailure, onSubmit, responseMeta } ) => {
 			>
 				{ attributes.submitButtonLabel }
 			</button>
-		</form>
+		</div>
 	);
 };
 

--- a/client/components/nps/feedback.js
+++ b/client/components/nps/feedback.js
@@ -43,6 +43,7 @@ const NpsFeedback = ( { attributes, onFailure, onSubmit, responseMeta } ) => {
 				className="wp-block-button__link crowdsignal-forms-nps__feedback-button"
 				disabled={ submitting }
 				onClick={ handleSubmit }
+				type="button"
 			>
 				{ attributes.submitButtonLabel }
 			</button>

--- a/client/components/nps/index.js
+++ b/client/components/nps/index.js
@@ -20,9 +20,13 @@ const views = {
 };
 
 const Nps = ( { attributes, contentWidth, onClose } ) => {
+	const [ responseMeta, setResponseMeta ] = useState( null );
 	const [ view, setView ] = useState( views.RATING );
 
-	const showRating = () => setView( views.FEEDBACK );
+	const handleRatingSubmit = ( meta ) => {
+		setResponseMeta( meta );
+		setView( views.FEEDBACK );
+	};
 
 	const questionText =
 		view === views.RATING
@@ -47,11 +51,20 @@ const Nps = ( { attributes, contentWidth, onClose } ) => {
 			</button>
 
 			{ view === views.RATING && (
-				<NpsRating attributes={ attributes } onSubmit={ showRating } />
+				<NpsRating
+					attributes={ attributes }
+					onFailure={ onClose }
+					onSubmit={ handleRatingSubmit }
+				/>
 			) }
 
 			{ view === views.FEEDBACK && (
-				<NpsFeedback attributes={ attributes } onSubmit={ onClose } />
+				<NpsFeedback
+					attributes={ attributes }
+					responseMeta={ responseMeta }
+					onFailure={ onClose }
+					onSubmit={ onClose }
+				/>
 			) }
 		</div>
 	);

--- a/client/components/nps/rating.js
+++ b/client/components/nps/rating.js
@@ -3,15 +3,29 @@
  */
 import React, { useState } from 'react';
 import classnames from 'classnames';
-import { times } from 'lodash';
+import { pick, times } from 'lodash';
 
-const NpsRating = ( { attributes, onSubmit } ) => {
+/**
+ * Internal dependencies
+ */
+import { updateNpsResponse } from 'data/nps';
+
+const NpsRating = ( { attributes, onFailure, onSubmit } ) => {
 	const [ selected, setSelected ] = useState( -1 );
 
-	const selectRating = ( n ) => () => {
-		setSelected( n );
+	const handleSubmit = ( rating ) => async () => {
+		setSelected( rating );
 
-		setTimeout( () => onSubmit(), 1000 );
+		try {
+			const data = await updateNpsResponse( attributes.surveyId, {
+				nonce: attributes.nonce,
+				score: rating,
+			} );
+
+			onSubmit( pick( data, [ 'r', 'checksum' ] ) );
+		} catch ( error ) {
+			onFailure();
+		}
 	};
 
 	return (
@@ -35,7 +49,7 @@ const NpsRating = ( { attributes, onSubmit } ) => {
 							key={ `rating-${ n }` }
 							disabled={ 0 <= selected }
 							className={ classes }
-							onClick={ selectRating( n ) }
+							onClick={ handleSubmit( n ) }
 						>
 							{ n }
 						</button>

--- a/client/data/nps/index.js
+++ b/client/data/nps/index.js
@@ -20,3 +20,14 @@ export const updateNps = ( data ) =>
 			data,
 		} )
 	);
+
+export const updateNpsResponse = ( surveyId, data ) =>
+	withRequestTimeout(
+		apiFetch( {
+			path: trimEnd(
+				`/crowdsignal-forms/v1/nps/${ surveyId || '' }/response`
+			),
+			method: 'POST',
+			data,
+		} )
+	);

--- a/client/nps.js
+++ b/client/nps.js
@@ -21,22 +21,25 @@ window.addEventListener( 'load', () =>
 				const attributes = JSON.parse( element.dataset.crowdsignalNps );
 				const viewThreshold = parseInt( attributes.viewThreshold, 10 );
 
-				const key = `${ NPS_VIEWS_STORAGE_PREFIX }${ attributes.surveyId }`;
-				const viewCount =
-					1 + parseInt( window.localStorage.getItem( key ) || 0, 10 );
-
-				window.localStorage.setItem( key, viewCount );
-
-				// eslint-disable-next-line no-console
-				console.log(
-					`NPS block: Current view count: ${ viewCount }. Threshold: ${ viewThreshold }.` +
-						`Use "localStorage.setItem( '${ key }', 0 );" to reset the counter.`
-				);
-
 				element.removeAttribute( 'data-crowdsignal-nps' );
 
-				if ( viewCount !== viewThreshold ) {
-					return;
+				if ( ! attributes.isPreview ) {
+					const key = `${ NPS_VIEWS_STORAGE_PREFIX }${ attributes.surveyId }`;
+					const viewCount =
+						1 +
+						parseInt( window.localStorage.getItem( key ) || 0, 10 );
+
+					window.localStorage.setItem( key, viewCount );
+
+					// eslint-disable-next-line no-console
+					console.log(
+						`NPS block: Current view count: ${ viewCount }. Threshold: ${ viewThreshold }.` +
+							`Use "localStorage.setItem( '${ key }', 0 );" to reset the counter.`
+					);
+
+					if ( viewCount !== viewThreshold ) {
+						return;
+					}
 				}
 
 				const closeDialog = () => element.remove();

--- a/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
@@ -24,6 +24,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 
 	/**
+	 * The nonce identifier string for NPS vote submittion.
+	 *
+	 * @since 1.4.0
+	 * @var string
+	 */
+	const NONCE = 'crowdsignal-forms-nps__submit';
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public function asset_identifier() {
@@ -71,6 +79,8 @@ class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 		wp_enqueue_style( $this->asset_identifier() );
 
 		$attributes['hideBranding'] = $this->should_hide_branding();
+		$attributes['isPreview']    = is_preview();
+		$attributes['nonce']        = wp_create_nonce( self::NONCE );
 
 		return sprintf(
 			'<div class="crowdsignal-nps-wrapper" data-crowdsignal-nps="%s"></div>',
@@ -122,7 +132,7 @@ class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 				'default' => __( 'Submit', 'crowdsignal-forms' ),
 			),
 			'surveyId'          => array(
-				'type'    => 'string',
+				'type'    => 'number',
 				'default' => null,
 			),
 			'title'             => array(

--- a/includes/gateways/class-api-gateway.php
+++ b/includes/gateways/class-api-gateway.php
@@ -202,6 +202,46 @@ class Api_Gateway implements Api_Gateway_Interface {
 	}
 
 	/**
+	 * Fires a proxy call to the Crowdsignal API NPS response endpoint
+	 * passing $data as is and returns the response body as an array or
+	 * a WP_Error.
+	 *
+	 * @param  int   $survey_id Survey ID.
+	 * @param  array $data      Request data.
+	 * @return array|WP_Error
+	 */
+	public function update_nps_response( $survey_id, array $data ) {
+		$response = $this->perform_request(
+			'POST',
+			'/nps/' . $survey_id . '/response',
+			$data
+		);
+
+		if ( is_wp_error( $response ) ) {
+			$this->log_webservice_event(
+				'response_error',
+				array(
+					'error' => $response,
+				)
+			);
+
+			return $response;
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		$data = json_decode( $body, true );
+
+		$this->log_webservice_event(
+			'response_success',
+			array(
+				'data' => $data,
+			)
+		);
+
+		return $data;
+	}
+
+	/**
 	 * Common method for either creating or updating a Poll.
 	 *
 	 * @param Poll $poll The poll.

--- a/includes/rest-api/controllers/class-nps-controller.php
+++ b/includes/rest-api/controllers/class-nps-controller.php
@@ -64,6 +64,18 @@ class Nps_Controller {
 				),
 			)
 		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<survey_id>\d+)/response',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'upsert_nps_response' ),
+					'permission_callback' => array( $this, 'create_or_update_nps_response_permissions_check' ),
+					'args'                => $this->get_nps_fetch_params(),
+				),
+			)
+		);
 	}
 
 	/**
@@ -72,7 +84,7 @@ class Nps_Controller {
 	 * @since 1.4.0
 	 *
 	 * @param  \WP_REST_Request $request The API Request.
-	 * @return \WP_REST_RESPONSE|WP_Error
+	 * @return \WP_REST_Response|WP_Error
 	 */
 	public function upsert_nps( \WP_REST_Request $request ) {
 		$data   = $request->get_json_params();
@@ -88,6 +100,47 @@ class Nps_Controller {
 	}
 
 	/**
+	 * This route acts as a proxy for Crowdsignal's NPS response endpoint,
+	 * which allows recording and updating responses.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @todo The nonce helps but it's still possible for someone to generate their own nonce and
+	 *       submit someone else's response id.
+	 *       The nonce needs to be tied to the response ID.
+	 *
+	 * @param  \WP_REST_Request $request The API Request.
+	 * @return \WP_REST_Response|WP_ERROR
+	 */
+	public function upsert_nps_response( \WP_REST_Request $request ) {
+		$data      = $request->get_json_params();
+		$survey_id = $request->get_param( 'survey_id' );
+
+		if (
+			! wp_verify_nonce( $data['nonce'], 'crowdsignal-forms-nps__submit' ) ||
+			(
+				$data['r'] &&
+				$data['checksum'] !== $this->get_response_checksum( $data['r'], $data['nonce'] )
+			)
+		) {
+			return new \WP_Error( 'Forbidden' );
+		}
+
+		$result = Crowdsignal_Forms::instance()->get_api_gateway()->update_nps_response(
+			$survey_id,
+			$data
+		);
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$result['checksum'] = $this->get_response_checksum( $result['r'], $data['nonce'] );
+
+		return rest_ensure_response( $result );
+	}
+
+	/**
 	 * The permission check for creating a new poll.
 	 *
 	 * @since 1.4.0
@@ -96,6 +149,17 @@ class Nps_Controller {
 	 */
 	public function create_or_update_nps_permissions_check() {
 		return current_user_can( 'publish_posts' );
+	}
+
+	/**
+	 * The permission check for creating/updating nps responses.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @return bool
+	 */
+	public function create_or_update_nps_response_permissions_check() {
+		return true;
 	}
 
 	/**
@@ -114,5 +178,16 @@ class Nps_Controller {
 				},
 			),
 		);
+	}
+
+	/**
+	 * Creates a checksum hash for a response ID and nonce combination.
+	 *
+	 * @param  string $response_id Response ID.
+	 * @param  string $nonce       Nonce.
+	 * @return string
+	 */
+	private function get_response_checksum( $response_id, $nonce ) {
+		return hash( 'sha1', $response_id . $nonce );
 	}
 }


### PR DESCRIPTION
This patch further integrates the block with Crowdsignal by allowing to record NPS responses from the block.
A small side-effect of this PR is the block will now display correctly on every refresh when previewing a post or a page.

This time the new WP-API is a simple, almost 1:1 proxy for Crowdsignal's NPS response endpoint. The differences are the addition of a `checksum` field in the response, as well as the addition of a `nonce` field to the request.

Because the response is submitted in two steps and we're potentially allowing anyone to submit the requests to the WP API, it's important to protect ourselves from a case where it'd be possible for someone to alter someone else's response just by knowing the response ID.  
The solution for this is to use the response ID and the current respondent's nonce to create a checksum as soon as the rating is recorded that is to be submitted in all subsequent request.

# Testing

- Create an NPS block, fill in the important values, press the save button and publish the post.
- Verify the block uses the correct `viewThreshold` value when viewing the public page.
- Verify the block is displayed on every view when previewing the post.
- Try submitting a rating and closing the dialog. You should get a response for your survey in the Crowdsignal dashboard. The feedback should be empty.
- Try submitting a rating and feedback. The dialog should close after the feedback has been submitted. You should get a response with both the rating and the feedback inside the Crowdsignal dashboard.

Bonus: 
- Try manually submitting a feedback request using the responseID and checksum from another session. This should not work. Neither if you try to submit it using a valid nonce from a different session.