### PR TITLE
Update default and placeholder values for the NPS block

### DIFF
--- a/client/blocks/nps/attributes.js
+++ b/client/blocks/nps/attributes.js
@@ -19,9 +19,19 @@ export default {
 	buttonTextColor: {
 		type: 'string',
 	},
+	feedbackPlaceholder: {
+		type: 'string',
+		default: __(
+			'Please help us understand your rating',
+			'crowdsignal-forms'
+		),
+	},
 	feedbackQuestion: {
 		type: 'string',
-		default: '',
+		default: __(
+			'Thanks so much for your response! How could we do better?',
+			'crowdsignal-forms'
+		),
 	},
 	hideBranding: {
 		type: 'boolean',
@@ -29,15 +39,18 @@ export default {
 	},
 	highRatingLabel: {
 		type: 'string',
-		default: '',
+		default: __( 'Extremely likely', 'crowdsignal-forms' ),
 	},
 	lowRatingLabel: {
 		type: 'string',
-		default: '',
+		default: __( 'Not likely at all', 'crowdsignal-forms' ),
 	},
 	ratingQuestion: {
 		type: 'string',
-		default: '',
+		default: __(
+			'How likely is it that you would recommend this project to a friend or colleague?',
+			'crowdsignal-forms'
+		),
 	},
 	submitButtonLabel: {
 		type: 'string',

--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Icon, Notice } from '@wordpress/components';
+import { Icon, Notice, TextareaControl } from '@wordpress/components';
 import { RichText } from '@wordpress/block-editor';
 import { dispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
@@ -144,7 +144,10 @@ const EditNpsBlock = ( props ) => {
 						<div className="crowdsignal-forms-nps__rating-labels">
 							<RichText
 								tagName="span"
-								placeholder={ __( 'Low', 'crowdsignal-forms' ) }
+								placeholder={ __(
+									'Not likely',
+									'crowdsignal-forms'
+								) }
 								onChange={ handleChangeAttribute(
 									'lowRatingLabel'
 								) }
@@ -154,7 +157,7 @@ const EditNpsBlock = ( props ) => {
 							<RichText
 								tagName="span"
 								placeholder={ __(
-									'High',
+									'Very likely',
 									'crowdsignal-forms'
 								) }
 								onChange={ handleChangeAttribute(
@@ -199,9 +202,13 @@ const EditNpsBlock = ( props ) => {
 							allowedFormats={ [] }
 						/>
 
-						<textarea
+						<TextareaControl
 							className="crowdsignal-forms-nps__feedback-text"
 							rows={ 6 }
+							onChange={ handleChangeAttribute(
+								'feedbackPlaceholder'
+							) }
+							value={ attributes.feedbackPlaceholder }
 						/>
 
 						<RichText

--- a/client/components/nps/feedback.js
+++ b/client/components/nps/feedback.js
@@ -4,6 +4,11 @@
 import React, { useState } from 'react';
 
 /**
+ * WordPress dependencies
+ */
+import { TextareaControl } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import { updateNpsResponse } from 'data/nps';
@@ -11,8 +16,6 @@ import { updateNpsResponse } from 'data/nps';
 const NpsFeedback = ( { attributes, onFailure, onSubmit, responseMeta } ) => {
 	const [ feedback, setFeedback ] = useState( '' );
 	const [ submitting, setSubmitting ] = useState( false );
-
-	const handleFeedbackChange = ( event ) => setFeedback( event.target.value );
 
 	const handleSubmit = async () => {
 		setSubmitting( true );
@@ -32,11 +35,13 @@ const NpsFeedback = ( { attributes, onFailure, onSubmit, responseMeta } ) => {
 
 	return (
 		<div className="crowdsignal-forms-nps__feedback">
-			<textarea
+			<TextareaControl
 				className="crowdsignal-forms-nps__feedback-text"
 				disabled={ submitting }
 				rows={ 6 }
-				onChange={ handleFeedbackChange }
+				placeholder={ attributes.feedbackPlaceholder }
+				onChange={ setFeedback }
+				value={ feedback }
 			/>
 
 			<button

--- a/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
@@ -107,51 +107,64 @@ class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 	 */
 	private function attributes() {
 		return array(
-			'backgroundColor'   => array(
+			'backgroundColor'     => array(
 				'type' => 'string',
 			),
-			'buttonColor'       => array(
+			'buttonColor'         => array(
 				'type' => 'string',
 			),
-			'buttonTextColor'   => array(
+			'buttonTextColor'     => array(
 				'type' => 'string',
 			),
-			'feedbackQuestion'  => array(
+			'feedbackPlaceholder' => array(
 				'type'    => 'string',
-				'default' => '',
+				'default' => __(
+					'Please help us understand your rating',
+					'crowdsignal-forms'
+				),
 			),
-			'hideBranding'      => array(
+			'feedbackQuestion'    => array(
+				'type'    => 'string',
+				'default' => __(
+					'Thanks so much for your response! How could we do better?',
+					'crowdsignal-forms'
+				),
+			),
+			'hideBranding'        => array(
 				'type'    => 'boolean',
 				'default' => false,
 			),
-			'highRatingLabel'   => array(
+			'highRatingLabel'     => array(
 				'type'    => 'string',
-				'default' => '',
+				'default' => __( 'Extremely likely', 'crowdsignal-forms' ),
 			),
-			'lowRatingLabel'    => array(
+			'lowRatingLabel'      => array(
 				'type'    => 'string',
-				'default' => '',
+				'default' => __( 'Not likely at all', 'crowdsignal-forms' ),
 			),
-			'ratingQuestion'    => array(
+			'ratingQuestion'      => array(
 				'type'    => 'string',
-				'default' => '',
+				'default' => __(
+					'How likely is it that you would recommend this project to a friend or colleague?',
+					'crowdsignal-forms'
+				),
 			),
-			'submitButtonLabel' => array(
+			'submitButtonLabel'   => array(
 				'type'    => 'string',
 				'default' => __( 'Submit', 'crowdsignal-forms' ),
 			),
-			'surveyId'          => array(
+			'surveyId'            => array(
 				'type'    => 'number',
 				'default' => null,
 			),
-			'textColor'         => array(
+			'textColor'           => array(
 				'type' => 'string',
 			),
-			'title'             => array(
+			'title'               => array(
 				'type'    => 'string',
 				'default' => '',
 			),
-			'viewThreshold'     => array(
+			'viewThreshold'       => array(
 				'type'    => 'string',
 				'default' => 3,
 			),


### PR DESCRIPTION
This patch updates the block placeholders and adds default values for the fields that likely make much sense given the very specific nature of the block.  
It also enables editing of the feedback placeholder text.

![Screen Shot 2021-01-21 at 3 31 20 PM](https://user-images.githubusercontent.com/8056203/105364971-11991d00-5bfe-11eb-8d4a-55adae3296f5.png)

# Testing

- Create w new NPS block
- All the fields should be pre-populated with values from the designs.