### PR TITLE
Add/source link to payload

### DIFF
--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useEffect, useState } from 'react';
-import { pick, tap, times } from 'lodash';
+import { times } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -56,28 +56,26 @@ const EditNpsBlock = ( props ) => {
 		dispatch( 'core/editor' ).lockPostSaving( clientId );
 
 		try {
-			const { surveyId } = await updateNps(
-				tap(
-					pick( { ...attributes, sourceLink }, [
-						'feedbackQuestion',
-						'ratingQuestion',
-						'surveyId',
-						'title',
-						'sourceLink',
-					] ),
-					( data ) => {
-						if ( ! data.title ) {
-							data.title = data.ratingQuestion;
-						}
-					}
-				)
-			);
+			const {
+				feedbackQuestion,
+				ratingQuestion,
+				surveyId,
+				title,
+			} = attributes;
+
+			const { apiSurveyId } = await updateNps( {
+				feedbackQuestion,
+				ratingQuestion,
+				sourceLink,
+				surveyId,
+				title: title || ratingQuestion,
+			} );
 
 			if ( attributes.surveyId ) {
 				return;
 			}
 
-			setAttributes( { surveyId } );
+			setAttributes( { apiSurveyId } );
 		} catch ( error ) {
 			// eslint-disable-next-line no-console
 			console.error( error );

--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -36,6 +36,7 @@ const EditNpsBlock = ( props ) => {
 		postPreviewLink,
 		setAttributes,
 		renderStyleProbe,
+		sourceLink,
 	} = props;
 
 	useEffect( () => {
@@ -57,11 +58,12 @@ const EditNpsBlock = ( props ) => {
 		try {
 			const { surveyId } = await updateNps(
 				tap(
-					pick( attributes, [
+					pick( { ...attributes, sourceLink }, [
 						'feedbackQuestion',
 						'ratingQuestion',
 						'surveyId',
 						'title',
+						'sourceLink',
 					] ),
 					( data ) => {
 						if ( ! data.title ) {
@@ -231,6 +233,7 @@ const EditNpsBlock = ( props ) => {
 export default compose( [
 	withSelect( ( select ) => ( {
 		postPreviewLink: select( 'core/editor' ).getEditedPostPreviewLink(),
+		sourceLink: select( 'core/editor' ).getPermalink(),
 	} ) ),
 	withFallbackStyles,
 ] )( EditNpsBlock );

--- a/includes/models/class-nps-survey.php
+++ b/includes/models/class-nps-survey.php
@@ -50,6 +50,14 @@ class Nps_Survey {
 	private $feedback_question = '';
 
 	/**
+	 * Permalink URL where the NPS is published.
+	 *
+	 * @since [next-version-number]
+	 * @var string
+	 */
+	private $source_link = '';
+
+	/**
 	 * Creates a new Nps_Survey object from an array of params.
 	 *
 	 * @param  array $data An array containing the survey data.
@@ -60,7 +68,8 @@ class Nps_Survey {
 			$data['id'],
 			$data['title'],
 			$data['rating_text'],
-			$data['feedback_text']
+			$data['feedback_text'],
+			! empty( $data['source_link'] ) ? $data['source_link'] : ''
 		);
 	}
 
@@ -75,7 +84,8 @@ class Nps_Survey {
 			$attributes['surveyId'],
 			$attributes['title'],
 			$attributes['ratingQuestion'],
-			$attributes['feedbackQuestion']
+			$attributes['feedbackQuestion'],
+			! empty( $attributes['sourceLink'] ) ? $attributes['sourceLink'] : ''
 		);
 	}
 
@@ -89,12 +99,14 @@ class Nps_Survey {
 	 * @param string $title             Survey title.
 	 * @param string $rating_question   Rating question.
 	 * @param string $feedback_question Feedback question.
+	 * @param string $source_link       Blog post/page permalink.
 	 */
-	public function __construct( $id, $title, $rating_question, $feedback_question ) {
+	public function __construct( $id, $title, $rating_question, $feedback_question, $source_link = '' ) {
 		$this->id                = $id;
 		$this->title             = $title;
 		$this->rating_question   = $rating_question;
 		$this->feedback_question = $feedback_question;
+		$this->source_link       = $source_link;
 	}
 
 	/**
@@ -120,6 +132,7 @@ class Nps_Survey {
 			'title'         => $this->title,
 			'rating_text'   => $this->rating_question,
 			'feedback_text' => $this->feedback_question,
+			'source_link'   => $this->source_link,
 		);
 
 		if ( $this->id ) {
@@ -142,6 +155,7 @@ class Nps_Survey {
 			'title'            => $this->title,
 			'ratingQuestion'   => $this->rating_question,
 			'feedbackQuestion' => $this->feedback_question,
+			'sourceLink'       => $this->source_link,
 		);
 	}
 }


### PR DESCRIPTION
This PR will append the `source_link`/`sourceLink` attribute to the payload sent to the API.

The `source_link` is taken from core selector `getPermalink`.

## Test instructions
Checkout and `make client`. Save an NPS block and confirm you can see the link on your dashboard under the column "Source" for the saved NPS survey.
