### PR TITLE
Inject 'source' prop on payload

### DIFF
--- a/includes/gateways/class-api-gateway.php
+++ b/includes/gateways/class-api-gateway.php
@@ -171,10 +171,15 @@ class Api_Gateway implements Api_Gateway_Interface {
 	 * @return Nps_Survey|WP_Error
 	 */
 	public function update_nps( Nps_Survey $survey ) {
+		$survey_array = $survey->to_array();
+
+		// Inject source attribute.
+		$survey_array['source'] = 'crowdsignal-forms';
+
 		$response = $this->perform_request(
 			'POST',
 			$survey->get_id() ? '/nps/' . $survey->get_id() : '/nps',
-			$survey->to_array()
+			$survey_array
 		);
 
 		if ( is_wp_error( $response ) ) {


### PR DESCRIPTION
This PR adds a forced injection on NPS payload through the API Gateway

This PR depends on D56246-code

## Test instructions
Checkout and create a post with an NPS block. Save the NPS. Make sure the dependent backend diff is applied.
Check your Crowdsignal dashboard. The newly created NPS should show with only the Results link available.