### PR TITLE
Use make command to build all blocks

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -51,13 +51,7 @@ jobs:
 
       - name: Build
         run: |
-          npm run build:styles
-          npm run build:apifetch
-          npm run build:editor
-          npm run build:poll
-          npm run build:vote
-          npm run build:applause
-          npm run build:nps
+          make client
         env:
           NODE_ENV: production
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -50,8 +50,7 @@ jobs:
 
 
       - name: Build
-        run: |
-          make client
+        run: make client
         env:
           NODE_ENV: production
 


### PR DESCRIPTION
This PR changes the individual calls for all `npm run build` on each block/lib for `make client` which is part of the *new block edits*.

So we don't have to update the action every time.