### PR TITLE
Change copy edits

### DIFF
--- a/client/blocks/nps/edit.scss
+++ b/client/blocks/nps/edit.scss
@@ -12,7 +12,7 @@
 
 .crowdsignal-forms-nps__toolbar-popover {
 	padding: 15px;
-	min-width: 280px;
+	min-width: 300px;
 
 	.components-base-control__field {
 		display: flex;

--- a/client/blocks/nps/sidebar.js
+++ b/client/blocks/nps/sidebar.js
@@ -123,7 +123,7 @@ const Sidebar = ( {
 			>
 				<SelectControl
 					value={ attributes.status }
-					label={ __( 'Status', 'crowdsignal-forms' ) }
+					label={ __( 'Survey Status', 'crowdsignal-forms' ) }
 					options={ [
 						{
 							label: __( 'Open', 'crowdsignal-forms' ),

--- a/client/blocks/nps/toolbar.js
+++ b/client/blocks/nps/toolbar.js
@@ -70,7 +70,7 @@ const PollToolbar = ( {
 							<div className="crowdsignal-forms-nps__toolbar-popover">
 								<TextControl
 									label={ __(
-										'Show this block after n visits:',
+										'Show this block after __ visits:',
 										'crowdsignal-forms'
 									) }
 									value={ attributes.viewThreshold }


### PR DESCRIPTION
This PR changes labels/texts on the editor:

  - "Survey Status" instead of "Status" on the Sidebar -> Settings section
  - "Show this block after __ visits": use double underscore as a placeholder for the threshold before showing the popup

## Test instructions
Checkout and run `make client`. Check the above mentioned texts.