### PR TITLE
Add NPS-specific toolbar options

### DIFF
--- a/client/blocks/nps/constants.js
+++ b/client/blocks/nps/constants.js
@@ -1,0 +1,4 @@
+export const views = {
+	RATING: 'rating',
+	FEEDBACK: 'feedback',
+};

--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { pick, times } from 'lodash';
 
 /**
@@ -17,8 +17,12 @@ import { __ } from '@wordpress/i18n';
 import ConnectToCrowdsignal from 'components/connect-to-crowdsignal';
 import { updateNps } from 'data/nps';
 import Sidebar from './sidebar';
+import Toolbar from './toolbar';
+import { views } from './constants';
 
 const EditNpsBlock = ( props ) => {
+	const [ view, setView ] = useState( views.RATING );
+
 	const { attributes, clientId, setAttributes } = props;
 
 	const handleChangeAttribute = ( attribute ) => ( value ) =>
@@ -57,6 +61,11 @@ const EditNpsBlock = ( props ) => {
 			blockIcon={ null }
 			blockName={ __( 'Crowdsignal NPS', 'crowdsignal-forms' ) }
 		>
+			<Toolbar
+				currentView={ view }
+				onViewChange={ setView }
+				{ ...props }
+			/>
 			<Sidebar { ...props } />
 
 			<button onClick={ handleSaveNPS }>
@@ -72,83 +81,87 @@ const EditNpsBlock = ( props ) => {
 				allowedFormats={ [] }
 			/>
 
-			<div className="crowdsignal-forms-nps">
-				<RichText
-					tagName="p"
-					className="crowdsignal-forms-nps__question"
-					placeholder={ __(
-						'Enter your rating question',
-						'crowdsignal-forms'
-					) }
-					onChange={ handleChangeAttribute( 'ratingQuestion' ) }
-					value={ attributes.ratingQuestion }
-					allowedFormats={ [] }
-				/>
-
-				<div className="crowdsignal-forms-nps__rating">
-					<div className="crowdsignal-forms-nps__rating-labels">
-						<RichText
-							tagName="span"
-							placeholder={ __( 'Low', 'crowdsignal-forms' ) }
-							onChange={ handleChangeAttribute(
-								'lowRatingLabel'
-							) }
-							value={ attributes.lowRatingLabel }
-							allowedFormats={ [] }
-						/>
-						<RichText
-							tagName="span"
-							placeholder={ __( 'High', 'crowdsignal-forms' ) }
-							onChange={ handleChangeAttribute(
-								'highRatingLabel'
-							) }
-							value={ attributes.highRatingLabel }
-							allowedFormats={ [] }
-						/>
-					</div>
-
-					<div className="crowdsignal-forms-nps__rating-scale">
-						{ times( 11, ( n ) => (
-							<div
-								key={ `rating-${ n }` }
-								className="crowdsignal-forms-nps__rating-button"
-							>
-								{ n }
-							</div>
-						) ) }
-					</div>
-				</div>
-			</div>
-
-			<div className="crowdsignal-forms-nps">
-				<div className="crowdsignal-forms-nps__feedback">
+			{ view === views.RATING && (
+				<div className="crowdsignal-forms-nps">
 					<RichText
 						tagName="p"
 						className="crowdsignal-forms-nps__question"
 						placeholder={ __(
-							'Enter your feedback question',
+							'Enter your rating question',
 							'crowdsignal-forms'
 						) }
-						onChange={ handleChangeAttribute( 'feedbackQuestion' ) }
-						value={ attributes.feedbackQuestion }
+						onChange={ handleChangeAttribute( 'ratingQuestion' ) }
+						value={ attributes.ratingQuestion }
 						allowedFormats={ [] }
 					/>
 
-					<textarea
-						className="crowdsignal-forms-nps__feedback-text"
-						rows={ 6 }
-					/>
+					<div className="crowdsignal-forms-nps__rating">
+						<div className="crowdsignal-forms-nps__rating-labels">
+							<RichText
+								tagName="span"
+								placeholder={ __( 'Low', 'crowdsignal-forms' ) }
+								onChange={ handleChangeAttribute(
+									'lowRatingLabel'
+								) }
+								value={ attributes.lowRatingLabel }
+								allowedFormats={ [] }
+							/>
+							<RichText
+								tagName="span"
+								placeholder={ __( 'High', 'crowdsignal-forms' ) }
+								onChange={ handleChangeAttribute(
+									'highRatingLabel'
+								) }
+								value={ attributes.highRatingLabel }
+								allowedFormats={ [] }
+							/>
+						</div>
 
-					<RichText
-						className="wp-block-button__link crowdsignal-forms-nps__feedback-button"
-						onChange={ handleChangeAttribute(
-							'submitButtonLabel'
-						) }
-						value={ attributes.submitButtonLabel }
-						allowedFormats={ [] }
-					/>
+						<div className="crowdsignal-forms-nps__rating-scale">
+							{ times( 11, ( n ) => (
+								<div
+									key={ `rating-${ n }` }
+									className="crowdsignal-forms-nps__rating-button"
+								>
+									{ n }
+								</div>
+							) ) }
+						</div>
+					</div>
 				</div>
-			</div>
+			) }
+
+			{ view === views.FEEDBACK && (
+				<div className="crowdsignal-forms-nps">
+					<div className="crowdsignal-forms-nps__feedback">
+						<RichText
+							tagName="p"
+							className="crowdsignal-forms-nps__question"
+							placeholder={ __(
+								'Enter your feedback question',
+								'crowdsignal-forms'
+							) }
+							onChange={ handleChangeAttribute( 'feedbackQuestion' ) }
+							value={ attributes.feedbackQuestion }
+							allowedFormats={ [] }
+						/>
+
+						<textarea
+							className="crowdsignal-forms-nps__feedback-text"
+							rows={ 6 }
+						/>
+
+						<RichText
+							className="wp-block-button__link crowdsignal-forms-nps__feedback-button"
+							onChange={ handleChangeAttribute(
+								'submitButtonLabel'
+							) }
+							value={ attributes.submitButtonLabel }
+							allowedFormats={ [] }
+						/>
+					</div>
+				</div>
+			) }
 		</ConnectToCrowdsignal>
 	);
 };

--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -108,7 +108,10 @@ const EditNpsBlock = ( props ) => {
 							/>
 							<RichText
 								tagName="span"
-								placeholder={ __( 'High', 'crowdsignal-forms' ) }
+								placeholder={ __(
+									'High',
+									'crowdsignal-forms'
+								) }
 								onChange={ handleChangeAttribute(
 									'highRatingLabel'
 								) }
@@ -141,7 +144,9 @@ const EditNpsBlock = ( props ) => {
 								'Enter your feedback question',
 								'crowdsignal-forms'
 							) }
-							onChange={ handleChangeAttribute( 'feedbackQuestion' ) }
+							onChange={ handleChangeAttribute(
+								'feedbackQuestion'
+							) }
 							value={ attributes.feedbackQuestion }
 							allowedFormats={ [] }
 						/>

--- a/client/blocks/nps/edit.scss
+++ b/client/blocks/nps/edit.scss
@@ -1,1 +1,15 @@
 /* Editor styles */
+
+.crowdsignal-forms-nps__toolbar-toggle {
+	font-weight: 600;
+	padding-left: 16px !important;
+	padding-right: 16px !important;
+}
+
+.crowdsignal-forms-nps__toolbar-popover {
+	padding: 15px;
+}
+
+.crowdsignal-forms-nps__toolbar-popover-button svg {
+	margin-right: 0 !important;
+

--- a/client/blocks/nps/edit.scss
+++ b/client/blocks/nps/edit.scss
@@ -12,4 +12,4 @@
 
 .crowdsignal-forms-nps__toolbar-popover-button svg {
 	margin-right: 0 !important;
-
+}

--- a/client/blocks/nps/toolbar.js
+++ b/client/blocks/nps/toolbar.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { BlockControls } from '@wordpress/block-editor';
+import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { views } from './constants';
+
+const PollToolbar = ( { currentView, onViewChange } ) => {
+	const handleViewChange = ( view ) => () => onViewChange( view );
+
+	return (
+		<BlockControls>
+			<ToolbarGroup label={ __( 'Current view', 'crowdsignal-forms' ) }>
+				<ToolbarButton
+					isActive={ currentView === views.RATING }
+					label={ __( 'Rating', 'crowdsignal-forms' ) }
+					onClick={ handleViewChange( views.RATING ) }
+				>
+					{ __( 'Rating', 'crowdsignal-forms' ) }
+				</ToolbarButton>
+				<ToolbarButton
+					isActive={ currentView === views.FEEDBACK }
+					label={ __( 'Feedback', 'crowdsignal-forms' ) }
+					onClick={ handleViewChange( views.FEEDBACK ) }
+				>
+					{ __( 'Feedback', 'crowdsignal-forms' ) }
+				</ToolbarButton>
+			</ToolbarGroup>
+		</BlockControls>
+	);
+};
+
+export default PollToolbar;

--- a/client/blocks/nps/toolbar.js
+++ b/client/blocks/nps/toolbar.js
@@ -1,13 +1,18 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState } from 'react';
 
 /**
  * WordPress dependencies
  */
 import { BlockControls } from '@wordpress/block-editor';
-import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
+import {
+	Popover,
+	TextControl,
+	ToolbarGroup,
+	ToolbarButton
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -15,13 +20,27 @@ import { __ } from '@wordpress/i18n';
  */
 import { views } from './constants';
 
-const PollToolbar = ( { currentView, onViewChange } ) => {
+const PollToolbar = ( { attributes, currentView, onViewChange, setAttributes } ) => {
+	const [ showThreshold, setShowThreshold ] = useState( false );
+
 	const handleViewChange = ( view ) => () => onViewChange( view );
+
+	const showThresholdPopover = () =>
+		setShowThreshold( true );
+
+	const hideThresholdPopover = () =>
+		setShowThreshold( false );
+
+	const handleChangeViewThreshold = ( viewThreshold ) =>
+		setAttributes( {
+			viewThreshold,
+		} );
 
 	return (
 		<BlockControls>
 			<ToolbarGroup label={ __( 'Current view', 'crowdsignal-forms' ) }>
 				<ToolbarButton
+					className="crowdsignal-forms-nps__toolbar-toggle"
 					isActive={ currentView === views.RATING }
 					label={ __( 'Rating', 'crowdsignal-forms' ) }
 					onClick={ handleViewChange( views.RATING ) }
@@ -29,11 +48,33 @@ const PollToolbar = ( { currentView, onViewChange } ) => {
 					{ __( 'Rating', 'crowdsignal-forms' ) }
 				</ToolbarButton>
 				<ToolbarButton
+					className="crowdsignal-forms-nps__toolbar-toggle"
 					isActive={ currentView === views.FEEDBACK }
 					label={ __( 'Feedback', 'crowdsignal-forms' ) }
 					onClick={ handleViewChange( views.FEEDBACK ) }
 				>
 					{ __( 'Feedback', 'crowdsignal-forms' ) }
+				</ToolbarButton>
+			</ToolbarGroup>
+			<ToolbarGroup>
+				<ToolbarButton
+					className="crowdsignal-forms-nps__toolbar-popover-button"
+					icon="visibility"
+					label={ __( 'Set view threshold', 'crowdsignal-forms' ) }
+					onClick={ showThresholdPopover }
+				>
+					{ showThreshold && (
+						<Popover onClose={ hideThresholdPopover }>
+							<div className="crowdsignal-forms-nps__toolbar-popover">
+								<TextControl
+									label={ __( 'Show this block after n visits:', 'crowdsignal-forms' ) }
+									value={ attributes.viewThreshold }
+									onChange={ handleChangeViewThreshold }
+									type="number"
+								/>
+							</div>
+						</Popover>
+					) }
 				</ToolbarButton>
 			</ToolbarGroup>
 		</BlockControls>

--- a/client/blocks/nps/toolbar.js
+++ b/client/blocks/nps/toolbar.js
@@ -11,7 +11,7 @@ import {
 	Popover,
 	TextControl,
 	ToolbarGroup,
-	ToolbarButton
+	ToolbarButton,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -20,16 +20,18 @@ import { __ } from '@wordpress/i18n';
  */
 import { views } from './constants';
 
-const PollToolbar = ( { attributes, currentView, onViewChange, setAttributes } ) => {
+const PollToolbar = ( {
+	attributes,
+	currentView,
+	onViewChange,
+	setAttributes,
+} ) => {
 	const [ showThreshold, setShowThreshold ] = useState( false );
 
 	const handleViewChange = ( view ) => () => onViewChange( view );
 
-	const showThresholdPopover = () =>
-		setShowThreshold( true );
-
-	const hideThresholdPopover = () =>
-		setShowThreshold( false );
+	const showThresholdPopover = () => setShowThreshold( true );
+	const hideThresholdPopover = () => setShowThreshold( false );
 
 	const handleChangeViewThreshold = ( viewThreshold ) =>
 		setAttributes( {
@@ -67,7 +69,10 @@ const PollToolbar = ( { attributes, currentView, onViewChange, setAttributes } )
 						<Popover onClose={ hideThresholdPopover }>
 							<div className="crowdsignal-forms-nps__toolbar-popover">
 								<TextControl
-									label={ __( 'Show this block after n visits:', 'crowdsignal-forms' ) }
+									label={ __(
+										'Show this block after n visits:',
+										'crowdsignal-forms'
+									) }
 									value={ attributes.viewThreshold }
 									onChange={ handleChangeViewThreshold }
 									type="number"


### PR DESCRIPTION
This patch implements toolbar options specific to the NPS block. That is:

- Toggling the view between rating and feedback views.
- Setting the view threshold.

Note the icons are still only temporary.

![Screen Shot 2021-01-18 at 10 29 27 PM](https://user-images.githubusercontent.com/8056203/105018461-4f067a80-5a45-11eb-9921-b512b48ed53b.png)

# Testing

- Add an NPS block, you should only see the rating view of the block. You can toggle between the rating and the feedback view using the 'Rating/Feedback' toggle in the toolbar.

- Click on the eye icon in the toolbar, you should see a popover with an input for the view threshold. Edit the number and verify your new value is saved and works correctly when the post is published.