### PR TITLE
Use optimistic requests for submitting NPS block results

### DIFF
--- a/client/components/nps/feedback.js
+++ b/client/components/nps/feedback.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { useState } from 'react';
+import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -13,31 +14,25 @@ import { TextareaControl } from '@wordpress/components';
  */
 import { updateNpsResponse } from 'data/nps';
 
-const NpsFeedback = ( { attributes, onFailure, onSubmit, responseMeta } ) => {
+const NpsFeedback = ( { attributes, onSubmit, responseMeta } ) => {
 	const [ feedback, setFeedback ] = useState( '' );
-	const [ submitting, setSubmitting ] = useState( false );
 
 	const handleSubmit = async () => {
-		setSubmitting( true );
-
-		try {
-			await updateNpsResponse( attributes.surveyId, {
+		if ( responseMeta !== null && ! isEmpty( feedback ) ) {
+			updateNpsResponse( attributes.surveyId, {
 				nonce: attributes.nonce,
 				feedback,
 				...responseMeta,
 			} );
-
-			onSubmit();
-		} catch ( error ) {
-			onFailure();
 		}
+
+		onSubmit();
 	};
 
 	return (
 		<div className="crowdsignal-forms-nps__feedback">
 			<TextareaControl
 				className="crowdsignal-forms-nps__feedback-text"
-				disabled={ submitting }
 				rows={ 6 }
 				placeholder={ attributes.feedbackPlaceholder }
 				onChange={ setFeedback }
@@ -47,7 +42,6 @@ const NpsFeedback = ( { attributes, onFailure, onSubmit, responseMeta } ) => {
 			<div className="wp-block-button crowdsignal-forms-nps__feedback-button-wrapper">
 				<button
 					className="wp-block-button__link crowdsignal-forms-nps__feedback-button"
-					disabled={ submitting }
 					onClick={ handleSubmit }
 					type="button"
 				>

--- a/client/components/nps/index.js
+++ b/client/components/nps/index.js
@@ -30,10 +30,7 @@ const Nps = ( {
 	const [ responseMeta, setResponseMeta ] = useState( null );
 	const [ view, setView ] = useState( views.RATING );
 
-	const handleRatingSubmit = ( meta ) => {
-		setResponseMeta( meta );
-		setView( views.FEEDBACK );
-	};
+	const handleRatingSubmit = () => setView( views.FEEDBACK );
 
 	const handleFeedbackSubmit = () => setView( views.SUBMIT );
 
@@ -71,8 +68,8 @@ const Nps = ( {
 				{ view === views.RATING && (
 					<NpsRating
 						attributes={ attributes }
-						onFailure={ onClose }
 						onSubmit={ handleRatingSubmit }
+						onSubmitSuccess={ setResponseMeta }
 					/>
 				) }
 
@@ -80,7 +77,6 @@ const Nps = ( {
 					<NpsFeedback
 						attributes={ attributes }
 						responseMeta={ responseMeta }
-						onFailure={ onClose }
 						onSubmit={ handleFeedbackSubmit }
 					/>
 				) }

--- a/client/components/nps/rating.js
+++ b/client/components/nps/rating.js
@@ -10,22 +10,21 @@ import { pick, times } from 'lodash';
  */
 import { updateNpsResponse } from 'data/nps';
 
-const NpsRating = ( { attributes, onFailure, onSubmit } ) => {
+const NpsRating = ( { attributes, onSubmit, onSubmitSuccess } ) => {
 	const [ selected, setSelected ] = useState( -1 );
 
 	const handleSubmit = ( rating ) => async () => {
 		setSelected( rating );
 
-		try {
-			const data = await updateNpsResponse( attributes.surveyId, {
-				nonce: attributes.nonce,
-				score: rating,
-			} );
+		updateNpsResponse( attributes.surveyId, {
+			nonce: attributes.nonce,
+			score: rating,
+		} ).then( ( data ) =>
+			onSubmitSuccess( pick( data, [ 'r', 'checksum' ] ) )
+		);
 
-			onSubmit( pick( data, [ 'r', 'checksum' ] ) );
-		} catch ( error ) {
-			onFailure();
-		}
+		// Wait for the animation to complete before proceeding to the next step
+		setTimeout( onSubmit, 300 );
 	};
 
 	return (


### PR DESCRIPTION
This patch updates the submission flow for the NPS blocks so requests aren't blocking for the next steps.
Because of this update, we'll now be giving every user the complete flow regardless if they requests go out or results in errors - previously we'd just hide the dialog at any point in the process if something goes wrong.

# Testing

Create an NPS block and try submitting a response. When you submit rating or feedback you should be taken to the next step immediately.
Verify your results show up in the dashboard.