### PR TITLE
Change translations pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ client:
 	npm run build:nps
 
 # Package for release
-release: clean-release install-node pot client
+release: clean-release install-node client pot
 	./scripts/package-for-release.sh
 
 # Clean the build directory

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,7 +51,7 @@ RUN \
 RUN a2enmod rewrite
 
 # Install wp-cli
-RUN curl -o /usr/local/bin/wp -SL https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar \
+RUN curl -o /usr/local/bin/wp -SL https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
 	&& chmod +x /usr/local/bin/wp
 
 # Install PsySH to use in wp-cli shell

--- a/includes/frontend/blocks/class-crowdsignal-forms-vote-item-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-vote-item-block.php
@@ -36,7 +36,7 @@ class Crowdsignal_Forms_Vote_Item_Block extends Crowdsignal_Forms_Block {
 	 */
 	public function assets() {
 		return array(
-			'config' => 'build/vote.asset.php', // same as vote block because they're compiled together.
+			'config' => '/build/vote.asset.php', // same as vote block because they're compiled together.
 		);
 	}
 

--- a/includes/frontend/class-crowdsignal-forms-blocks-assets.php
+++ b/includes/frontend/class-crowdsignal-forms-blocks-assets.php
@@ -109,7 +109,7 @@ class Crowdsignal_Forms_Blocks_Assets {
 	 * @return string
 	 */
 	private function include_path( $path ) {
-		return plugin_dir_path( CROWDSIGNAL_FORMS_PLUGIN_FILE ) . $path;
+		return untrailingslashit( plugin_dir_path( CROWDSIGNAL_FORMS_PLUGIN_FILE ) ) . $path;
 	}
 
 	/**

--- a/includes/frontend/class-crowdsignal-forms-blocks-assets.php
+++ b/includes/frontend/class-crowdsignal-forms-blocks-assets.php
@@ -78,6 +78,9 @@ class Crowdsignal_Forms_Blocks_Assets {
 				$config['version'],
 				true
 			);
+			if ( function_exists( 'wp_set_script_translations' ) ) {
+				wp_set_script_translations( $id, 'crowdsignal-forms', $this->include_path( '/languages' ) );
+			}
 		}
 
 		if ( isset( $paths['style'] ) ) {

--- a/scripts/makepot.sh
+++ b/scripts/makepot.sh
@@ -6,4 +6,4 @@
 
 set -e
 
-docker-compose -f docker/docker-compose.yml exec wordpress bash -c "cd /var/www/html/wp-content/plugins/crowdsignal-forms && wp i18n make-pot --allow-root . languages/crowdsignal-forms.pot --exclude={docker,tests,vendor,release,node_modules}"
+docker-compose -f docker/docker-compose.yml exec wordpress bash -c "cd /var/www/html/wp-content/plugins/crowdsignal-forms && wp i18n make-pot --allow-root . languages/crowdsignal-forms.pot --exclude={docker,tests,vendor,release,node_modules,client} --include=build"


### PR DESCRIPTION
This PR will:

  - invert `pot` and `client` process order, to have the client built before creating the .pot file
  - change `makepot.sh` script to extract the strings from the built client JS files
  - change the `wp-cli` version installed on the docker (stable)
  - enqueue translation files on the asset loading step

The PR is just a first step towards automated translations. The steps are:

  - create a .pot with references to **built** files (as opposed to reference source files)
  - upload the .pot file to the GlotPress project (manual step, it might be replaced with the Global Team pipeline)
  - load, if available, translation files for JS packages

The D58764-code implements a new script which can be ran manually or automated to download the translated sets (.po/.mo) for locales in the GlotPress project (currently only Spanish passes the translation threshold, 82%), but the script allows for a forced extraction with any percentage. Read more at the differential.

## Test instructions
Checkout with `git checkout add/translations-script`. Stop and delete any docker you might have running:

```
make docker_down
```

Check docker instances and delete them:

```
docker ps -a
# use the docker name, repeat for every instance related to our docker
docker rm [docker name here]
```

Check and delete docker images:

```
docker image ls
# use the image ID to delete, repeat for every image related to our docker
docker image rm [docker image ID here]
```

Build the docker again and run it:
```
make docker_build
make docker_up
```

Make a production release:
```
NODE_ENV=production make release
```

Check that the `.pot` file generated contains references to these JS files (instead of referencing source JS files):

  - applause.js
  - editor.js
  - nps.js
  - poll.js
  - vote.js

Continue test on the differential