### PR TITLE
Use 'crowdsignal_forms_translations_path' filter to load translations

### DIFF
--- a/includes/frontend/class-crowdsignal-forms-blocks-assets.php
+++ b/includes/frontend/class-crowdsignal-forms-blocks-assets.php
@@ -79,7 +79,8 @@ class Crowdsignal_Forms_Blocks_Assets {
 				true
 			);
 			if ( function_exists( 'wp_set_script_translations' ) ) {
-				wp_set_script_translations( $id, 'crowdsignal-forms', $this->include_path( '/languages' ) );
+				$path = apply_filters( 'crowdsignal_forms_translations_path', $this->include_path( '/languages' ) );
+				wp_set_script_translations( $id, 'crowdsignal-forms', $path );
 			}
 		}
 


### PR DESCRIPTION
This PR adds a filter to the path where translations are loaded from through the "crowdsignal_forms_translations_path" filter, in case the user wants to store/load translations from a different path.

## Test instructions
Checkout and load the editor, the filter currently defaults to the `/languages` dir.