### PR TITLE
Add a submit view for the NPS block

### DIFF
--- a/client/blocks/nps/constants.js
+++ b/client/blocks/nps/constants.js
@@ -1,6 +1,7 @@
 export const views = {
 	RATING: 'rating',
 	FEEDBACK: 'feedback',
+	SUBMIT: 'submit',
 };
 
 export const NpsStatus = Object.freeze( {

--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -232,6 +232,7 @@ const EditNpsBlock = ( props ) => {
 								</div>
 							) ) }
 						</div>
+
 						{ ! hideBranding && (
 							<FooterBranding
 								editing={ true }
@@ -282,6 +283,7 @@ const EditNpsBlock = ( props ) => {
 							value={ attributes.submitButtonLabel }
 							allowedFormats={ [] }
 						/>
+
 						{ ! hideBranding && (
 							<FooterBranding
 								editing={ true }
@@ -294,6 +296,7 @@ const EditNpsBlock = ( props ) => {
 					</div>
 				</div>
 			) }
+
 			{ renderStyleProbe() }
 		</ConnectToCrowdsignal>
 	);

--- a/client/components/footer-branding/index.js
+++ b/client/components/footer-branding/index.js
@@ -23,32 +23,32 @@ const promoteLink = (
 
 const FooterBranding = ( { showLogo, editing, message } ) => (
 	<div className="crowdsignal-forms__footer-branding">
-		<div>
-			<a
-				className="crowdsignal-forms__footer-cs-link"
-				href="https://crowdsignal.com?ref=cs-forms-poll"
-				target="_blank"
-				rel="noopener noreferrer"
-			>
-				{ message ||
-					__(
-						'Create your own poll with Crowdsignal',
-						'crowdsignal-forms'
-					) }
-			</a>
-			{ editing && (
-				<Tooltip text={ promoteLink } position="top center">
-					<a
-						href="https://crowdsignal.com/pricing"
-						target="_blank"
-						rel="noopener noreferrer"
-						className="crowdsignal-forms__branding-promote"
-					>
-						{ __( 'Hide', 'crowdsignal-forms' ) }
-					</a>
-				</Tooltip>
-			) }
-		</div>
+		<a
+			className="crowdsignal-forms__footer-cs-link"
+			href="https://crowdsignal.com?ref=cs-forms-poll"
+			target="_blank"
+			rel="noopener noreferrer"
+		>
+			{ message ||
+				__(
+					'Create your own poll with Crowdsignal',
+					'crowdsignal-forms'
+				) }
+		</a>
+
+		{ editing && (
+			<Tooltip text={ promoteLink } position="top center">
+				<a
+					href="https://crowdsignal.com/pricing"
+					target="_blank"
+					rel="noopener noreferrer"
+					className="crowdsignal-forms__branding-promote"
+				>
+					{ __( 'Hide', 'crowdsignal-forms' ) }
+				</a>
+			</Tooltip>
+		) }
+
 		{ showLogo && (
 			<img
 				className="crowdsignal-forms__footer-branding-logo"

--- a/client/components/footer-branding/style.scss
+++ b/client/components/footer-branding/style.scss
@@ -1,18 +1,18 @@
 .crowdsignal-forms__footer-branding {
+	align-items: flex-end;
 	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	width: 100%;
 	margin-top: 16px;
+	width: 100%;
 
 	img.crowdsignal-forms__footer-branding-logo {
-		width: 50px;
 		height: 50px;
-		margin-left: 0;
+		margin-left: auto;
 		margin-right: 0;
+		width: 50px;
 	}
 
 	.crowdsignal-forms__branding-promote {
+		display: inline-flex;
 		font-family: $font-sans-serif;
 		font-size: 10px;
 		text-decoration: none !important;
@@ -25,15 +25,17 @@
 		padding-left: 8px;
 		margin-left: 16px;
 		border-radius: 2px;
-		padding-top: 4px;
-		padding-bottom: 4px;
+		padding-top: 2px;
+		padding-bottom: 2px;
 		vertical-align: middle;
 	}
 }
 
 .crowdsignal-forms__footer-cs-link {
+	display: inline-flex;
 	font-family: $font-sans-serif;
 	font-size: 16px;
+	line-height: 18px;
 	text-decoration: none;
 	text-transform: uppercase;
 	vertical-align: middle;

--- a/client/components/nps/feedback.js
+++ b/client/components/nps/feedback.js
@@ -7,13 +7,11 @@ import React, { useState } from 'react';
  * WordPress dependencies
  */
 import { TextareaControl } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { updateNpsResponse } from 'data/nps';
-import FooterBranding from 'components/footer-branding';
 
 const NpsFeedback = ( { attributes, onFailure, onSubmit, responseMeta } ) => {
 	const [ feedback, setFeedback ] = useState( '' );
@@ -54,14 +52,6 @@ const NpsFeedback = ( { attributes, onFailure, onSubmit, responseMeta } ) => {
 			>
 				{ attributes.submitButtonLabel }
 			</button>
-			{ ! attributes.hideBranding && (
-				<FooterBranding
-					message={ __(
-						'Collect your own feedback with Crowdsignal',
-						'crowdsignal-forms'
-					) }
-				/>
-			) }
 		</div>
 	);
 };

--- a/client/components/nps/index.js
+++ b/client/components/nps/index.js
@@ -35,14 +35,16 @@ const Nps = ( {
 		setView( views.FEEDBACK );
 	};
 
-	const handleFeedbackSubmit = () =>
-		setView( views.SUBMIT );
+	const handleFeedbackSubmit = () => setView( views.SUBMIT );
 
 	const questionText = get(
 		{
 			[ views.FEEDBACK ]: attributes.feedbackQuestion,
 			[ views.RATING ]: attributes.ratingQuestion,
-			[ views.SUBMIT ]: __( 'Thanks so much for your feedback!', 'crowdsignal-forms' ),
+			[ views.SUBMIT ]: __(
+				'Thanks so much for your feedback!',
+				'crowdsignal-forms'
+			),
 		},
 		[ view ]
 	);

--- a/client/components/nps/index.js
+++ b/client/components/nps/index.js
@@ -2,24 +2,23 @@
  * External dependencies
  */
 import React, { useState } from 'react';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { views } from 'blocks/nps/constants';
 import { getStyleVars } from 'blocks/nps/util';
+import FooterBranding from 'components/footer-branding';
 import { withFallbackStyles } from 'components/with-fallback-styles';
 import NpsFeedback from './feedback';
 import NpsRating from './rating';
-
-const views = {
-	RATING: 'rating',
-	FEEDBACK: 'feedback',
-};
 
 const Nps = ( {
 	attributes,
@@ -36,10 +35,17 @@ const Nps = ( {
 		setView( views.FEEDBACK );
 	};
 
-	const questionText =
-		view === views.RATING
-			? attributes.ratingQuestion
-			: attributes.feedbackQuestion;
+	const handleFeedbackSubmit = () =>
+		setView( views.SUBMIT );
+
+	const questionText = get(
+		{
+			[ views.FEEDBACK ]: attributes.feedbackQuestion,
+			[ views.RATING ]: attributes.ratingQuestion,
+			[ views.SUBMIT ]: __( 'Thanks so much for your feedback!', 'crowdsignal-forms' ),
+		},
+		[ view ]
+	);
 
 	const style = {
 		width: `${ contentWidth }px`,
@@ -73,7 +79,17 @@ const Nps = ( {
 						attributes={ attributes }
 						responseMeta={ responseMeta }
 						onFailure={ onClose }
-						onSubmit={ onClose }
+						onSubmit={ handleFeedbackSubmit }
+					/>
+				) }
+
+				{ ! attributes.hideBranding && (
+					<FooterBranding
+						showLogo={ view === views.SUBMIT }
+						message={ __(
+							'Collect your own feedback with Crowdsignal',
+							'crowdsignal-forms'
+						) }
 					/>
 				) }
 			</div>

--- a/client/components/nps/rating.js
+++ b/client/components/nps/rating.js
@@ -6,15 +6,9 @@ import classnames from 'classnames';
 import { pick, times } from 'lodash';
 
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import { updateNpsResponse } from 'data/nps';
-import FooterBranding from 'components/footer-branding';
 
 const NpsRating = ( { attributes, onFailure, onSubmit } ) => {
 	const [ selected, setSelected ] = useState( -1 );
@@ -62,14 +56,6 @@ const NpsRating = ( { attributes, onFailure, onSubmit } ) => {
 					);
 				} ) }
 			</div>
-			{ ! attributes.hideBranding && (
-				<FooterBranding
-					message={ __(
-						'Collect your own feedback with Crowdsignal',
-						'crowdsignal-forms'
-					) }
-				/>
-			) }
 		</div>
 	);
 };

--- a/client/components/nps/style.scss
+++ b/client/components/nps/style.scss
@@ -6,8 +6,12 @@
 	background-color: var(--crowdsignal-forms-background-color);
 	color: var(--crowdsignal-forms-text-color);
 	height: auto;
-	padding: 32px;
+	padding: 32px 32px 24px 32px;
 	position: relative;
+
+	.crowdsignal-forms__footer-branding {
+		margin-top: 40px;
+	}
 }
 
 .crowdsignal-forms-nps__close-button {
@@ -38,10 +42,6 @@
 .crowdsignal-forms-nps__rating {
 	display: flex;
 	flex-direction: column;
-
-	.crowdsignal-forms__footer-branding {
-		padding-top: 16px;
-	}
 }
 
 .crowdsignal-forms-nps__rating-labels {
@@ -92,10 +92,6 @@
 .crowdsignal-forms-nps__feedback {
 	display: flex;
 	flex-direction: column;
-
-	.crowdsignal-forms__footer-branding {
-		padding-top: 16px;
-	}
 }
 
 .crowdsignal-forms-nps__feedback-text {


### PR DESCRIPTION
This patch adds the submit view for the block along with the branding (which was previously only present in the editor).

![Screen Shot 2021-02-15 at 4 44 11 PM](https://user-images.githubusercontent.com/8056203/107967139-0b078680-6fad-11eb-8643-4ae73e23a470.png)

The view is shown after the user submits their feedback, unless the request failed in which case the dialog will just close.

# Testing

Create a new block and proceed to submitting a rating and feedback. You should see the new 'submit view' instead of the dialog disappearing.