### PR TITLE
Add a notification/preview bar to the block

### DIFF
--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -3,12 +3,15 @@
  */
 import React, { useState } from 'react';
 import { pick, tap, times } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
+import { Icon, Notice } from '@wordpress/components';
 import { RichText } from '@wordpress/block-editor';
-import { dispatch } from '@wordpress/data';
+import { dispatch, withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -29,6 +32,8 @@ const EditNpsBlock = ( props ) => {
 		attributes,
 		clientId,
 		fallbackStyles,
+		isSelected,
+		postPreviewLink,
 		setAttributes,
 		renderStyleProbe,
 	} = props;
@@ -71,6 +76,10 @@ const EditNpsBlock = ( props ) => {
 		}
 	};
 
+	const classes = classnames( 'crowdsignal-forms-nps', {
+		'is-inactive': ! isSelected,
+	} );
+
 	return (
 		<ConnectToCrowdsignal
 			blockIcon={ null }
@@ -87,9 +96,28 @@ const EditNpsBlock = ( props ) => {
 				{ __( 'Save', 'crowdsignal-forms' ) }
 			</button>
 
-			{ view === views.RATING && (
+			<Notice
+				className="crowdsignal-forms-nps__editor-notice"
+				isDismissible={ false }
+				actions={ [
+					{
+						label: __( 'Preview', 'crowdsignal-forms' ),
+						onClick: () => window.open( postPreviewLink, 'blank' ),
+					},
+				] }
+			>
+				<Icon icon="visibility" />
+				<span className="crowdsignal-forms-nps__editor-notice-text">
+					{ __(
+						'This block will appear as a popup window to people who have visited this page at least 3 times.',
+						'crowdsignal-forms'
+					) }
+				</span>
+			</Notice>
+
+			{ ( view === views.RATING || ! isSelected ) && (
 				<div
-					className="crowdsignal-forms-nps"
+					className={ classes }
 					style={ getStyleVars( attributes, fallbackStyles ) }
 				>
 					<RichText
@@ -143,14 +171,14 @@ const EditNpsBlock = ( props ) => {
 				</div>
 			) }
 
-			{ view === views.FEEDBACK && (
+			{ view === views.FEEDBACK && isSelected && (
 				<div
-					className="crowdsignal-forms-nps"
+					className={ classes }
 					style={ getStyleVars( attributes, fallbackStyles ) }
 				>
 					<div className="crowdsignal-forms-nps__feedback">
 						<RichText
-							tagName="p"
+							tagName="h3"
 							className="crowdsignal-forms-nps__question"
 							placeholder={ __(
 								'Enter your feedback question',
@@ -185,4 +213,9 @@ const EditNpsBlock = ( props ) => {
 	);
 };
 
-export default withFallbackStyles( EditNpsBlock );
+export default compose( [
+	withSelect( ( select ) => ( {
+		postPreviewLink: select( 'core/editor' ).getEditedPostPreviewLink(),
+	} ) ),
+	withFallbackStyles,
+] )( EditNpsBlock );

--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { pick, tap, times } from 'lodash';
 import classnames from 'classnames';
 
@@ -37,6 +37,14 @@ const EditNpsBlock = ( props ) => {
 		setAttributes,
 		renderStyleProbe,
 	} = props;
+
+	useEffect( () => {
+		if ( isSelected ) {
+			return;
+		}
+
+		setView( views.RATING );
+	}, [ isSelected ] );
 
 	const handleChangeAttribute = ( attribute ) => ( value ) =>
 		setAttributes( {
@@ -121,7 +129,7 @@ const EditNpsBlock = ( props ) => {
 					style={ getStyleVars( attributes, fallbackStyles ) }
 				>
 					<RichText
-						tagName="p"
+						tagName="h3"
 						className="crowdsignal-forms-nps__question"
 						placeholder={ __(
 							'Enter your rating question',

--- a/client/blocks/nps/edit.scss
+++ b/client/blocks/nps/edit.scss
@@ -1,5 +1,9 @@
 /* Editor styles */
 
+.crowdsignal-forms-nps.is-inactive {
+	opacity: 0.6;
+}
+
 .crowdsignal-forms-nps__toolbar-toggle {
 	font-weight: 600;
 	padding-left: 16px !important;
@@ -12,6 +16,24 @@
 
 .crowdsignal-forms-nps__toolbar-popover-button svg {
 	margin-right: 0 !important;
+}
+
+.crowdsignal-forms-nps__editor-notice {
+	margin: 0 0 15px !important;
+
+	.components-notice__content {
+		align-items: center;
+		display: flex;
+
+		svg:first-child {
+			margin-right: 12px;
+		}
+	}
+}
+
+.crowdsignal-forms-nps__editor-notice-text {
+	display: flex;
+	flex: 1;
 }
 
 .crowdsignal-forms-nps__rating-button:hover {

--- a/client/components/nps/style.scss
+++ b/client/components/nps/style.scss
@@ -2,11 +2,11 @@
 
 .crowdsignal-forms-nps {
 	border: 0;
-	border-top: 5px solid var(--crowdsignal-forms-button-color);
+	border-top: 10px solid var(--crowdsignal-forms-button-color);
 	background-color: var(--crowdsignal-forms-background-color);
 	color: var(--crowdsignal-forms-text-color);
 	height: auto;
-	padding: 50px;
+	padding: 32px;
 	position: relative;
 }
 


### PR DESCRIPTION
This patch adds a notification above the NPS block in the editor, informing the user the block is actually a popup, and offering a preview link which opens the post preview in a new tab.

The block will be 'grayed out' when unselected to further highlight this fact. The block always switches to the rating view when unselected.

![Screen Shot 2021-01-20 at 6 19 08 PM](https://user-images.githubusercontent.com/8056203/105211727-e3a7d000-5b4c-11eb-9b14-cd3b23b86b83.png)

# Testing

Add an NPS block and verify there's a notification banner on top. Clicking the **Preview** button should open a new post preview.  
Check that the block gets 'grayed out' when unselected and that the rating view is shown even if feedback view was previously active.  
Clicking into the block again should go into the last active view.