### PR TITLE
Add the results section to the NPS block sidebar

### DIFF
--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { pick, times } from 'lodash';
+import { pick, tap, times } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -35,12 +35,19 @@ const EditNpsBlock = ( props ) => {
 
 		try {
 			const { surveyId } = await updateNps(
-				pick( attributes, [
-					'feedbackQuestion',
-					'ratingQuestion',
-					'surveyId',
-					'title',
-				] )
+				tap(
+					pick( attributes, [
+						'feedbackQuestion',
+						'ratingQuestion',
+						'surveyId',
+						'title',
+					] ),
+					( data ) => {
+						if ( ! data.title ) {
+							data.title = data.ratingQuestion;
+						}
+					}
+				)
 			);
 
 			if ( attributes.surveyId ) {

--- a/client/blocks/nps/sidebar.js
+++ b/client/blocks/nps/sidebar.js
@@ -6,8 +6,14 @@ import React from 'react';
 /**
  * WordPress dependencies
  */
-import { PanelBody, TextControl } from '@wordpress/components';
+import {
+	Button,
+	ExternalLink,
+	PanelBody,
+	TextControl,
+} from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -15,22 +21,53 @@ import { __ } from '@wordpress/i18n';
  */
 
 const Sidebar = ( { attributes, setAttributes } ) => {
-	const handleChangeViewThreshold = ( viewThreshold ) =>
-		setAttributes( {
-			viewThreshold,
-		} );
+	const handleChangeTitle = ( title ) => setAttributes( { title } );
+
+	const resultsUrl = `https://app.crowdsignal.com/surveys/${ attributes.surveyId }/report/overview`;
 
 	return (
 		<InspectorControls>
 			<PanelBody
-				title={ __( 'NPS Settings', 'crowdsignal-forms' ) }
+				title={ __( 'Results', 'crowdsignal-forms' ) }
 				initialOpen={ true }
 			>
+				<p>
+					{ attributes.surveyId
+						? __( 'Manage results on ', 'crowdsignal-forms' )
+						: __(
+								'Save the block to track results on ',
+								'crowdsignal-forms'
+						  ) }
+					<ExternalLink
+						href={
+							attributes.surveyId
+								? resultsUrl
+								: 'https://www.crowdsignal.com'
+						}
+					>
+						crowdsignal.com
+					</ExternalLink>
+				</p>
+				<p>
+					<Button
+						isSecondary
+						disabled={ ! attributes.surveyId }
+						href={ resultsUrl }
+						target="blank"
+					>
+						{ __( 'View results', 'crowdsignal-forms' ) }
+					</Button>
+				</p>
+
 				<TextControl
-					label={ __( 'View threshold', 'crowdsignal-forms' ) }
-					value={ attributes.viewThreshold }
-					onChange={ handleChangeViewThreshold }
-					type="number"
+					label={ __(
+						'Title of the NPS block',
+						'crowdsignal-forms'
+					) }
+					onChange={ handleChangeTitle }
+					value={ decodeEntities(
+						attributes.title ?? attributes.ratingQuestion
+					) }
 				/>
 			</PanelBody>
 		</InspectorControls>


### PR DESCRIPTION
This patch updates the sidebar of the NPS block to add the results section. It also removes the viewThreshold from the sidebar which will be implemented as part of the toolbar (#21).  
The 'title' input inside the block has also been removed in favor of the `title` input inside the results area in the sidebar. It's populated with the rating question by default.

# Testing

- Add a new NPS block and focus it. You should see the results section in the sidebar.
- The results should be disabled until you save the block to the platform by clicking the `save` button on the block.
- Once the block is saved, the `View results` button should redirect you to the results page.