### PR TITLE
Remove console debugging message

### DIFF
--- a/client/components/with-poll-base/index.js
+++ b/client/components/with-poll-base/index.js
@@ -21,7 +21,7 @@ import usePollDuplicateCleaner from 'components/use-poll-duplicate-cleaner';
 
 startSubscriptions();
 
-const isP2tenberg = () => 'p2tenberg' in window;
+const isP2tenberg = () => 'p2tenberg' in window || 'p2editor' in window;
 
 const withPollBase = ( Element ) => {
 	return ( props ) => {

--- a/client/nps.js
+++ b/client/nps.js
@@ -44,12 +44,6 @@ window.addEventListener( 'load', () =>
 
 					window.localStorage.setItem( key, viewCount );
 
-					// eslint-disable-next-line no-console
-					console.log(
-						`NPS block: Current view count: ${ viewCount }. Threshold: ${ viewThreshold }.` +
-							`Use "localStorage.setItem( '${ key }', 0 );" to reset the counter.`
-					);
-
 					if ( viewCount !== viewThreshold ) {
 						return;
 					}


### PR DESCRIPTION
This PR removes the console message used for debugging.

Also addresses #27 by searching for either `p2tenberg` or `p2editor` on `window` object.

Closes #27 