### PR TITLE
Use is singular instead of is_single

### DIFF
--- a/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
@@ -94,7 +94,7 @@ class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 	 * @return bool
 	 */
 	private function should_hide_block() {
-		return ! $this->is_cs_connected() || ! is_single();
+		return ! $this->is_cs_connected() || ! is_singular();
 	}
 
 	/**


### PR DESCRIPTION
This PR addresses a report that came in during tests where the block would not be rendered at all. The call on `is_single()` is returning false, which prevents the block from rendering.

As per [codex recommendation](https://developer.wordpress.org/reference/functions/is_single/#more-information), this PR changes `is_single()` call for `is_singular()`

## Test instructions
Checkout on sandbox and run `make client`. Be sure to sandbox ParKff-9N-p2 and visit the page where the NPS was inserted: ParKff-9W-p2
After 3 visits, the NPS should popup.