### PR TITLE
Change NPS title label (sidebar)

### DIFF
--- a/client/blocks/nps/sidebar.js
+++ b/client/blocks/nps/sidebar.js
@@ -81,10 +81,7 @@ const Sidebar = ( {
 				</p>
 
 				<TextControl
-					label={ __(
-						'Title of the NPS block',
-						'crowdsignal-forms'
-					) }
+					label={ __( 'Title (optional)', 'crowdsignal-forms' ) }
 					onChange={ handleChangeTitle }
 					value={ decodeEntities(
 						attributes.title ?? attributes.ratingQuestion


### PR DESCRIPTION
This PR changes the label shown on the sidebar to give the NPS a title.

Previous version seem to be confusing for some users (making them believe that was the title to be shown on the block).

## Test instructions
Checkout and `make client`. Add an NPS block to a post. Check on the sidebar to confirm the title input label now reads: "Title (optional)"