### PR TITLE
Support exclusive block

### DIFF
--- a/client/blocks/nps/index.js
+++ b/client/blocks/nps/index.js
@@ -14,5 +14,8 @@ export default {
 	description: __( 'Net Promoter Score', 'crowdsignal-forms' ),
 	category: 'crowdsignal-forms',
 	attributes,
+	supports: {
+		multiple: false,
+	},
 	edit,
 };


### PR DESCRIPTION
This PR sets the `supports.multiple: false` for the NPS block.

## Test instructions
Checkout and `make client`. Insert an NPS block on a post, then try to insert another. The second time the NPS should not be available for insertion
![image](https://user-images.githubusercontent.com/157240/106799875-875da980-663e-11eb-9e4c-c3f92010afd1.png)
