### PR TITLE
Tweak NPS block styles

### DIFF
--- a/client/blocks/nps/util.js
+++ b/client/blocks/nps/util.js
@@ -11,6 +11,7 @@ export const getStyleVars = ( attributes, fallbackStyles ) =>
 			buttonTextColor:
 				attributes.buttonTextColor || fallbackStyles.textColorInverted,
 			textColor: attributes.textColor || fallbackStyles.textColor,
+			textSize: fallbackStyles.textSize,
 		},
 		( _, key ) => `--crowdsignal-forms-${ kebabCase( key ) }`
 	);

--- a/client/components/nps/feedback.js
+++ b/client/components/nps/feedback.js
@@ -44,14 +44,25 @@ const NpsFeedback = ( { attributes, onFailure, onSubmit, responseMeta } ) => {
 				value={ feedback }
 			/>
 
-			<button
-				className="wp-block-button__link crowdsignal-forms-nps__feedback-button"
-				disabled={ submitting }
-				onClick={ handleSubmit }
-				type="button"
-			>
-				{ attributes.submitButtonLabel }
-			</button>
+			<div className="wp-block-button crowdsignal-forms-nps__feedback-button-wrapper">
+				<button
+					className="wp-block-button__link crowdsignal-forms-nps__feedback-button"
+					disabled={ submitting }
+					onClick={ handleSubmit }
+					type="button"
+				>
+					{ attributes.submitButtonLabel }
+				</button>
+			</div>
+
+			{ ! attributes.hideBranding && (
+				<FooterBranding
+					message={ __(
+						'Collect your own feedback with Crowdsignal',
+						'crowdsignal-forms'
+					) }
+				/>
+			) }
 		</div>
 	);
 };

--- a/client/components/nps/feedback.js
+++ b/client/components/nps/feedback.js
@@ -54,15 +54,6 @@ const NpsFeedback = ( { attributes, onFailure, onSubmit, responseMeta } ) => {
 					{ attributes.submitButtonLabel }
 				</button>
 			</div>
-
-			{ ! attributes.hideBranding && (
-				<FooterBranding
-					message={ __(
-						'Collect your own feedback with Crowdsignal',
-						'crowdsignal-forms'
-					) }
-				/>
-			) }
 		</div>
 	);
 };

--- a/client/components/nps/style.scss
+++ b/client/components/nps/style.scss
@@ -6,8 +6,12 @@
 	background-color: var(--crowdsignal-forms-background-color);
 	color: var(--crowdsignal-forms-text-color);
 	height: auto;
-	padding: 32px 32px 24px 32px;
+	padding: 24px 16px;
 	position: relative;
+
+	@media screen and (min-width: 670px) {
+		padding: 32px 32px 24px 32px;
+	}
 
 	.crowdsignal-forms__footer-branding {
 		margin-top: 40px;
@@ -17,6 +21,7 @@
 .crowdsignal-forms-nps__close-button {
 	align-items: center;
 	background-color: var(--crowdsignal-forms-button-color);
+	border: 0;
 	border-radius: 20px;
 	color: var(--crowdsignal-forms-button-text-color);
 	display: flex;
@@ -26,7 +31,7 @@
 	padding: 0;
 	position: absolute;
 	right: -20px;
-	top: -20px;
+	top: -25px;
 	width: 40px;
 
 	&:hover {
@@ -47,7 +52,10 @@
 .crowdsignal-forms-nps__rating-labels {
 	display: flex;
 	flex-direction: row;
+	font-family: $font-sans-serif;
+	font-size: 14px;
 	justify-content: space-between;
+	margin-top: 8px;
 }
 
 .crowdsignal-forms-nps__rating-scale {
@@ -63,12 +71,13 @@
 	cursor: pointer;
 	display: inline-flex;
 	flex: 1;
+	font-family: $font-sans-serif;
 	font-size: 15px;
 	font-weight: 600;
 	height: 50px;
 	justify-content: center;
 	line-height: 50px;
-	margin: 0 0 0 0.7em;
+	margin: 0 0 0 0.4em;
 	padding: 0;
 	text-align: center;
 	transition: background-color 0.2s, color 0.2s;
@@ -79,13 +88,16 @@
 
 	&:hover:enabled {
 		background-color: var(--crowdsignal-forms-button-text-color);
-		border-color: var(--crowdsignal-forms-button-text-color);
 		color: var(--crowdsignal-forms-button-color);
 	}
 
 	&:disabled:not(.is-active) {
 		background-color: transparent;
 		color: var(--crowdsignal-forms-button-color);
+	}
+
+	@media screen and (min-width: 670px) {
+		margin: 0 0 0 0.7em;
 	}
 }
 
@@ -95,12 +107,17 @@
 }
 
 .crowdsignal-forms-nps__feedback-text {
+	font-size: 15px;
+	margin-top: 16px;
 	margin-bottom: 25px;
 	width: 100%;
 }
 
-.crowdsignal-forms-nps__feedback-button {
+.crowdsignal-forms-nps__feedback-button-wrapper {
 	align-self: flex-end;
+}
+
+.crowdsignal-forms-nps__feedback-button {
 	background-color: var(--crowdsignal-forms-button-color) !important;
 	color: var(--crowdsignal-forms-button-text-color) !important;
 

--- a/client/components/nps/style.scss
+++ b/client/components/nps/style.scss
@@ -42,6 +42,7 @@
 
 .crowdsignal-forms-nps__question {
 	margin-top: 0 !important;
+	margin-bottom: 32px !important;
 }
 
 .crowdsignal-forms-nps__rating {
@@ -80,6 +81,7 @@
 	margin: 0 0 0 0.4em;
 	padding: 0;
 	text-align: center;
+	text-decoration: none;
 	transition: background-color 0.2s, color 0.2s;
 
 	&:first-child {
@@ -107,10 +109,13 @@
 }
 
 .crowdsignal-forms-nps__feedback-text {
-	font-size: 15px;
 	margin-top: 16px;
 	margin-bottom: 25px;
 	width: 100%;
+
+	textarea {
+		font-size: var(--crowdsignal-forms-text-size);
+	}
 }
 
 .crowdsignal-forms-nps__feedback-button-wrapper {
@@ -118,8 +123,10 @@
 }
 
 .crowdsignal-forms-nps__feedback-button {
+	align-self: flex-end;
 	background-color: var(--crowdsignal-forms-button-color) !important;
 	color: var(--crowdsignal-forms-button-text-color) !important;
+	text-decoration: none;
 
 	&:hover {
 		background-color: var(--crowdsignal-forms-button-text-color) !important;

--- a/client/components/nps/style.scss
+++ b/client/components/nps/style.scss
@@ -91,6 +91,7 @@
 	&:hover:enabled {
 		background-color: var(--crowdsignal-forms-button-text-color);
 		color: var(--crowdsignal-forms-button-color);
+		text-decoration: none;
 	}
 
 	&:disabled:not(.is-active) {
@@ -131,5 +132,6 @@
 	&:hover {
 		background-color: var(--crowdsignal-forms-button-text-color) !important;
 		color: var(--crowdsignal-forms-button-color) !important;
+		text-decoration: none;
 	}
 }

--- a/client/components/with-fallback-styles/index.js
+++ b/client/components/with-fallback-styles/index.js
@@ -53,6 +53,7 @@ const getStyles = ( node ) => {
 		textColor,
 		textColorInverted: window.getComputedStyle( buttonNode ).color,
 		textFont: window.getComputedStyle( textNode ).fontFamily,
+		textSize: window.getComputedStyle( textNode ).fontSize,
 		headingFont: window.getComputedStyle( h3Node ).fontFamily,
 		contentWideWidth: window.getComputedStyle( wideContentNode ).maxWidth,
 	};


### PR DESCRIPTION
This block addresses some of the remaining styling issues with the NPS block:

- Updated the rating scale labels to use system fonts instead of themes'
- Improved the inconsistency issue with the submit button on the feedback view between the editor and the page
- Adjusted paddings/margins and rating buttons for mobile view (<670px)
- Increased the font size for the feedback textarea
- Added a fixed `margin-top` for the feedback textarea

# Testing

Just stylistic changes. Run the build and verify that things look as expected :)