### PR TITLE
Finetune NPS editor

### DIFF
--- a/client/blocks/nps/attributes.js
+++ b/client/blocks/nps/attributes.js
@@ -73,7 +73,7 @@ export default {
 	},
 	viewThreshold: {
 		type: 'string',
-		default: 3,
+		default: 2,
 	},
 	status: {
 		type: 'string',

--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -163,13 +163,23 @@ const EditNpsBlock = ( props ) => {
 				<EditorNotice
 					isDismissible={ false }
 					icon="visibility"
-					actions={ [
-						{
-							label: __( 'Preview', 'crowdsignal-forms' ),
-							onClick: () =>
-								window.open( postPreviewLink, 'blank' ),
-						},
-					] }
+					actions={
+						attributes.surveyId
+							? [
+									{
+										label: __(
+											'Preview',
+											'crowdsignal-forms'
+										),
+										onClick: () =>
+											window.open(
+												postPreviewLink,
+												'blank'
+											),
+									},
+							  ]
+							: []
+					}
 				>
 					{ sprintf(
 						// translators: %d: number of pageviews

--- a/client/blocks/nps/edit.scss
+++ b/client/blocks/nps/edit.scss
@@ -12,6 +12,25 @@
 
 .crowdsignal-forms-nps__toolbar-popover {
 	padding: 15px;
+	min-width: 280px;
+
+	.components-base-control__field {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		margin-bottom: 0;
+	}
+
+	.components-base-control__label {
+		display: block;
+		flex-grow: 1;
+		line-height: 30px;
+		margin-bottom: 0;
+	}
+
+	.components-text-control__input {
+		width: 5em;
+	}
 }
 
 .crowdsignal-forms-nps__toolbar-popover-button svg {

--- a/client/blocks/nps/toolbar.js
+++ b/client/blocks/nps/toolbar.js
@@ -76,6 +76,7 @@ const PollToolbar = ( {
 									value={ attributes.viewThreshold }
 									onChange={ handleChangeViewThreshold }
 									type="number"
+									min="1"
 								/>
 							</div>
 						</Popover>


### PR DESCRIPTION
This PR addresses little issues within the NPS editor:

  - Threshold input accommodates for 3 digits (5em)
  - Threshold popup width enlarged to make it a one-liner
  - Threshold default value is 2
  - Preview button should only show once the NPS is saved (on platform backend)

## Test instructions
Checkout and `make client`.

Confirm the mentioned behaviors above. Visit the page and confirm that (without modification) the popup shows on the second visit.