### PR TITLE
Check if redirectAddress is set before accessing it.

### DIFF
--- a/includes/frontend/blocks/class-crowdsignal-forms-poll-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-poll-block.php
@@ -71,9 +71,11 @@ class Crowdsignal_Forms_Poll_Block extends Crowdsignal_Forms_Block {
 		wp_enqueue_script( $this->asset_identifier() );
 		wp_enqueue_style( $this->asset_identifier() );
 
-		$attributes['redirectAddress'] = esc_url( $attributes['redirectAddress'] );
-		$attributes['hideBranding']    = $this->should_hide_branding();
-		$platform_poll_data            = $this->get_platform_poll_data( $attributes['pollId'] );
+		if ( isset( $attributes['redirectAddress'] ) ) {
+			$attributes['redirectAddress'] = esc_url( $attributes['redirectAddress'] );
+		}
+		$attributes['hideBranding'] = $this->should_hide_branding();
+		$platform_poll_data         = $this->get_platform_poll_data( $attributes['pollId'] );
 		if ( ! empty( $platform_poll_data ) ) {
 			$attributes['apiPollData'] = $platform_poll_data;
 		}


### PR DESCRIPTION
Avoids a PHP warning.  https://wordpress.org/support/topic/error-notice-23/