### PR TITLE
PoC: Use native fetch for WPCOM

### DIFF
--- a/client/data/nps/index.js
+++ b/client/data/nps/index.js
@@ -21,8 +21,32 @@ export const updateNps = ( data ) =>
 		} )
 	);
 
-export const updateNpsResponse = ( surveyId, data ) =>
-	withRequestTimeout(
+export const updateNpsResponse = ( surveyId, data ) => {
+	console.log( window.csFormsSetup );
+	if ( window.csFormsSetup || window.csFormsSetup._isWpcom ) {
+		return window
+			.fetch(
+				'https://public-api.wordpress.com/crowdsignal-forms/v1/sites/' +
+					window.csFormsSetup._currentSiteId +
+					'/nps/' +
+					surveyId +
+					'/response?_locale=user',
+				{
+					headers: {
+						accept: 'application/json, */*;q=0.1',
+						'content-type': 'application/json',
+						'x-wp-nonce': window.csFormsSetup._nonce,
+					},
+					referrer: window.csFormsSetup._siteUrl,
+					referrerPolicy: 'strict-origin-when-cross-origin',
+					body: JSON.stringify( data ),
+					method: 'POST',
+					mode: 'cors',
+				}
+			)
+			.then( ( response ) => response.json() );
+	}
+	return withRequestTimeout(
 		apiFetch( {
 			path: trimEnd(
 				`/crowdsignal-forms/v1/nps/${ surveyId || '' }/response`
@@ -31,3 +55,19 @@ export const updateNpsResponse = ( surveyId, data ) =>
 			data,
 		} )
 	);
+	// return window.fetch(
+	// 	'https://public-api.wordpress.com/crowdsignal-forms/v1/sites/155526329/nps/2601743/response?_locale=user',
+	// 	{
+	// 		headers: {
+	// 			accept: 'application/json, */*;q=0.1',
+	// 			'content-type': 'application/json',
+	// 			'x-wp-nonce': '8313ac1ea1',
+	// 		},
+	// 		referrer: 'https://dasprofilen.wordpress.com/',
+	// 		referrerPolicy: 'strict-origin-when-cross-origin',
+	// 		body: '{"nonce":"39de0f40f6","score":9}',
+	// 		method: 'POST',
+	// 		mode: 'cors',
+	// 	}
+	// );
+};

--- a/client/data/nps/index.js
+++ b/client/data/nps/index.js
@@ -55,19 +55,3 @@ export const updateNpsResponse = ( surveyId, data ) => {
 			data,
 		} )
 	);
-	// return window.fetch(
-	// 	'https://public-api.wordpress.com/crowdsignal-forms/v1/sites/155526329/nps/2601743/response?_locale=user',
-	// 	{
-	// 		headers: {
-	// 			accept: 'application/json, */*;q=0.1',
-	// 			'content-type': 'application/json',
-	// 			'x-wp-nonce': '8313ac1ea1',
-	// 		},
-	// 		referrer: 'https://dasprofilen.wordpress.com/',
-	// 		referrerPolicy: 'strict-origin-when-cross-origin',
-	// 		body: '{"nonce":"39de0f40f6","score":9}',
-	// 		method: 'POST',
-	// 		mode: 'cors',
-	// 	}
-	// );
-};

--- a/includes/rest-api/controllers/class-nps-controller.php
+++ b/includes/rest-api/controllers/class-nps-controller.php
@@ -76,6 +76,18 @@ class Nps_Controller {
 				),
 			)
 		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<survey_id>\d+)/nonce',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'create_nonce' ),
+					'permission_callback' => array( $this, 'create_or_update_nps_response_permissions_check' ),
+					'args'                => $this->get_nps_fetch_params(),
+				),
+			)
+		);
 	}
 
 	/**
@@ -138,6 +150,16 @@ class Nps_Controller {
 		$result['checksum'] = $this->get_response_checksum( $result['r'], $data['nonce'] );
 
 		return rest_ensure_response( $result );
+	}
+
+	/**
+	 * Desperate attempt to make this work
+	 *
+	 * @param  \WP_REST_Request $request The API Request.
+	 * @return \WP_REST_Response|WP_ERROR\
+	 */
+	public function create_nonce( $request ) {
+		return rest_ensure_response( array( 'nonce' => wp_create_nonce( 'crowdsignal-forms-nps__submit' ) ) );
 	}
 
 	/**


### PR DESCRIPTION
Still a PoC. Works against D57291-code 

This PR implements a native fetch call to request the API. 

It adds a new endpoint `/nonce` on the NPS controller to be available for a preflight request. The fetch does the roundtrip and then makes the actual request with the newly acquired nonce.

The fetch mechanism is here for testing purposes while we do a call for testing. The mechanism should become a separate module to be used externally.

## Test instructions
Apply D57291-code and used a sandboxed site.

Checkout this PR and run `make client`.

Add an NPS block to a post, then visit it to check functionality. Then open the post with an incognito window and check functionality again.

Both times the requests should make it through and be viewable on the results page of the NPS