### PR TITLE
Update the NPS preview button to behave identically to the editor's one

### DIFF
--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -39,7 +39,6 @@ const EditNpsBlock = ( props ) => {
 		clientId,
 		fallbackStyles,
 		isSelected,
-		postPreviewLink,
 		setAttributes,
 		renderStyleProbe,
 		sourceLink,
@@ -161,10 +160,7 @@ const EditNpsBlock = ( props ) => {
 			) }
 
 			{ ! isExample && (
-				<EditorNotice
-					isDismissible={ false }
-					icon="visibility"
-				>
+				<EditorNotice isDismissible={ false } icon="visibility">
 					{ sprintf(
 						// translators: %d: number of pageviews
 						_n(
@@ -181,7 +177,7 @@ const EditNpsBlock = ( props ) => {
 							className={ [
 								'is-secondary',
 								'components-notice__action',
-								'crowdsignal-forms-nps__preview-button'
+								'crowdsignal-forms-nps__preview-button',
 							] }
 							textContent={ __( 'Preview', 'crowdsignal-forms' ) }
 						/>
@@ -324,7 +320,6 @@ const EditNpsBlock = ( props ) => {
 
 export default compose( [
 	withSelect( ( select ) => ( {
-		postPreviewLink: select( 'core/editor' ).getEditedPostPreviewLink(),
 		sourceLink: select( 'core/editor' ).getPermalink(),
 	} ) ),
 	withFallbackStyles,

--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -10,6 +10,7 @@ import classnames from 'classnames';
  */
 import { TextareaControl } from '@wordpress/components';
 import { RichText } from '@wordpress/block-editor';
+import { PostPreviewButton } from '@wordpress/editor';
 import { dispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -163,23 +164,6 @@ const EditNpsBlock = ( props ) => {
 				<EditorNotice
 					isDismissible={ false }
 					icon="visibility"
-					actions={
-						attributes.surveyId
-							? [
-									{
-										label: __(
-											'Preview',
-											'crowdsignal-forms'
-										),
-										onClick: () =>
-											window.open(
-												postPreviewLink,
-												'blank'
-											),
-									},
-							  ]
-							: []
-					}
 				>
 					{ sprintf(
 						// translators: %d: number of pageviews
@@ -190,6 +174,17 @@ const EditNpsBlock = ( props ) => {
 							'crowdsignal-forms'
 						),
 						viewThreshold
+					) }
+
+					{ attributes.surveyId && (
+						<PostPreviewButton
+							className={ [
+								'is-secondary',
+								'components-notice__action',
+								'crowdsignal-forms-nps__preview-button'
+							] }
+							textContent={ __( 'Preview', 'crowdsignal-forms' ) }
+						/>
 					) }
 				</EditorNotice>
 			) }

--- a/client/blocks/nps/edit.scss
+++ b/client/blocks/nps/edit.scss
@@ -49,3 +49,7 @@
 	border-color: var(--crowdsignal-forms-button-color);
 	color: var(--crowdsignal-forms-button-color);
 }
+
+.editor-styles-wrapper .components-button.is-secondary.crowdsignal-forms-nps__preview-button {
+	text-decoration: none;
+}

--- a/client/components/editor-notice/index.js
+++ b/client/components/editor-notice/index.js
@@ -4,6 +4,8 @@
 import { Notice, Icon } from '@wordpress/components';
 
 const EditorNotice = ( { icon, children, ...props } ) => {
+	const [ text, ...actions ] = children;
+
 	return (
 		<Notice className="crowdsignal-forms__editor-notice" { ...props }>
 			{ icon && (
@@ -12,8 +14,10 @@ const EditorNotice = ( { icon, children, ...props } ) => {
 				</div>
 			) }
 			<div className="crowdsignal-forms__editor-notice-text">
-				{ children }
+				{ text }
 			</div>
+
+			{ actions }
 		</Notice>
 	);
 };


### PR DESCRIPTION
This patch updates the preview button on the NPS block to behave the same way as the editor's preview button.  

Previously it was prone to issues when it'd redirect you to the preview of a yet unsaved post or show you an outdated version. With this upgrade you should get the same 'generating preview' screen and should always see the current version of the post.

In order to get this to work in the least invasive manner and without duplicating core's functionality I had to tweak `EditorNotice` component a little.  
With the tweak I made, it'll only put the first `child` into the `crowdsignal-forms__editor-notice-text` node and append the rest behind it. I believe this should actually be good in the long run as it now allows us to append custom elements or buttons without breaking the layout. If we ever need to fit more nodes into the text node we could just use an additional wrapper for that.

# Testing

Verify that the preview button triggers a save if the post hasn't been saved yet and that the preview always reflects the latest changes made in the editor.