### PR TITLE
Add UA and X-Forwarded-For headers for proper response results tracking

### DIFF
--- a/includes/gateways/class-api-gateway.php
+++ b/includes/gateways/class-api-gateway.php
@@ -378,7 +378,9 @@ class Api_Gateway implements Api_Gateway_Interface {
 		$headers = apply_filters(
 			'crowdsignal_forms_api_request_headers',
 			array(
-				'content-type' => 'application/json',
+				'content-type'    => 'application/json',
+				'user-agent'      => ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : 'unknown',
+				'x-forwarded-for' => ! empty( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '',
 			)
 		);
 


### PR DESCRIPTION
This PR will add `user-agent` and `x-forwarded-for` headers to be sent on requests for Crowdsignal API.

These headers provide analytic metadata for the responses results page. 

## Test instructions
Checkout and respond to an NPS rating. Visit the results page to see the response and check the geolocation and User Agent data for the response.