### PR TITLE
Add branding for NPS block

### DIFF
--- a/assets/stylesheets/editor.scss
+++ b/assets/stylesheets/editor.scss
@@ -5,6 +5,7 @@
 @import "components/connect-to-crowdsignal/style.scss";
 @import "components/signal-warning/style.scss";
 @import "components/sidebar-promote/style.scss";
+@import "components/footer-branding/style.scss";
 
 // Poll
 @import "blocks/poll/edit.scss";

--- a/assets/stylesheets/nps.scss
+++ b/assets/stylesheets/nps.scss
@@ -5,3 +5,4 @@
 // Components
 @import "components/dialog-wrapper/style.scss";
 @import "components/nps/style.scss";
+@import "components/footer-branding/style.scss";

--- a/assets/stylesheets/poll.scss
+++ b/assets/stylesheets/poll.scss
@@ -5,3 +5,4 @@
 // Components
 @import "components/poll/style.scss";
 @import "components/with-fallback-styles/style.scss";
+@import "components/footer-branding/style.scss";

--- a/client/blocks/nps/sidebar.js
+++ b/client/blocks/nps/sidebar.js
@@ -19,8 +19,14 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import SidebarPromote from 'components/sidebar-promote';
 
-const Sidebar = ( { attributes, setAttributes } ) => {
+const Sidebar = ( {
+	attributes,
+	setAttributes,
+	shouldPromote,
+	signalWarning,
+} ) => {
 	const handleChangeTitle = ( title ) => setAttributes( { title } );
 
 	const resultsUrl = `https://app.crowdsignal.com/surveys/${ attributes.surveyId }/report/overview`;
@@ -74,6 +80,9 @@ const Sidebar = ( { attributes, setAttributes } ) => {
 						attributes.title ?? attributes.ratingQuestion
 					) }
 				/>
+				{ shouldPromote && (
+					<SidebarPromote signalWarning={ signalWarning } />
+				) }
 			</PanelBody>
 			<PanelColorSettings
 				title={ __( 'Block styling', 'crowdsignal-forms' ) }

--- a/client/blocks/poll/edit.js
+++ b/client/blocks/poll/edit.js
@@ -41,7 +41,7 @@ import EditBar from './edit-bar';
 import ConnectToCrowdsignal from 'components/connect-to-crowdsignal';
 import PollIcon from 'components/icon/poll';
 import withPollBase from 'components/with-poll-base';
-import FooterBranding from 'components/poll/footer-branding';
+import FooterBranding from 'components/footer-branding';
 import { useAccountInfo } from 'data/hooks';
 import SignalWarning from 'components/signal-warning';
 

--- a/client/components/footer-branding/index.js
+++ b/client/components/footer-branding/index.js
@@ -21,19 +21,20 @@ const promoteLink = (
 	</span>
 );
 
-const FooterBranding = ( { showLogo, editing } ) => (
-	<div className="crowdsignal-forms-poll__footer-branding">
+const FooterBranding = ( { showLogo, editing, message } ) => (
+	<div className="crowdsignal-forms__footer-branding">
 		<div>
 			<a
-				className="crowdsignal-forms-poll__footer-cs-link"
+				className="crowdsignal-forms__footer-cs-link"
 				href="https://crowdsignal.com?ref=cs-forms-poll"
 				target="_blank"
 				rel="noopener noreferrer"
 			>
-				{ __(
-					'Create your own poll with Crowdsignal',
-					'crowdsignal-forms'
-				) }
+				{ message ||
+					__(
+						'Create your own poll with Crowdsignal',
+						'crowdsignal-forms'
+					) }
 			</a>
 			{ editing && (
 				<Tooltip text={ promoteLink } position="top center">
@@ -50,7 +51,7 @@ const FooterBranding = ( { showLogo, editing } ) => (
 		</div>
 		{ showLogo && (
 			<img
-				className="crowdsignal-forms-poll__footer-branding-logo"
+				className="crowdsignal-forms__footer-branding-logo"
 				src="https://app.crowdsignal.com/images/svg/cs-logo-dots.svg"
 				alt="Crowdsignal sticker"
 			/>

--- a/client/components/footer-branding/style.scss
+++ b/client/components/footer-branding/style.scss
@@ -1,0 +1,52 @@
+.crowdsignal-forms__footer-branding {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	width: 100%;
+	margin-top: 16px;
+
+	img.crowdsignal-forms__footer-branding-logo {
+		width: 50px;
+		height: 50px;
+		margin-left: 0;
+		margin-right: 0;
+	}
+
+	.crowdsignal-forms__branding-promote {
+		font-family: $font-sans-serif;
+		font-size: 10px;
+		text-decoration: none !important;
+		box-shadow: none;
+		border: 0;
+		background-color: #a4a4a4a4;
+		color: #fff;
+		cursor: pointer;
+		padding-right: 8px;
+		padding-left: 8px;
+		margin-left: 16px;
+		border-radius: 2px;
+		padding-top: 4px;
+		padding-bottom: 4px;
+		vertical-align: middle;
+	}
+}
+
+.crowdsignal-forms__footer-cs-link {
+	font-family: $font-sans-serif;
+	font-size: 16px;
+	text-decoration: none;
+	text-transform: uppercase;
+	vertical-align: middle;
+	border-bottom: 0 solid var(--crowdsignal-forms-text-color) !important;
+
+	&:not(:hover) {
+		color: var(--crowdsignal-forms-text-color);
+		opacity: 0.4;
+	}
+
+	.has-default-thankyou & {
+		// hardcoded as the background has been forced to white
+		// to match the video background
+		color: #333;
+	}
+}

--- a/client/components/nps/feedback.js
+++ b/client/components/nps/feedback.js
@@ -7,11 +7,13 @@ import React, { useState } from 'react';
  * WordPress dependencies
  */
 import { TextareaControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { updateNpsResponse } from 'data/nps';
+import FooterBranding from 'components/footer-branding';
 
 const NpsFeedback = ( { attributes, onFailure, onSubmit, responseMeta } ) => {
 	const [ feedback, setFeedback ] = useState( '' );
@@ -52,6 +54,14 @@ const NpsFeedback = ( { attributes, onFailure, onSubmit, responseMeta } ) => {
 			>
 				{ attributes.submitButtonLabel }
 			</button>
+			{ ! attributes.hideBranding && (
+				<FooterBranding
+					message={ __(
+						'Collect your own feedback with Crowdsignal',
+						'crowdsignal-forms'
+					) }
+				/>
+			) }
 		</div>
 	);
 };

--- a/client/components/nps/rating.js
+++ b/client/components/nps/rating.js
@@ -6,9 +6,15 @@ import classnames from 'classnames';
 import { pick, times } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { updateNpsResponse } from 'data/nps';
+import FooterBranding from 'components/footer-branding';
 
 const NpsRating = ( { attributes, onFailure, onSubmit } ) => {
 	const [ selected, setSelected ] = useState( -1 );
@@ -56,6 +62,14 @@ const NpsRating = ( { attributes, onFailure, onSubmit } ) => {
 					);
 				} ) }
 			</div>
+			{ ! attributes.hideBranding && (
+				<FooterBranding
+					message={ __(
+						'Collect your own feedback with Crowdsignal',
+						'crowdsignal-forms'
+					) }
+				/>
+			) }
 		</div>
 	);
 };

--- a/client/components/nps/style.scss
+++ b/client/components/nps/style.scss
@@ -38,6 +38,10 @@
 .crowdsignal-forms-nps__rating {
 	display: flex;
 	flex-direction: column;
+
+	.crowdsignal-forms__footer-branding {
+		padding-top: 16px;
+	}
 }
 
 .crowdsignal-forms-nps__rating-labels {
@@ -88,6 +92,10 @@
 .crowdsignal-forms-nps__feedback {
 	display: flex;
 	flex-direction: column;
+
+	.crowdsignal-forms__footer-branding {
+		padding-top: 16px;
+	}
 }
 
 .crowdsignal-forms-nps__feedback-text {

--- a/client/components/poll/results.js
+++ b/client/components/poll/results.js
@@ -12,7 +12,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
  */
 import { usePollResults } from 'data/hooks';
 import PollAnswerResults from './answer-results';
-import FooterBranding from './footer-branding';
+import FooterBranding from 'components/footer-branding';
 import { isAnswerEmpty } from './util';
 
 const PollResults = ( {

--- a/client/components/poll/style.scss
+++ b/client/components/poll/style.scss
@@ -449,59 +449,6 @@ div.crowdsignal-forms-poll__answer-label-wrapper {
 	}
 }
 
-.crowdsignal-forms-poll__footer-branding {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	width: 100%;
-	margin-top: 16px;
-
-	img.crowdsignal-forms-poll__footer-branding-logo {
-		width: 50px;
-		height: 50px;
-		margin-left: 0;
-		margin-right: 0;
-	}
-
-	.crowdsignal-forms__branding-promote {
-		font-family: $font-sans-serif;
-		font-size: 10px;
-		text-decoration: none !important;
-		box-shadow: none;
-		border: 0;
-		background-color: #a4a4a4a4;
-		color: #fff;
-		cursor: pointer;
-		padding-right: 8px;
-		padding-left: 8px;
-		margin-left: 16px;
-		border-radius: 2px;
-		padding-top: 4px;
-		padding-bottom: 4px;
-		vertical-align: middle;
-	}
-}
-
-.crowdsignal-forms-poll__footer-cs-link {
-	font-family: $font-sans-serif;
-	font-size: 16px;
-	text-decoration: none;
-	text-transform: uppercase;
-	vertical-align: middle;
-	border-bottom: 0 solid var(--crowdsignal-forms-text-color) !important;
-
-	&:not(:hover) {
-		color: var(--crowdsignal-forms-text-color);
-		opacity: 0.4;
-	}
-
-	.has-default-thankyou & {
-		// hardcoded as the background has been forced to white
-		// to match the video background
-		color: #333;
-	}
-}
-
 .crowdsignal-forms-poll__error-banner {
 	font-family: $font-sans-serif;
 	font-size: $font-size-gutenberg-system-default;

--- a/client/components/poll/submit-message.js
+++ b/client/components/poll/submit-message.js
@@ -11,7 +11,7 @@ import { ConfirmMessageType } from 'blocks/poll/constants';
 import CloseIcon from 'components/icon/close';
 import CheckCircleIcon from 'components/icon/check-circle';
 import ThankYouIcon from 'components/icon/thank-you';
-import FooterBranding from './footer-branding';
+import FooterBranding from 'components/footer-branding';
 
 const toggleAnimationPlayPause = ( event ) => {
 	const player = event.target;

--- a/client/components/poll/vote.js
+++ b/client/components/poll/vote.js
@@ -11,7 +11,7 @@ import classnames from 'classnames';
  */
 import { AnswerStyle, ButtonAlignment } from 'blocks/poll/constants';
 import PollAnswer from './answer';
-import FooterBranding from './footer-branding';
+import FooterBranding from 'components/footer-branding';
 
 const PollVote = ( {
 	answers,


### PR DESCRIPTION
This PR sets up branding for the NPS block:

  - Turns FooterBranding to a more independent component
  - Adds `message` option for the FooterBranding legend
  - Adds SignalWarning on both Sidebar and main block

### Screenshots
![image](https://user-images.githubusercontent.com/157240/107252077-c3648600-6a13-11eb-8e39-3f0716bd3981.png)
![image](https://user-images.githubusercontent.com/157240/107252146-d1b2a200-6a13-11eb-816d-a157b349f369.png)


## Test instructions
Checkout and `make client`.

Test with free user over and under signal limit to see SignalWarning.
Verify that SignalWarning is not shown when within limits
Test with Business plan to verify no warning/branding is shown on editor nor public
