### PR TITLE
Fix preview button causing the NPS block to break when creating a new block

### DIFF
--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -172,16 +172,15 @@ const EditNpsBlock = ( props ) => {
 						viewThreshold
 					) }
 
-					{ attributes.surveyId && (
-						<PostPreviewButton
-							className={ [
-								'is-secondary',
-								'components-notice__action',
-								'crowdsignal-forms-nps__preview-button',
-							] }
-							textContent={ __( 'Preview', 'crowdsignal-forms' ) }
-						/>
-					) }
+					<PostPreviewButton
+						className={ [
+							'is-secondary',
+							'components-notice__action',
+							'crowdsignal-forms-nps__preview-button',
+							attributes.surveyId ? '' : 'is-disabled',
+						] }
+						textContent={ __( 'Preview', 'crowdsignal-forms' ) }
+					/>
 				</EditorNotice>
 			) }
 

--- a/client/blocks/nps/edit.scss
+++ b/client/blocks/nps/edit.scss
@@ -52,4 +52,8 @@
 
 .editor-styles-wrapper .components-button.is-secondary.crowdsignal-forms-nps__preview-button {
 	text-decoration: none;
+
+	&.is-disabled {
+		display: none;
+	}
 }


### PR DESCRIPTION
This patch fixes an issue that occurs when adding a new NPS block: when it saves and the preview should become available the block breaks instead.

Unfortunately, the root cause is related to some of Gutenberg's internal components - I haven't dug into those yet as it'll require building the development version before we can get anything more than a few obscure React errors. This means two things:

- At some point, this might get fixed 'upstream', either by us or someone else.
- Potentially, these changes could break the block again as I don't think any of this is considered public API.

Since the issue doesn't occur if the button is rendered from the get-go, the best interim solution I could come up with was to always render it and only hide it using CSS. 🤷 

# Testing

- Create/Edit a test post and make sure there's no NPS block within it.
- Add a new NPS block - the preview button should appear after a short delay after the block has been saved.
- The preview button should still work correctly ;)