### PR TITLE
Fix double entry (no uses and run on same step)

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -24,7 +24,6 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
-        run: echo ${{ github.event.inputs.buildBranch }}
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.buildBranch }}


### PR DESCRIPTION
Fix syntax: a step cannot have both `uses` and `run`