### PR TITLE
Add Github action for nightly builds

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Install
         run: |
           npm install
+          composer update
           composer install
 
       #

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -27,6 +27,11 @@ jobs:
         with:
           php-version: '7.4'
 
+      - name: Setup Node version
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -31,10 +31,11 @@ jobs:
       - name: Fork
         run: git checkout -b nightly_build
 
-      # - name: Install
-      #   run: |
-      #     npm install
-      #     composer install
+      - name: Install
+        run: |
+          npm install
+          composer install
+
       #
       # - name: Build
       #   run: |

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -66,11 +66,11 @@ jobs:
           scripts/makepot.sh
           scripts/package-for-release.sh
 
-      # - name: Create nightly build release
-      #   uses: marvinpinto/action-automatic-releases@latest
-      #   with:
-      #     repo_token: ${{ secrets.GITHUB_TOKEN }}
-      #     automatic_release_tag: nightly_build
-      #     prerelease: true
-      #     title: Development Build
-      #     files: ./release/crowdsignal-forms.nightly_build.zip
+      - name: Create nightly build release
+        uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          automatic_release_tag: nightly_build
+          prerelease: true
+          title: Development Build
+          files: release/crowdsignal-forms.nightly_build.zip

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -20,7 +20,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: "Trigger ${{ github.event_name }}"
+      - name: "Trigger"
         run: echo "Triggered by ${{ github.event_name }}"
 
       - name: Setup PHP 7.4 with PECL extension
@@ -60,21 +60,12 @@ jobs:
           npm run build:nps
         env:
           NODE_ENV: production
-<<<<<<< Updated upstream
-      #
-      #   - name: Package for release
-      #     run: |
-      #       scripts/makepot.sh
-      #       scripts/package-for-release.sh
-      #
-=======
 
       - name: Package for release
         run: |
           scripts/makepot.sh
           scripts/package-for-release.sh
 
->>>>>>> Stashed changes
       # - name: Create nightly build release
       #   uses: marvinpinto/action-automatic-releases@latest
       #   with:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       buildBranch:
-        description: Branch to build, defaults to master
+        description: Branch to build
         required: true
         default: master
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -60,12 +60,21 @@ jobs:
           npm run build:nps
         env:
           NODE_ENV: production
+<<<<<<< Updated upstream
       #
       #   - name: Package for release
       #     run: |
       #       scripts/makepot.sh
       #       scripts/package-for-release.sh
       #
+=======
+
+      - name: Package for release
+        run: |
+          scripts/makepot.sh
+          scripts/package-for-release.sh
+
+>>>>>>> Stashed changes
       # - name: Create nightly build release
       #   uses: marvinpinto/action-automatic-releases@latest
       #   with:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -22,6 +22,11 @@ jobs:
     steps:
       - run: echo "Triggered by ${{ github.event_name }}"
 
+      - name: Setup PHP with PECL extension
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -20,14 +20,15 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - run: echo "Triggered by ${{ github.event_name }}"
+      - name: "Trigger ${{ github.event_name }}"
+        run: echo "Triggered by ${{ github.event_name }}"
 
-      - name: Setup PHP with PECL extension
+      - name: Setup PHP 7.4 with PECL extension
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
 
-      - name: Setup Node version
+      - name: Setup Node version 14
         uses: actions/setup-node@v2
         with:
           node-version: '14'
@@ -47,18 +48,18 @@ jobs:
           composer update
           composer install
 
-      #
-      # - name: Build
-      #   run: |
-      #     npm run build:styles
-      #     npm run build:apifetch
-      #     npm run build:editor
-      #     npm run build:poll
-      #     npm run build:vote
-      #     npm run build:applause
-      #     npm run build:nps
-      #   env:
-      #     NODE_ENV: production
+
+      - name: Build
+        run: |
+          npm run build:styles
+          npm run build:apifetch
+          npm run build:editor
+          npm run build:poll
+          npm run build:vote
+          npm run build:applause
+          npm run build:nps
+        env:
+          NODE_ENV: production
       #
       #   - name: Package for release
       #     run: |


### PR DESCRIPTION
This PR adds (actually just polishes it) a workflow to manually trigger a build.

When triggered, the action allows to type a branch name to be built (in case you need to build something else than master branch). **Do not confuse with the "from" branch** (first dropdown), which just lets you pick a different version of the action itself (for example, when you're editing the action on a branch, you can run the action from that particular branch to see how your changes work)
![image](https://user-images.githubusercontent.com/157240/112523223-4dc33800-8d7d-11eb-893c-1f8fd3888c5f.png)

When the action ends successfully, you should be able to see the "Development Build" release as a pre-release:
![image](https://user-images.githubusercontent.com/157240/112523754-da6df600-8d7d-11eb-97d1-3c25e1afc93b.png)
and, most importantly, the archived version of the nightly build should be available for download among the assets.

## Test instructions
Go the repo actions: https://github.com/Automattic/crowdsignal-forms/actions
Select the "Create nightly build release" workflow
![image](https://user-images.githubusercontent.com/157240/112524378-8283bf00-8d7e-11eb-873b-5b30228c175b.png)
Use the "Run workflow" dropdown. Select "debug/action-steps" as the "Use workflow from" and target "test/get-rid-of-docker-step-for-pot-file" (this is the only branch that can be built right now as it doesn't use the docker to generate the .pot file).
Click again on the "Create nightly build release" to see the workflow triggered, it will show with a yellow dot indicating that it's still running. Wait for it to finish and then head to the releases section: https://github.com/Automattic/crowdsignal-forms/releases
You should see the "nightly_build" release just updated with the workflow you triggered
