### PR TITLE
Create nightly-build workflow

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -27,6 +27,8 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout repo
       - uses: actions/checkout@v2
+      - with:
+        ref: ${{ github.events.inputs.branch }}
 
       # Runs a single command using the runners shell
       - name: Run a one-line script
@@ -39,7 +41,6 @@ jobs:
           echo test, and deploy your project.
       - name: install deps
         run: |
-          git checkout ${{ github.events.inputs.branch }}
           git checkout -b nightly_build
           npm install
           composer install

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -2,7 +2,7 @@
 
 name: Create nightly build release
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   # push:
@@ -40,6 +40,7 @@ jobs:
       - name: install deps
         run: |
           git checkout ${{ github.events.inputs.branch }}
+          git checkout -b nightly_build
           npm install
           composer install
       - name: build
@@ -62,4 +63,4 @@ jobs:
           prerelease: true
           title: "Development Build"
           files: |
-            release/crowdsignal-forms.*.zip
+            release/crowdsignal-forms.nightly_build.zip

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,65 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Create nightly build release
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  # push:
+  #  branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      branch: 'Branch to build, defaults to master'
+      required: true
+      default: 'master'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repo
+      - uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.
+      - name: install deps
+        run: |
+          git checkout ${{ github.events.inputs.branch }}
+          npm install
+          composer install
+      - name: build
+        run: |
+          npm run build:styles
+          npm run build:apifetch
+          npm run build:editor
+          npm run build:poll
+          npm run build:vote
+          npm run build:applause
+          npm run build:nps
+          ./scripts/makepot.sh
+          ./scripts/package-for-release.sh
+        env:
+          NODE_ENV: production
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "nightly_build"
+          prerelease: true
+          title: "Development Build"
+          files: |
+            release/crowdsignal-forms.*.zip


### PR DESCRIPTION
This PR introduces a workflow file to create nightly builds. 

This is mostly in a testing phase and it would be the first of a 2 stepped release flow.

There is no way to test this as it generates a new Github action for the repo.

The actions used on this workflow are:

  - https://github.com/marvinpinto/action-automatic-releases
  - https://github.com/actions/checkout