### PR TITLE
Turn html and reusable options to false

### DIFF
--- a/client/blocks/nps/index.js
+++ b/client/blocks/nps/index.js
@@ -20,6 +20,8 @@ export default {
 	attributes,
 	supports: {
 		multiple: false,
+		html: false,
+		reusable: false,
 	},
 	icon: <NpsIcon />,
 	edit,


### PR DESCRIPTION
This PR changes the NPS `supports` options `html` and `reusable` to false. The NPS block is not prepared to be manually edited nor turned into a reusable one.

## Test instructions
Checkout and `make client`. Try to edit the block on HTML mode, you shouldn't be able to. Try to make an NPS block into a reusable one, you shouldn't be able to do so.