### PR TITLE
Add credential-less nonce create/verify mechanism

### DIFF
--- a/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
@@ -80,7 +80,13 @@ class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 
 		$attributes['hideBranding'] = $this->should_hide_branding();
 		$attributes['isPreview']    = is_preview();
-		$attributes['nonce']        = wp_create_nonce( self::NONCE );
+
+		// store the logged in user ID.
+		$actual_user_id = wp_get_current_user()->ID;
+		// temporarily set user ID to 0 so we create a consistent nonce.
+		wp_set_current_user( 0 );
+		$attributes['nonce'] = wp_create_nonce( self::NONCE );
+		wp_set_current_user( $actual_user_id );
 
 		return sprintf(
 			'<div class="crowdsignal-nps-wrapper" data-crowdsignal-nps="%s"></div>',

--- a/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
@@ -184,12 +184,31 @@ class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 	 * The nonce creation is first attempted through crowdsignal_forms_nps_nonce filter.
 	 *
 	 * @since [next-version-number]
+	 * @return string
 	 */
 	private function create_nonce() {
 		$nonce = apply_filters( 'crowdsignal_forms_nps_nonce', self::NONCE );
-		if ( empty( $nonce ) ) {
+
+		if ( self::NONCE === $nonce ) { // returned unfiltered.
 			$nonce = wp_create_nonce( self::NONCE );
 		}
 		return $nonce;
+	}
+
+	/**
+	 * Verifies a nonce based on the NONCE.
+	 * The nonce creation is first attempted through crowdsignal_forms_nps_nonce filter.
+	 *
+	 * @since [next-version-number]
+	 * @param string $nonce
+	 * @return bool
+	 */
+	public static function verify_nonce( $nonce ) {
+		$verifies = apply_filters( 'crowdsignal_forms_nps_nonce_check', $nonce, self::NONCE );
+
+		if ( $verifies === $nonce ) { // returned unfiltered.
+			$verifies = wp_verify_nonce( $nonce, self::NONCE );
+		}
+		return $verifies;
 	}
 }

--- a/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
@@ -80,13 +80,7 @@ class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 
 		$attributes['hideBranding'] = $this->should_hide_branding();
 		$attributes['isPreview']    = is_preview();
-
-		// store the logged in user ID.
-		$actual_user_id = wp_get_current_user()->ID;
-		// temporarily set user ID to 0 so we create a consistent nonce.
-		wp_set_current_user( 0 );
-		$attributes['nonce'] = wp_create_nonce( self::NONCE );
-		wp_set_current_user( $actual_user_id );
+		$attributes['nonce']        = $this->create_nonce();
 
 		return sprintf(
 			'<div class="crowdsignal-nps-wrapper" data-crowdsignal-nps="%s"></div>',
@@ -183,5 +177,19 @@ class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 				'default' => null,
 			),
 		);
+	}
+
+	/**
+	 * Returns a nonce based on the NONCE.
+	 * The nonce creation is first attempted through crowdsignal_forms_nps_nonce filter.
+	 *
+	 * @since [next-version-number]
+	 */
+	private function create_nonce() {
+		$nonce = apply_filters( 'crowdsignal_forms_nps_nonce', self::NONCE );
+		if ( empty( $nonce ) ) {
+			$nonce = wp_create_nonce( self::NONCE );
+		}
+		return $nonce;
 	}
 }

--- a/includes/rest-api/controllers/class-nps-controller.php
+++ b/includes/rest-api/controllers/class-nps-controller.php
@@ -117,13 +117,7 @@ class Nps_Controller {
 		$data      = $request->get_json_params();
 		$survey_id = $request->get_param( 'survey_id' );
 
-		// store the logged in user ID.
-		$actual_user_id = wp_get_current_user()->ID;
-
-		// temporarily set user ID to 0 so we create a consistent nonce.
-		wp_set_current_user( 0 );
 		$verifies = wp_verify_nonce( $data['nonce'], Crowdsignal_Forms_Nps_Block::NONCE );
-		wp_set_current_user( $actual_user_id );
 
 		if (
 			! $verifies ||

--- a/includes/rest-api/controllers/class-nps-controller.php
+++ b/includes/rest-api/controllers/class-nps-controller.php
@@ -117,7 +117,7 @@ class Nps_Controller {
 		$data      = $request->get_json_params();
 		$survey_id = $request->get_param( 'survey_id' );
 
-		$verifies = wp_verify_nonce( $data['nonce'], Crowdsignal_Forms_Nps_Block::NONCE );
+		$verifies = Crowdsignal_Forms_Nps_Block::verify_nonce( $data['nonce'] );
 
 		if (
 			! $verifies ||

--- a/includes/rest-api/controllers/class-nps-controller.php
+++ b/includes/rest-api/controllers/class-nps-controller.php
@@ -10,6 +10,7 @@ namespace Crowdsignal_Forms\Rest_Api\Controllers;
 
 use Crowdsignal_Forms\Crowdsignal_Forms;
 use Crowdsignal_Forms\Models\Nps_Survey;
+use Crowdsignal_Forms\Frontend\Blocks\Crowdsignal_Forms_Nps_Block;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	die;
@@ -116,8 +117,16 @@ class Nps_Controller {
 		$data      = $request->get_json_params();
 		$survey_id = $request->get_param( 'survey_id' );
 
+		// store the logged in user ID.
+		$actual_user_id = wp_get_current_user()->ID;
+
+		// temporarily set user ID to 0 so we create a consistent nonce.
+		wp_set_current_user( 0 );
+		$verifies = wp_verify_nonce( $data['nonce'], Crowdsignal_Forms_Nps_Block::NONCE );
+		wp_set_current_user( $actual_user_id );
+
 		if (
-			! wp_verify_nonce( $data['nonce'], 'crowdsignal-forms-nps__submit' ) ||
+			! $verifies ||
 			(
 				$data['r'] &&
 				$data['checksum'] !== $this->get_response_checksum( $data['r'], $data['nonce'] )


### PR DESCRIPTION
This PR makes the nonce be created without any user session data. This allows for consistent nonce validation which can't be done between the render request and the REST API request.

## Test instructions
Checkout and `make client`. Visit a post with an NPS block and submit both rating and feedback. You shouldn't get a 403/500 response.