### PR TITLE
Update dependency to node-sass@5.x.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8672,6 +8672,12 @@
 			"integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
 			"dev": true
 		},
+		"env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"dev": true
+		},
 		"enzyme": {
 			"version": "3.11.0",
 			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
@@ -15487,6 +15493,24 @@
 				"minipass": "^3.0.0"
 			}
 		},
+		"minizlib": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+			"dev": true,
+			"requires": {
+				"minipass": "^3.0.0",
+				"yallist": "^4.0.0"
+			},
+			"dependencies": {
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"dev": true
+				}
+			}
+		},
 		"mississippi": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
@@ -15777,26 +15801,25 @@
 			"dev": true
 		},
 		"node-sass": {
-			"version": "4.13.1",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
-			"integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-5.0.0.tgz",
+			"integrity": "sha512-opNgmlu83ZCF792U281Ry7tak9IbVC+AKnXGovcQ8LG8wFaJv6cLnRlc6DIHlmNxWEexB5bZxi9SZ9JyUuOYjw==",
 			"dev": true,
 			"requires": {
 				"async-foreach": "^0.1.3",
 				"chalk": "^1.1.1",
-				"cross-spawn": "^3.0.0",
+				"cross-spawn": "^7.0.3",
 				"gaze": "^1.0.0",
 				"get-stdin": "^4.0.1",
 				"glob": "^7.0.3",
-				"in-publish": "^2.0.0",
 				"lodash": "^4.17.15",
 				"meow": "^3.7.0",
 				"mkdirp": "^0.5.1",
 				"nan": "^2.13.2",
-				"node-gyp": "^3.8.0",
+				"node-gyp": "^7.1.0",
 				"npmlog": "^4.0.0",
 				"request": "^2.88.0",
-				"sass-graph": "^2.2.4",
+				"sass-graph": "2.2.5",
 				"stdout-stream": "^1.4.0",
 				"true-case-path": "^1.0.2"
 			},
@@ -15826,25 +15849,109 @@
 						"supports-color": "^2.0.0"
 					}
 				},
+				"chownr": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+					"dev": true
+				},
 				"cross-spawn": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-					"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
 					"dev": true,
 					"requires": {
-						"lru-cache": "^4.0.1",
-						"which": "^1.2.9"
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
 					}
 				},
 				"lru-cache": {
-					"version": "4.1.5",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 					"dev": true,
 					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
+						"yallist": "^4.0.0"
 					}
+				},
+				"node-gyp": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
+					"integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
+					"dev": true,
+					"requires": {
+						"env-paths": "^2.2.0",
+						"glob": "^7.1.4",
+						"graceful-fs": "^4.2.3",
+						"nopt": "^5.0.0",
+						"npmlog": "^4.1.2",
+						"request": "^2.88.2",
+						"rimraf": "^3.0.2",
+						"semver": "^7.3.2",
+						"tar": "^6.0.2",
+						"which": "^2.0.2"
+					}
+				},
+				"nopt": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+					"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+					"dev": true,
+					"requires": {
+						"abbrev": "1"
+					}
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"sass-graph": {
+					"version": "2.2.5",
+					"resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
+					"integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.0.0",
+						"lodash": "^4.0.0",
+						"scss-tokenizer": "^0.2.3",
+						"yargs": "^13.3.2"
+					}
+				},
+				"semver": {
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
@@ -15861,10 +15968,41 @@
 					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
 					"dev": true
 				},
+				"tar": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
+					"integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+					"dev": true,
+					"requires": {
+						"chownr": "^2.0.0",
+						"fs-minipass": "^2.0.0",
+						"minipass": "^3.0.0",
+						"minizlib": "^2.1.1",
+						"mkdirp": "^1.0.3",
+						"yallist": "^4.0.0"
+					},
+					"dependencies": {
+						"mkdirp": {
+							"version": "1.0.4",
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+							"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+							"dev": true
+						}
+					}
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
 				"yallist": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 					"dev": true
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"@automattic/calypso-build": "^6.1.0",
 		"@wordpress/scripts": "^8.0.1",
 		"classnames": "^2.2.6",
-		"node-sass": "^4.13.1",
+		"node-sass": "^5.0.0",
 		"prettier": "npm:wp-prettier@^2.0.5-alpha-2"
 	},
 	"dependencies": {


### PR DESCRIPTION
This PR updates the `node-sass` dependency version and fixes incompatibility with Linux 64bit environments

On a second thought, this might be useless until we update the calypso-build dependency as well (node-sass@4.x is a direct dependency of it)

## Test instructions
Checkout update/node-sass-dependency-v5 and run `make client` on a Linux 64 env. The build should complete without errors