### PR TITLE
Fix an issue with threshold icon margin in the toolbar

### DIFF
--- a/client/blocks/nps/edit.scss
+++ b/client/blocks/nps/edit.scss
@@ -39,7 +39,7 @@
 	}
 
 	&.components-button.has-icon .dashicon {
-		margin-right: 0;
+		margin-right: 2px;
 	}
 }
 

--- a/client/blocks/nps/edit.scss
+++ b/client/blocks/nps/edit.scss
@@ -34,6 +34,7 @@
 }
 
 .crowdsignal-forms-nps__toolbar-popover-button {
+
 	svg {
 		margin-right: 0 !important;
 	}

--- a/client/blocks/nps/edit.scss
+++ b/client/blocks/nps/edit.scss
@@ -33,8 +33,14 @@
 	}
 }
 
-.crowdsignal-forms-nps__toolbar-popover-button svg {
-	margin-right: 0 !important;
+.crowdsignal-forms-nps__toolbar-popover-button {
+	svg {
+		margin-right: 0 !important;
+	}
+
+	&.components-button.has-icon .dashicon {
+		margin-right: 0;
+	}
 }
 
 .crowdsignal-forms-nps__rating-button:hover {


### PR DESCRIPTION
This fixes an issue with the icon margin styles for the toolbar icon for setting the NPS threshold.
The unwanted margin is caused by the popover adding another `<span>` next to the icon.

Before:

![Screen Shot 2021-02-24 at 9 37 45 AM](https://user-images.githubusercontent.com/8056203/108972812-f9e10880-7683-11eb-9475-6dd331b67435.png)

After:

![Screen Shot 2021-02-24 at 9 37 30 AM](https://user-images.githubusercontent.com/8056203/108972822-fcdbf900-7683-11eb-8348-bac40ae658aa.png)

# Testing

This doesn't actually affect the default Gutenberg setup but shouldn't break it either ;)