### PR TITLE
Add status and scheduled disable

### DIFF
--- a/client/blocks/nps/attributes.js
+++ b/client/blocks/nps/attributes.js
@@ -4,6 +4,10 @@
 import { __ } from '@wordpress/i18n';
 
 /**
+ * Internal dependencies
+ */
+import { NpsStatus } from './constants';
+/**
  * Note: Any changes made to the attributes definition need to be duplicated in
  *       Crowdsignal_Forms\Frontend\Blocks\Crowdsignal_Forms_Nps_Block::attributes()
  *       inside includes/frontend/blocks/class-crowdsignal-forms-nps-block.php.
@@ -70,5 +74,13 @@ export default {
 	viewThreshold: {
 		type: 'string',
 		default: 3,
+	},
+	status: {
+		type: 'string',
+		default: NpsStatus.OPEN,
+	},
+	closedAfterDateTime: {
+		type: 'string',
+		default: null,
 	},
 };

--- a/client/blocks/nps/constants.js
+++ b/client/blocks/nps/constants.js
@@ -2,3 +2,9 @@ export const views = {
 	RATING: 'rating',
 	FEEDBACK: 'feedback',
 };
+
+export const NpsStatus = Object.freeze( {
+	OPEN: 'open',
+	CLOSED: 'closed',
+	CLOSED_AFTER: 'closed-after',
+} );

--- a/client/blocks/nps/sidebar.js
+++ b/client/blocks/nps/sidebar.js
@@ -129,15 +129,15 @@ const Sidebar = ( {
 					label={ __( 'Status', 'crowdsignal-forms' ) }
 					options={ [
 						{
-							label: __( 'Enabled', 'crowdsignal-forms' ),
+							label: __( 'Open', 'crowdsignal-forms' ),
 							value: NpsStatus.OPEN,
 						},
 						{
-							label: __( 'Disable after', 'crowdsignal-forms' ),
+							label: __( 'Closed after', 'crowdsignal-forms' ),
 							value: NpsStatus.CLOSED_AFTER,
 						},
 						{
-							label: __( 'Disabled', 'crowdsignal-forms' ),
+							label: __( 'Closed', 'crowdsignal-forms' ),
 							value: NpsStatus.CLOSED,
 						},
 					] }
@@ -147,7 +147,7 @@ const Sidebar = ( {
 						null !== attributes.closedAfterDateTime &&
 						new Date().toISOString() >
 							attributes.closedAfterDateTime
-							? 'Currently disabled as date has passed'
+							? 'Currently closed as date has passed'
 							: ''
 					}
 				/>
@@ -159,7 +159,7 @@ const Sidebar = ( {
 								new Date( attributes.closedAfterDateTime ) ) ||
 							new Date()
 						}
-						label={ __( 'Disable on', 'crowdsignal-forms' ) }
+						label={ __( 'Close on', 'crowdsignal-forms' ) }
 						onChange={ handleChangeCloseAfterDateTime }
 						is12Hour={ true }
 					/>

--- a/client/blocks/nps/sidebar.js
+++ b/client/blocks/nps/sidebar.js
@@ -10,7 +10,9 @@ import {
 	Button,
 	ExternalLink,
 	PanelBody,
+	SelectControl,
 	TextControl,
+	DateTimePicker,
 } from '@wordpress/components';
 import { InspectorControls, PanelColorSettings } from '@wordpress/block-editor';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -20,6 +22,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import SidebarPromote from 'components/sidebar-promote';
+import { NpsStatus } from './constants';
 
 const Sidebar = ( {
 	attributes,
@@ -35,6 +38,13 @@ const Sidebar = ( {
 		setAttributes( {
 			[ attribute ]: value,
 		} );
+
+	const handleChangeStatus = ( status ) => setAttributes( { status } );
+
+	const handleChangeCloseAfterDateTime = ( closedAfterDateTime ) => {
+		const dateTime = new Date( closedAfterDateTime );
+		setAttributes( { closedAfterDateTime: dateTime.toISOString() } );
+	};
 
 	return (
 		<InspectorControls>
@@ -110,6 +120,51 @@ const Sidebar = ( {
 					},
 				] }
 			/>
+			<PanelBody
+				title={ __( 'Settings', 'crowdsignal-forms' ) }
+				initialOpen={ false }
+			>
+				<SelectControl
+					value={ attributes.status }
+					label={ __( 'Status', 'crowdsignal-forms' ) }
+					options={ [
+						{
+							label: __( 'Enabled', 'crowdsignal-forms' ),
+							value: NpsStatus.OPEN,
+						},
+						{
+							label: __( 'Disable after', 'crowdsignal-forms' ),
+							value: NpsStatus.CLOSED_AFTER,
+						},
+						{
+							label: __( 'Disabled', 'crowdsignal-forms' ),
+							value: NpsStatus.CLOSED,
+						},
+					] }
+					onChange={ handleChangeStatus }
+					help={
+						NpsStatus.CLOSED_AFTER === attributes.status &&
+						null !== attributes.closedAfterDateTime &&
+						new Date().toISOString() >
+							attributes.closedAfterDateTime
+							? 'Currently disabled as date has passed'
+							: ''
+					}
+				/>
+
+				{ NpsStatus.CLOSED_AFTER === attributes.status && (
+					<DateTimePicker
+						currentDate={
+							( attributes.closedAfterDateTime &&
+								new Date( attributes.closedAfterDateTime ) ) ||
+							new Date()
+						}
+						label={ __( 'Disable on', 'crowdsignal-forms' ) }
+						onChange={ handleChangeCloseAfterDateTime }
+						is12Hour={ true }
+					/>
+				) }
+			</PanelBody>
 		</InspectorControls>
 	);
 };

--- a/client/nps.js
+++ b/client/nps.js
@@ -10,6 +10,7 @@ import { forEach } from 'lodash';
  */
 import DialogWrapper from 'components/dialog-wrapper';
 import NpsBlock from 'components/nps';
+import { NpsStatus } from 'blocks/nps/constants';
 
 const NPS_VIEWS_STORAGE_PREFIX = `cs-nps-views-`;
 
@@ -22,6 +23,18 @@ window.addEventListener( 'load', () =>
 				const viewThreshold = parseInt( attributes.viewThreshold, 10 );
 
 				element.removeAttribute( 'data-crowdsignal-nps' );
+
+				if ( NpsStatus.CLOSED === attributes.status ) {
+					return;
+				}
+
+				if (
+					NpsStatus.CLOSED_AFTER === attributes.status &&
+					null !== attributes.closedAfterDateTime &&
+					new Date().toISOString() > attributes.closedAfterDateTime
+				) {
+					return;
+				}
 
 				if ( ! attributes.isPreview ) {
 					const key = `${ NPS_VIEWS_STORAGE_PREFIX }${ attributes.surveyId }`;

--- a/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
@@ -168,6 +168,14 @@ class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 				'type'    => 'string',
 				'default' => 3,
 			),
+			'status'              => array(
+				'type'    => 'string',
+				'default' => 'open', // See: client/blocks/nps/constants.js.
+			),
+			'closedAfterDateTime' => array(
+				'type'    => 'string',
+				'default' => null,
+			),
 		);
 	}
 }


### PR DESCRIPTION
This PR introduces the option to enable/disable the NPS popup or schedule disabling it after a certain date.

![image](https://user-images.githubusercontent.com/157240/107441757-921faf00-6b14-11eb-916b-e35b18e55dce.png)
![image](https://user-images.githubusercontent.com/157240/107441783-9d72da80-6b14-11eb-9b08-6010d1e4b23f.png)
![image](https://user-images.githubusercontent.com/157240/107441813-ab286000-6b14-11eb-9481-dd0d130be02f.png)

## Test instructions
Checkout and `make client`.

### Enabled
  - DateTime Picker should not be visible
  - Previewing the draft should always popup the NPS survey

### Disabled
  - NPS survey should not popup, not even on draft preview

### Disable after (should it be "Disabled after"?)
  - DateTime Picker should be visible when selecting this option
  - If date is in the past, a small hint should appear below the dropdown: "Currently disabled as date has passed"
  - Previewing draft should popup the NPS survey until the date/time has passed, not after

