### PR TITLE
Fix button styles

### DIFF
--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -282,14 +282,16 @@ const EditNpsBlock = ( props ) => {
 							value={ attributes.feedbackPlaceholder }
 						/>
 
-						<RichText
-							className="wp-block-button__link crowdsignal-forms-nps__feedback-button"
-							onChange={ handleChangeAttribute(
-								'submitButtonLabel'
-							) }
-							value={ attributes.submitButtonLabel }
-							allowedFormats={ [] }
-						/>
+						<div className="wp-block-button crowdsignal-forms-nps__feedback-button-wrapper">
+							<RichText
+								className="wp-block-button__link crowdsignal-forms-nps__feedback-button"
+								onChange={ handleChangeAttribute(
+									'submitButtonLabel'
+								) }
+								value={ attributes.submitButtonLabel }
+								allowedFormats={ [] }
+							/>
+						</div>
 
 						{ ! hideBranding && (
 							<FooterBranding

--- a/client/blocks/nps/edit.scss
+++ b/client/blocks/nps/edit.scss
@@ -20,6 +20,6 @@
 
 .crowdsignal-forms-nps__rating-button:hover {
 	background-color: var(--crowdsignal-forms-button-text-color);
-	border-color: var(--crowdsignal-forms-button-text-color);
+	border-color: var(--crowdsignal-forms-button-color);
 	color: var(--crowdsignal-forms-button-color);
 }

--- a/client/components/nps/style.scss
+++ b/client/components/nps/style.scss
@@ -68,6 +68,7 @@
 .crowdsignal-forms-nps__rating-button {
 	background-color: var(--crowdsignal-forms-button-color);
 	border: 1px solid var(--crowdsignal-forms-button-color);
+	border-radius: 2px;
 	color: var(--crowdsignal-forms-button-text-color);
 	cursor: pointer;
 	display: inline-flex;
@@ -126,6 +127,7 @@
 .crowdsignal-forms-nps__feedback-button {
 	align-self: flex-end;
 	background-color: var(--crowdsignal-forms-button-color) !important;
+	border: 1px solid var(--crowdsignal-forms-button-color);
 	color: var(--crowdsignal-forms-button-text-color) !important;
 	text-decoration: none;
 


### PR DESCRIPTION
This patch addresses some styling issues with the buttons on the NPS block:

- The buttons should have a border on hover in the editor
- The buttons should have a fixed border radius of `2px`
- The feedback submit button should now be styled correctly on both the page and in the editor regardless of the style

![Screen Shot 2021-02-23 at 4 53 20 PM](https://user-images.githubusercontent.com/8056203/108869652-af19af00-75f7-11eb-8eca-fa9833b2b896.png)
![Screen Shot 2021-02-23 at 4 53 29 PM](https://user-images.githubusercontent.com/8056203/108869663-b0e37280-75f7-11eb-9b5f-a091f7983b35.png)


# Testing

Twenty-nighteen seemed especially problematic with these points so it's a good place to start when looking it over.