### PR TITLE
Use RichText component on frontend

### DIFF
--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -224,6 +224,8 @@ const EditNpsBlock = ( props ) => {
 								) }
 								value={ attributes.lowRatingLabel }
 								allowedFormats={ [] }
+								multiline={ false }
+								disableLineBreaks={ true }
 							/>
 							<RichText
 								tagName="span"
@@ -236,6 +238,8 @@ const EditNpsBlock = ( props ) => {
 								) }
 								value={ attributes.highRatingLabel }
 								allowedFormats={ [] }
+								multiline={ false }
+								disableLineBreaks={ true }
 							/>
 						</div>
 
@@ -300,6 +304,8 @@ const EditNpsBlock = ( props ) => {
 								) }
 								value={ attributes.submitButtonLabel }
 								allowedFormats={ [] }
+								multiline={ false }
+								disableLineBreaks={ true }
 							/>
 						</div>
 

--- a/client/blocks/poll/edit-answers.js
+++ b/client/blocks/poll/edit-answers.js
@@ -129,6 +129,8 @@ const EditAnswers = ( {
 								onChange={ handleChangeSubmitButtonLabel }
 								value={ attributes.submitButtonLabel }
 								allowedFormats={ [] }
+								multiline={ false }
+								disableLineBreaks={ true }
 							/>
 						) : (
 							<div className="wp-block-button__link crowdsignal-forms-poll__submit-button">

--- a/client/blocks/poll/edit.js
+++ b/client/blocks/poll/edit.js
@@ -240,14 +240,15 @@ const PollBlock = ( props ) => {
 									allowedFormats={ [] }
 								/>
 							) : (
-								<p className="crowdsignal-forms-poll__note">
-									{ attributes.note
-										? decodeEntities( attributes.note )
-										: __(
-												'Add a note (optional)',
-												'crowdsignal-forms'
-										  ) }
-								</p>
+								<RichText.Content
+									tagName="div"
+									className="crowdsignal-forms-poll__note"
+									placeholder={ __(
+										'Add a note (optional)',
+										'crowdsignal-forms'
+									) }
+									value={ decodeEntities( attributes.note ) }
+								/>
 							) ) }
 
 						{ ! showResults && (

--- a/client/blocks/poll/edit.js
+++ b/client/blocks/poll/edit.js
@@ -215,14 +215,15 @@ const PollBlock = ( props ) => {
 								allowedFormats={ [] }
 							/>
 						) : (
-							<h3 className="crowdsignal-forms-poll__question">
-								{ attributes.question
-									? decodeEntities( attributes.question )
-									: __(
-											'Enter your question',
-											'crowdsignal-forms'
-									  ) }
-							</h3>
+							<RichText.Content
+								tagName="h3"
+								className="crowdsignal-forms-poll__question"
+								placeholder={ __(
+									'Enter your question',
+									'crowdsignal-forms'
+								) }
+								value={ decodeEntities( attributes.question ) }
+							/>
 						) }
 
 						{ showNote &&

--- a/client/components/nps/index.js
+++ b/client/components/nps/index.js
@@ -9,6 +9,7 @@ import { get } from 'lodash';
  */
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { RichText } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -57,9 +58,11 @@ const Nps = ( {
 	return (
 		<>
 			<div className="crowdsignal-forms-nps" style={ style }>
-				<h3 className="crowdsignal-forms-nps__question">
-					{ questionText }
-				</h3>
+				<RichText.Content
+					tagName="h3"
+					className="crowdsignal-forms-nps__question"
+					value={ questionText }
+				/>
 
 				<button
 					className="crowdsignal-forms-nps__close-button"

--- a/client/components/poll/index.js
+++ b/client/components/poll/index.js
@@ -164,9 +164,11 @@ const Poll = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 				/>
 
 				{ attributes.note && (
-					<p className="crowdsignal-forms-poll__note">
-						{ decodeEntities( attributes.note ) }
-					</p>
+					<RichText.Content
+						className="crowdsignal-forms-poll__note"
+						tagName="div"
+						value={ decodeEntities( attributes.note ) }
+					/>
 				) }
 
 				{ ! showResults && (

--- a/client/components/poll/index.js
+++ b/client/components/poll/index.js
@@ -11,6 +11,7 @@ import classNames from 'classnames';
  */
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
+import { RichText } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -156,9 +157,11 @@ const Poll = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 			{ errorMessage && <ErrorBanner>{ errorMessage }</ErrorBanner> }
 
 			<div className={ contentClasses }>
-				<h3 className="crowdsignal-forms-poll__question">
-					{ decodeEntities( attributes.question ) }
-				</h3>
+				<RichText.Content
+					tagName="h3"
+					value={ decodeEntities( attributes.question ) }
+					className="crowdsignal-forms-poll__question"
+				/>
 
 				{ attributes.note && (
 					<p className="crowdsignal-forms-poll__note">

--- a/client/components/poll/style.scss
+++ b/client/components/poll/style.scss
@@ -34,7 +34,7 @@
 		}
 	}
 
-	p.crowdsignal-forms-poll__note {
+	.crowdsignal-forms-poll__note {
 		font-style: italic;
 		margin: 0 0 32px;
 	}


### PR DESCRIPTION
This PR addresses the issue seen on CS Forms blocks which allow for multiple line paragraphs but then render a `<br>` on frontend.

Applying this PR will allow line breaks on:

  - NPS Rating question
  - NPS Feedback prompt
  - Poll question (and preview while disabled)
  - Poll note (and preview while disabled)

and prevent line breaks on:

  - NPS low/high rating labels
  - NPS Feedback submit button
  - Poll submit button

## Test instructions

**NOTE:** we are importing a `block-editor` component on the visitor frontend. While this is not optimal, verify the `RichText` component can be seen already loading both on WP.com and self hosted environments before building this PR.

Checkout and run `NODE_ENV=production make client`. Verify the conditions described above.
