### PR TITLE
implement feedback question view

### DIFF
--- a/client/blocks/feedback/attributes.js
+++ b/client/blocks/feedback/attributes.js
@@ -25,7 +25,10 @@ export default {
 	},
 	feedbackPlaceholder: {
 		type: 'string',
-		default: __( 'Please let us know how we can do better...', 'crowdsignal-forms' ),
+		default: __(
+			'Please let us know how we can do better…',
+			'crowdsignal-forms'
+		),
 	},
 	header: {
 		type: 'string',

--- a/client/blocks/feedback/attributes.js
+++ b/client/blocks/feedback/attributes.js
@@ -1,20 +1,61 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Note: Any changes made to the attributes definition need to be duplicated in
  *       Crowdsignal_Forms\Frontend\Blocks\Crowdsignal_Forms_Nps_Block::attributes()
  *       inside includes/frontend/blocks/class-crowdsignal-forms-nps-block.php.
  */
 
 export default {
+	backgroundColor: {
+		type: 'string',
+	},
+	buttonColor: {
+		type: 'string',
+	},
+	buttonTextColor: {
+		type: 'string',
+	},
+	emailPlaceholder: {
+		type: 'string',
+		default: __( 'Your email (optional)', 'crowdsignal-forms' ),
+	},
+	feedbackPlaceholder: {
+		type: 'string',
+		default: __( 'Please let us know how we can do better...', 'crowdsignal-forms' ),
+	},
+	header: {
+		type: 'string',
+		default: __( 'Hello there!', 'crowdsignal-forms' ),
+	},
 	hideBranding: {
 		type: 'boolean',
 		default: false,
+	},
+	submitButtonLabel: {
+		type: 'text',
+		default: __( 'Submit', 'crowdsignal-forms' ),
 	},
 	surveyId: {
 		type: 'number',
 		default: null,
 	},
+	textColor: {
+		type: 'string',
+	},
 	title: {
 		type: 'string',
 		default: '',
+	},
+	x: {
+		type: 'string',
+		default: 'right',
+	},
+	y: {
+		type: 'string',
+		default: 'bottom',
 	},
 };

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -175,7 +175,7 @@ const EditFeedbackBlock = ( props ) => {
 
 						<div className="wp-block-button crowdsignal-forms-feedback__button-wrapper">
 							<RichText
-								className="wp-block-button__link crowdsignal-forms-nps__feedback-button"
+								className="wp-block-button__link crowdsignal-forms-feedback__feedback-button"
 								onChange={ handleChangeAttribute(
 									'submitButtonLabel'
 								) }

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useLayoutEffect, useState } from 'react';
+import React, { useLayoutEffect } from 'react';
 import classnames from 'classnames';
 import { get } from 'lodash';
 
@@ -17,7 +17,6 @@ import { withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import ConnectToCrowdsignal from 'components/connect-to-crowdsignal';
-import SignalWarning from 'components/signal-warning';
 import { withFallbackStyles } from 'components/with-fallback-styles';
 import { getAlignmentClassNames } from 'components/feedback/util';
 import { useAccountInfo } from 'data/hooks';
@@ -89,7 +88,6 @@ const getVerticalPadding = ( position ) => {
 	};
 };
 
-
 const EditFeedbackBlock = ( props ) => {
 	const {
 		attributes,
@@ -97,7 +95,7 @@ const EditFeedbackBlock = ( props ) => {
 		editorFeatures,
 		fallbackStyles,
 		isSelected,
-		setAttributes
+		setAttributes,
 	} = props;
 
 	const accountInfo = useAccountInfo();
@@ -117,8 +115,8 @@ const EditFeedbackBlock = ( props ) => {
 
 	const setPosition = ( x, y ) => setAttributes( { x, y } );
 
-	const handleChangeAttribute = ( key ) =>
-		( value ) => setAttributes( { [ key ]: value } );
+	const handleChangeAttribute = ( key ) => ( value ) =>
+		setAttributes( { [ key ]: value } );
 
 	const shouldPromote = get( accountInfo, [
 		'signalCount',
@@ -127,8 +125,8 @@ const EditFeedbackBlock = ( props ) => {
 
 	const signalWarning =
 		shouldPromote &&
-			get( accountInfo, [ 'signalCount', 'count' ] ) >=
-				get( accountInfo, [ 'signalCount', 'userLimit' ] );
+		get( accountInfo, [ 'signalCount', 'count' ] ) >=
+			get( accountInfo, [ 'signalCount', 'userLimit' ] );
 
 	const classes = classnames(
 		'crowdsignal-forms-feedback',
@@ -137,10 +135,7 @@ const EditFeedbackBlock = ( props ) => {
 
 	return (
 		<ConnectToCrowdsignal>
-			<Toolbar
-				onChangePosition={ setPosition }
-				{ ...props }
-			/>
+			<Toolbar onChangePosition={ setPosition } { ...props } />
 			<Sidebar
 				shouldPromote={ shouldPromote }
 				signalWarning={ signalWarning }
@@ -164,13 +159,17 @@ const EditFeedbackBlock = ( props ) => {
 						<TextareaControl
 							className="crowdsignal-forms-feedback__input"
 							rows={ 6 }
-							onChange={ handleChangeAttribute( 'feedbackPlaceholder' ) }
+							onChange={ handleChangeAttribute(
+								'feedbackPlaceholder'
+							) }
 							value={ attributes.feedbackPlaceholder }
 						/>
 
 						<TextControl
 							className="crowdsignal-forms-feedback__input"
-							onChange={ handleChangeAttribute( 'emailPlaceholder' ) }
+							onChange={ handleChangeAttribute(
+								'emailPlaceholder'
+							) }
 							value={ attributes.emailPlaceholder }
 						/>
 

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -3,10 +3,13 @@
  */
 import React, { useLayoutEffect, useState } from 'react';
 import classnames from 'classnames';
+import { get } from 'lodash';
 
 /**
  * WordPress depenencies
  */
+import { RichText } from '@wordpress/block-editor';
+import { TextControl, TextareaControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 
@@ -14,8 +17,13 @@ import { withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import ConnectToCrowdsignal from 'components/connect-to-crowdsignal';
+import SignalWarning from 'components/signal-warning';
 import { withFallbackStyles } from 'components/with-fallback-styles';
+import { getAlignmentClassNames } from 'components/feedback/util';
+import { useAccountInfo } from 'data/hooks';
+import Sidebar from './sidebar';
 import Toolbar from './toolbar';
+import { getStyleVars } from './util';
 
 // Probably dependent on the button style
 const PADDING = 20;
@@ -23,7 +31,7 @@ const PADDING = 20;
 const getHorizontalPosition = ( position ) => {
 	const body = document.body;
 	const editorWrapper = document.getElementsByClassName(
-		'edit-post-visual-editor'
+		'interface-interface-skeleton__content'
 	)[ 0 ];
 
 	if ( ! editorWrapper ) {
@@ -32,7 +40,7 @@ const getHorizontalPosition = ( position ) => {
 
 	const wrapperPos = editorWrapper.getBoundingClientRect();
 
-	if ( 0 < position ) {
+	if ( position === 'right' ) {
 		return {
 			left: null,
 			right:
@@ -50,7 +58,7 @@ const getHorizontalPosition = ( position ) => {
 const getVerticalPadding = ( position ) => {
 	const body = document.body;
 	const editorWrapper = document.getElementsByClassName(
-		'edit-post-visual-editor'
+		'interface-interface-skeleton__content'
 	)[ 0 ];
 
 	if ( ! editorWrapper ) {
@@ -59,7 +67,7 @@ const getVerticalPadding = ( position ) => {
 
 	const wrapperPos = editorWrapper.getBoundingClientRect();
 
-	if ( position < 0 ) {
+	if ( position === 'bottom' ) {
 		return {
 			bottom:
 				PADDING +
@@ -68,10 +76,10 @@ const getVerticalPadding = ( position ) => {
 		};
 	}
 
-	if ( 0 < position ) {
+	if ( position === 'top' ) {
 		return {
 			bottom: null,
-			top: PADDING + wrapperPos.y,
+			top: PADDING + wrapperPos.y + 50, // 50 to account for the toolbar
 		};
 	}
 
@@ -81,55 +89,107 @@ const getVerticalPadding = ( position ) => {
 	};
 };
 
-const EditFeedbackBlock = ( props ) => {
-	const [ position, setPosition ] = useState( [ 1, -1 ] );
 
-	const { activeSidebar, editorFeatures, isSelected } = props;
+const EditFeedbackBlock = ( props ) => {
+	const {
+		attributes,
+		activeSidebar,
+		editorFeatures,
+		fallbackStyles,
+		isSelected,
+		setAttributes
+	} = props;
+
+	const accountInfo = useAccountInfo();
 
 	useLayoutEffect( () => {
-		const pos = {
-			...getHorizontalPosition( position[ 0 ] ),
-			...getVerticalPadding( position[ 1 ] ),
-		};
-
-		props.setPosition( pos );
+		props.setPosition( {
+			...getHorizontalPosition( attributes.x ),
+			...getVerticalPadding( attributes.y ),
+		} );
 	}, [
 		activeSidebar,
 		editorFeatures.fullscreenMode,
 		props.setPosition,
-		position,
+		attributes.x,
+		attributes.y,
 	] );
 
-	const classes = classnames( 'crowdsignal-forms-feedback', {
-		'align-left': position[ 0 ] < 0,
-		'align-right': position[ 0 ] > 0,
-		'align-top': position[ 1 ] > 0,
-		'align-center': position[ 1 ] === 0,
-		'align-bottom': position[ 1 ] < 0,
-	} );
+	const setPosition = ( x, y ) => setAttributes( { x, y } );
+
+	const handleChangeAttribute = ( key ) =>
+		( value ) => setAttributes( { [ key ]: value } );
+
+	const shouldPromote = get( accountInfo, [
+		'signalCount',
+		'shouldDisplay',
+	] );
+
+	const signalWarning =
+		shouldPromote &&
+			get( accountInfo, [ 'signalCount', 'count' ] ) >=
+				get( accountInfo, [ 'signalCount', 'userLimit' ] );
+
+	const classes = classnames(
+		'crowdsignal-forms-feedback',
+		getAlignmentClassNames( attributes.x, attributes.y )
+	);
 
 	return (
 		<ConnectToCrowdsignal>
 			<Toolbar
 				onChangePosition={ setPosition }
-				position={ position }
+				{ ...props }
+			/>
+			<Sidebar
+				shouldPromote={ shouldPromote }
+				signalWarning={ signalWarning }
 				{ ...props }
 			/>
 
-			<div className={ classes }>
-				{ position[ 0 ] < 0 && (
-					<button className="crowdsignal-forms-feedback__trigger-button"></button>
-				) }
-
+			<div
+				className={ classes }
+				style={ getStyleVars( attributes, fallbackStyles ) }
+			>
 				{ isSelected && (
 					<div className="crowdsignal-forms-feedback__popover">
-						Here Be Dragons
+						<RichText
+							tagName="h3"
+							className="crowdsignal-forms-feedback__header"
+							onChange={ handleChangeAttribute( 'header' ) }
+							value={ attributes.header }
+							allowedFormats={ [] }
+						/>
+
+						<TextareaControl
+							className="crowdsignal-forms-feedback__input"
+							rows={ 6 }
+							onChange={ handleChangeAttribute( 'feedbackPlaceholder' ) }
+							value={ attributes.feedbackPlaceholder }
+						/>
+
+						<TextControl
+							className="crowdsignal-forms-feedback__input"
+							onChange={ handleChangeAttribute( 'emailPlaceholder' ) }
+							value={ attributes.emailPlaceholder }
+						/>
+
+						<div className="wp-block-button crowdsignal-forms-feedback__button-wrapper">
+							<RichText
+								className="wp-block-button__link crowdsignal-forms-nps__feedback-button"
+								onChange={ handleChangeAttribute(
+									'submitButtonLabel'
+								) }
+								value={ attributes.submitButtonLabel }
+								allowedFormats={ [] }
+								multiline={ false }
+								disableLineBreaks={ true }
+							/>
+						</div>
 					</div>
 				) }
 
-				{ 0 < position[ 0 ] && (
-					<button className="crowdsignal-forms-feedback__trigger-button"></button>
-				) }
+				<button className="crowdsignal-forms-feedback__trigger"></button>
 			</div>
 
 			{ props.renderStyleProbe() }

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -1,8 +1,13 @@
 /** Editor styles */
+
 .editor-styles-wrapper {
 
 	.wp-block[data-type="crowdsignal-forms/feedback"] {
 		width: auto;
+	}
+
+	.crowdsignal-forms-feedback__popover {
+		position: static;
 	}
 
 	.crowdsignal-forms-feedback {
@@ -35,18 +40,14 @@
 			padding-bottom: 60px;
 		}
 	}
-
-	.crowdsignal-forms-feedback__popover {
-		position: static;
-	}
-
-	.crowdsignal-forms-feedback__trigger {
-		position: absolute;
-	}
 }
 
-
 .crowdsignal-forms-feedback__trigger {
+
+	.editor-styles-wrapper & {
+		position: absolute;
+	}
+
 	.editor-styles-wrapper .crowdsignal-forms-feedback.align-left & {
 		left: 10px;
 	}

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -1,5 +1,4 @@
 /** Editor styles */
-
 .editor-styles-wrapper {
 
 	.wp-block[data-type="crowdsignal-forms/feedback"] {
@@ -7,6 +6,65 @@
 	}
 
 	.crowdsignal-forms-feedback {
+		justify-content: center;
+		margin: 0 !important;
+		padding: 20px;
+		position: relative;
+
+		&.align-left {
+			padding-left: 60px;
+		}
+
+		&.align-right {
+			padding-right: 60px;
+		}
+
+		&.vertical-align-top {
+			padding-top: 60px;
+		}
+
+		&.align-left.vertical-align-center {
+			padding-left: 70px;
+		}
+
+		&.align-right.vertical-align-center {
+			padding-right: 70px;
+		}
+
+		&.vertical-align-bottom {
+			padding-bottom: 60px;
+		}
+	}
+
+	.crowdsignal-forms-feedback__popover {
 		position: static;
+	}
+
+	.crowdsignal-forms-feedback__trigger {
+		position: absolute;
+	}
+}
+
+
+.crowdsignal-forms-feedback__trigger {
+	.editor-styles-wrapper .crowdsignal-forms-feedback.align-left & {
+		left: 10px;
+	}
+
+	.editor-styles-wrapper .crowdsignal-forms-feedback.align-right & {
+		right: 10px;
+	}
+
+	.editor-styles-wrapper .crowdsignal-forms-feedback.vertical-align-top & {
+		top: 0;
+	}
+
+	.editor-styles-wrapper .crowdsignal-forms-feedback.vertical-align-center & {
+		margin-top: -25px;
+		top: 50%;
+	}
+
+	.editor-styles-wrapper .crowdsignal-forms-feedback.vertical-align-bottom & {
+		bottom: 10px;
 	}
 }

--- a/client/blocks/feedback/sidebar.js
+++ b/client/blocks/feedback/sidebar.js
@@ -10,9 +10,7 @@ import {
 	Button,
 	ExternalLink,
 	PanelBody,
-	SelectControl,
 	TextControl,
-	DateTimePicker,
 } from '@wordpress/components';
 import { InspectorControls, PanelColorSettings } from '@wordpress/block-editor';
 import { decodeEntities } from '@wordpress/html-entities';

--- a/client/blocks/feedback/sidebar.js
+++ b/client/blocks/feedback/sidebar.js
@@ -1,0 +1,116 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	ExternalLink,
+	PanelBody,
+	SelectControl,
+	TextControl,
+	DateTimePicker,
+} from '@wordpress/components';
+import { InspectorControls, PanelColorSettings } from '@wordpress/block-editor';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import SidebarPromote from 'components/sidebar-promote';
+
+const Sidebar = ( {
+	attributes,
+	setAttributes,
+	shouldPromote,
+	signalWarning,
+} ) => {
+	const handleChangeTitle = ( title ) => setAttributes( { title } );
+
+	const resultsUrl = `https://app.crowdsignal.com/surveys/${ attributes.surveyId }/report/overview`;
+
+	const handleChangeAttribute = ( attribute ) => ( value ) =>
+		setAttributes( {
+			[ attribute ]: value,
+		} );
+
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={ __( 'Results', 'crowdsignal-forms' ) }
+				initialOpen={ true }
+			>
+				<p>
+					{ attributes.surveyId
+						? __( 'Manage results on ', 'crowdsignal-forms' )
+						: __(
+								'Save the block to track results on ',
+								'crowdsignal-forms'
+						  ) }
+					<ExternalLink
+						href={
+							attributes.surveyId
+								? resultsUrl
+								: 'https://www.crowdsignal.com'
+						}
+					>
+						crowdsignal.com
+					</ExternalLink>
+				</p>
+				<p>
+					<Button
+						isSecondary
+						disabled={ ! attributes.surveyId }
+						href={ resultsUrl }
+						target="blank"
+					>
+						{ __( 'View results', 'crowdsignal-forms' ) }
+					</Button>
+				</p>
+
+				<TextControl
+					label={ __( 'Title (optional)', 'crowdsignal-forms' ) }
+					onChange={ handleChangeTitle }
+					value={ decodeEntities(
+						attributes.title ?? attributes.ratingQuestion
+					) }
+				/>
+				{ shouldPromote && (
+					<SidebarPromote signalWarning={ signalWarning } />
+				) }
+			</PanelBody>
+			<PanelColorSettings
+				title={ __( 'Block styling', 'crowdsignal-forms' ) }
+				initialOpen={ false }
+				colorSettings={ [
+					{
+						label: __( 'Background color', 'crowdsignal-forms' ),
+						onChange: handleChangeAttribute( 'backgroundColor' ),
+						value: attributes.backgroundColor,
+					},
+					{
+						label: __( 'Text color', 'crowdsignal-forms' ),
+						onChange: handleChangeAttribute( 'textColor' ),
+						value: attributes.textColor,
+					},
+					{
+						label: __( 'Button color', 'crowdsignal-forms' ),
+						onChange: handleChangeAttribute( 'buttonColor' ),
+						value: attributes.buttonColor,
+					},
+					{
+						label: __( 'Button text color', 'crowdsignal-forms' ),
+						onChange: handleChangeAttribute( 'buttonTextColor' ),
+						value: attributes.buttonTextColor,
+					},
+				] }
+			/>
+		</InspectorControls>
+	);
+};
+
+export default Sidebar;

--- a/client/blocks/feedback/toolbar.js
+++ b/client/blocks/feedback/toolbar.js
@@ -27,32 +27,44 @@ const FeedbackToolbar = ( { onChangePosition } ) => {
 					{ showPosition && (
 						<Popover onClose={ hidePositionPopover }>
 							<Button
-								onClick={ () => onChangePosition( 'left', 'top' ) }
+								onClick={ () =>
+									onChangePosition( 'left', 'top' )
+								}
 							>
 								Top Left
 							</Button>
 							<Button
-								onClick={ () => onChangePosition( 'left', 'center' ) }
+								onClick={ () =>
+									onChangePosition( 'left', 'center' )
+								}
 							>
 								Center Left
 							</Button>
 							<Button
-								onClick={ () => onChangePosition( 'left', 'bottom' ) }
+								onClick={ () =>
+									onChangePosition( 'left', 'bottom' )
+								}
 							>
 								Bottom left
 							</Button>
 							<Button
-								onClick={ () => onChangePosition( 'right', 'top' ) }
+								onClick={ () =>
+									onChangePosition( 'right', 'top' )
+								}
 							>
 								Top right
 							</Button>
 							<Button
-								onClick={ () => onChangePosition( 'right', 'center' ) }
+								onClick={ () =>
+									onChangePosition( 'right', 'center' )
+								}
 							>
 								Center right
 							</Button>
 							<Button
-								onClick={ () => onChangePosition( 'right', 'bottom' ) }
+								onClick={ () =>
+									onChangePosition( 'right', 'bottom' )
+								}
 							>
 								Bottom right
 							</Button>

--- a/client/blocks/feedback/toolbar.js
+++ b/client/blocks/feedback/toolbar.js
@@ -27,32 +27,32 @@ const FeedbackToolbar = ( { onChangePosition } ) => {
 					{ showPosition && (
 						<Popover onClose={ hidePositionPopover }>
 							<Button
-								onClick={ () => onChangePosition( [ -1, 1 ] ) }
+								onClick={ () => onChangePosition( 'left', 'top' ) }
 							>
 								Top Left
 							</Button>
 							<Button
-								onClick={ () => onChangePosition( [ -1, 0 ] ) }
+								onClick={ () => onChangePosition( 'left', 'center' ) }
 							>
 								Center Left
 							</Button>
 							<Button
-								onClick={ () => onChangePosition( [ -1, -1 ] ) }
+								onClick={ () => onChangePosition( 'left', 'bottom' ) }
 							>
 								Bottom left
 							</Button>
 							<Button
-								onClick={ () => onChangePosition( [ 1, 1 ] ) }
+								onClick={ () => onChangePosition( 'right', 'top' ) }
 							>
 								Top right
 							</Button>
 							<Button
-								onClick={ () => onChangePosition( [ 1, 0 ] ) }
+								onClick={ () => onChangePosition( 'right', 'center' ) }
 							>
 								Center right
 							</Button>
 							<Button
-								onClick={ () => onChangePosition( [ 1, -1 ] ) }
+								onClick={ () => onChangePosition( 'right', 'bottom' ) }
 							>
 								Bottom right
 							</Button>

--- a/client/blocks/feedback/util.js
+++ b/client/blocks/feedback/util.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { kebabCase, mapKeys } from 'lodash';
+
+export const getStyleVars = ( attributes, fallbackStyles ) =>
+	mapKeys(
+		{
+			backgroundColor: attributes.backgroundColor || '#ffffff',
+			buttonColor: attributes.buttonColor || fallbackStyles.accentColor,
+			buttonTextColor:
+				attributes.buttonTextColor || fallbackStyles.textColorInverted,
+			textColor: attributes.textColor || fallbackStyles.textColor,
+			textSize: fallbackStyles.textSize,
+		},
+		( _, key ) => `--crowdsignal-forms-${ kebabCase( key ) }`
+	);

--- a/client/blocks/nps/edit.scss
+++ b/client/blocks/nps/edit.scss
@@ -57,3 +57,7 @@
 		display: none;
 	}
 }
+
+.editor-styles-wrapper .crowdsignal-forms-feedback__header {
+	color: var(--crowdsignal-forms-text-color);
+}

--- a/client/components/feedback/index.js
+++ b/client/components/feedback/index.js
@@ -23,7 +23,7 @@ const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 	const toggleDialog = () => setActive( ! active );
 
 	const classes = classnames(
-		'crowdsignal-forms-feedback', 
+		'crowdsignal-forms-feedback',
 		getAlignmentClassNames( attributes.x, attributes.y )
 	);
 
@@ -60,7 +60,6 @@ const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 							>
 								{ attributes.submitButtonLabel }
 							</button>
-
 						</div>
 					</div>
 				) }
@@ -68,8 +67,7 @@ const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 				<button
 					className="crowdsignal-forms-feedback__trigger"
 					onClick={ toggleDialog }
-				>
-				</button>
+				/>
 			</div>
 
 			{ renderStyleProbe() }

--- a/client/components/feedback/index.js
+++ b/client/components/feedback/index.js
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import React, { useState } from 'react';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { RichText } from '@wordpress/block-editor';
+import { TextControl, TextareaControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { getStyleVars } from 'blocks/feedback/util';
+import { withFallbackStyles } from 'components/with-fallback-styles';
+import { getAlignmentClassNames } from './util';
+
+const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
+	const [ active, setActive ] = useState( false );
+
+	const toggleDialog = () => setActive( ! active );
+
+	const classes = classnames(
+		'crowdsignal-forms-feedback', 
+		getAlignmentClassNames( attributes.x, attributes.y )
+	);
+
+	return (
+		<>
+			<div
+				className={ classes }
+				style={ getStyleVars( attributes, fallbackStyles ) }
+			>
+				{ active && (
+					<div className="crowdsignal-forms-feedback__popover">
+						<RichText.Content
+							tagName="h3"
+							className="crowdsignal-forms-feedback__header"
+							value={ attributes.header }
+						/>
+
+						<TextareaControl
+							className="crowdsignal-forms-feedback__input"
+							rows={ 6 }
+							placeholder={ attributes.feedbackPlaceholder }
+							value={ '' }
+						/>
+
+						<TextControl
+							className="crowdsignal-forms-feedback__input"
+							placeholder={ attributes.emailPlaceholder }
+						/>
+
+						<div className="wp-block-button crowdsignal-forms-feedback__button-wrapper">
+							<button
+								className="wp-block-button__link crowdsignal-forms-nps__feedback-button"
+								type="button"
+							>
+								{ attributes.submitButtonLabel }
+							</button>
+
+						</div>
+					</div>
+				) }
+
+				<button
+					className="crowdsignal-forms-feedback__trigger"
+					onClick={ toggleDialog }
+				>
+				</button>
+			</div>
+
+			{ renderStyleProbe() }
+		</>
+	);
+};
+
+export default withFallbackStyles( Feedback );

--- a/client/components/feedback/index.js
+++ b/client/components/feedback/index.js
@@ -55,7 +55,7 @@ const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 
 						<div className="wp-block-button crowdsignal-forms-feedback__button-wrapper">
 							<button
-								className="wp-block-button__link crowdsignal-forms-nps__feedback-button"
+								className="wp-block-button__link crowdsignal-forms-feedback__feedback-button"
 								type="button"
 							>
 								{ attributes.submitButtonLabel }

--- a/client/components/feedback/popover.js
+++ b/client/components/feedback/popover.js
@@ -1,3 +1,0 @@
-/**
- * External dependencies
- */

--- a/client/components/feedback/popover.js
+++ b/client/components/feedback/popover.js
@@ -1,0 +1,3 @@
+/**
+ * External dependencies
+ */

--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -1,5 +1,4 @@
-.crowdsignal-forms-feedback {
-}
+/** Public styles */
 
 .crowdsignal-forms-feedback__trigger {
 	border-radius: 25px;
@@ -19,14 +18,6 @@
 		right: 20px;
 	}
 
-	.crowdsignal-forms-feedback.vertical-align-top & {
-		top: 20px;
-
-		.admin-bar & {
-			top: 52px;
-		}
-	}
-
 	.crowdsignal-forms-feedback.vertical-align-center & {
 		margin-top: -25px;
 		top: 50%;
@@ -34,6 +25,14 @@
 
 	.crowdsignal-forms-feedback.vertical-align-bottom & {
 		bottom: 20px;
+	}
+
+	.crowdsignal-forms-feedback.vertical-align-top & {
+		top: 20px;
+
+		.admin-bar & {
+			top: 52px;
+		}
 	}
 }
 
@@ -57,20 +56,20 @@
 		right: 70px;
 	}
 
-	.crowdsignal-forms-feedback.vertical-align-top & {
-		top: 70px;
-
-		.admin-bar & {
-			top: 102px;
-		}
-	}
-
 	.crowdsignal-forms-feedback.vertical-align-center & {
 		top: 50%;
 	}
 
 	.crowdsignal-forms-feedback.vertical-align-bottom & {
 		bottom: 70px;
+	}
+
+	.crowdsignal-forms-feedback.vertical-align-top & {
+		top: 70px;
+
+		.admin-bar & {
+			top: 102px;
+		}
 	}
 }
 

--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -1,26 +1,96 @@
 .crowdsignal-forms-feedback {
-	display: flex;
-	flex-direction: row;
-	justify-content: flex-start;
-	position: fixed;
+}
 
-	&.align-left {
+.crowdsignal-forms-feedback__trigger {
+	border-radius: 25px;
+	box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.3);
+	cursor: pointer;
+	height: 50px;
+	outline: 0;
+	position: fixed;
+	width: 50px;
+	z-index: 100;
+
+	.crowdsignal-forms-feedback.align-left & {
 		left: 20px;
 	}
 
-	&.align-right {
-		justify-content: flex-end;
+	.crowdsignal-forms-feedback.align-right & {
 		right: 20px;
 	}
 
-	&.align-top {
+	.crowdsignal-forms-feedback.vertical-align-top & {
 		top: 20px;
+
+		.admin-bar & {
+			top: 52px;
+		}
 	}
 
-	&.align-bottom {
-		align-items: flex-end;
+	.crowdsignal-forms-feedback.vertical-align-center & {
+		margin-top: -25px;
+		top: 50%;
+	}
+
+	.crowdsignal-forms-feedback.vertical-align-bottom & {
 		bottom: 20px;
 	}
+}
+
+.crowdsignal-forms-feedback__popover {
+	background-color: var(--crowdsignal-forms-background-color);
+	border-bottom-left-radius: 10px;
+	border-bottom-right-radius: 10px;
+	border-top: 10px solid var(--crowdsignal-forms-button-color);
+	box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.3);
+	color: var(--crowdsignal-forms-background-color);
+	padding: 24px;
+	position: fixed;
+	width: 380px;
+	z-index: 100;
+
+	.crowdsignal-forms-feedback.align-left & {
+		left: 70px;
+	}
+
+	.crowdsignal-forms-feedback.align-right & {
+		right: 70px;
+	}
+
+	.crowdsignal-forms-feedback.vertical-align-top & {
+		top: 70px;
+
+		.admin-bar & {
+			top: 102px;
+		}
+	}
+
+	.crowdsignal-forms-feedback.vertical-align-center & {
+		top: 50%;
+	}
+
+	.crowdsignal-forms-feedback.vertical-align-bottom & {
+		bottom: 70px;
+	}
+}
+
+.crowdsignal-forms-feedback__header {
+	color: var(--crowdsignal-forms-text-color);
+	margin-top: 0 !important;
+	margin-bottom: 32px !important;
+}
+
+.crowdsignal-forms-feedback__input {
+	margin-top: 16px;
+	font-size: var(--crowdsignal-forms-text-size);
+	width: 100%;
+}
+
+.crowdsignal-forms-feedback__button-wrapper {
+	display: flex;
+	justify-content: flex-end;
+	margin-top: 35px;
+	width: 100%;
 }
 
 .crowdsignal-forms-feedback__trigger-button {
@@ -29,10 +99,4 @@
 	box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.3);
 	height: 50px;
 	width: 50px;
-}
-
-.crowdsignal-forms-feedback__popover {
-	background-color: #fff;
-	border: 1px solid #000;
-	padding: 20px;
 }

--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -99,3 +99,7 @@
 	height: 50px;
 	width: 50px;
 }
+
+.crowdsignal-forms-feedback__feedback-button {
+	background-color: var(--crowdsignal-forms-button-color) !important;
+}

--- a/client/components/feedback/util.js
+++ b/client/components/feedback/util.js
@@ -1,6 +1,3 @@
 export const getAlignmentClassNames = ( x, y ) => {
-	return [
-		`align-${ x }`,
-		`vertical-align-${ y }`,
-	];
+	return [ `align-${ x }`, `vertical-align-${ y }` ];
 };

--- a/client/components/feedback/util.js
+++ b/client/components/feedback/util.js
@@ -1,0 +1,6 @@
+export const getAlignmentClassNames = ( x, y ) => {
+	return [
+		`align-${ x }`,
+		`vertical-align-${ y }`,
+	];
+};

--- a/client/components/with-fixed-position/index.js
+++ b/client/components/with-fixed-position/index.js
@@ -49,14 +49,15 @@ export const withFixedPosition = ( BlockListBlock ) => {
 			...get( props, [ 'wrapperProps', 'style' ], {} ),
 			...offset,
 			position: ! isEmpty( offset ) ? 'fixed' : null,
+			margin: 0,
 		};
 
-		props.wrapperProps = {
+		const wrapperProps = {
 			...props.wrapperProps,
 			style,
 		};
 
-		return <BlockListBlock { ...props } />;
+		return <BlockListBlock { ...props } wrapperProps={ wrapperProps } />;
 	};
 };
 

--- a/client/feedback.js
+++ b/client/feedback.js
@@ -1,2 +1,14 @@
-// eslint-disable-next-line no-console
-console.log( 'Hello world!' );
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Feedback from 'components/feedback';
+import MutationObserver from 'lib/mutation-observer';
+
+MutationObserver( 'data-crowdsignal-feedback', ( attributes ) => (
+	<Feedback attributes={ attributes } />
+) );

--- a/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
@@ -27,7 +27,7 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 	 * {@inheritDoc}
 	 */
 	public function asset_identifier() {
-		return 'crowdsignal-forms-nps';
+		return 'crowdsignal-forms-feedback';
 	}
 
 	/**
@@ -71,7 +71,7 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 		wp_enqueue_style( $this->asset_identifier() );
 
 		$attributes['hideBranding'] = $this->should_hide_branding();
-		$attributes['isPreview']    = is_preview();
+		// $attributes['isPreview']    = is_preview();
 
 		return sprintf(
 			'<div class="crowdsignal-feedback-wrapper" data-crowdsignal-feedback="%s"></div>',
@@ -80,7 +80,7 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 	}
 
 	/**
-	 * Determines if the NPS block should be rendered or not.
+	 * Determines if the Feedback block should be rendered or not.
 	 *
 	 * @return bool
 	 */
@@ -92,23 +92,59 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 	 * Returns the attributes definition array for register_block_type
 	 *
 	 * Note: Any changes to the array returned by this function need to be
-	 *       duplicated in client/blocks/nps/attributes.js.
+	 *       duplicated in client/blocks/feedback/attributes.js.
 	 *
 	 * @return array
 	 */
 	private function attributes() {
 		return array(
-			'hideBranding' => array(
+			'backgroundColor'	  => array(
+				'type' => 'string',
+			),
+			'buttonColor'		  => array(
+				'type' => 'string',
+			),
+			'buttonTextColor'	  => array(
+				'type' => 'string',
+			),
+			'emailPlaceholder'	  => array(
+				'type' 	  => 'string',
+				'default' => __( 'Your email (optional)', 'crowdsignal-forms' ),
+			),
+			'feedbackPlaceholder' => array(
+				'type' 	  => 'string',
+				'default' => __( 'Please let us know how we can do better...', 'crowdsignal-forms' ),
+			),
+			'header'			  => array(
+				'type' 	  => 'string',
+				'default' => __( 'Hello there!', 'crowdsignal-forms' ),
+			),
+			'hideBranding'		  => array(
 				'type'    => 'boolean',
 				'default' => false,
 			),
-			'surveyId'     => array(
+			'submitButtonLabel'	  => array(
+				'type' 	  => 'string',
+				'default' => __( 'Submit', 'crowdsignal-forms' ),
+			),
+			'surveyId'			  => array(
 				'type'    => 'number',
 				'default' => null,
 			),
-			'title'        => array(
+			'textColor'			  => array(
+				'type' => 'string',
+			),
+			'title'				  => array(
 				'type'    => 'string',
 				'default' => '',
+			),
+			'x'					  => array(
+				'type'	  => 'string',
+				'default' => 'right',
+			),
+			'y'					  => array(
+				'type'	  => 'string',
+				'default' => 'bottom',
 			),
 		);
 	}

--- a/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
@@ -71,7 +71,6 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 		wp_enqueue_style( $this->asset_identifier() );
 
 		$attributes['hideBranding'] = $this->should_hide_branding();
-		// $attributes['isPreview']    = is_preview();
 
 		return sprintf(
 			'<div class="crowdsignal-feedback-wrapper" data-crowdsignal-feedback="%s"></div>',
@@ -98,52 +97,52 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 	 */
 	private function attributes() {
 		return array(
-			'backgroundColor'	  => array(
+			'backgroundColor'     => array(
 				'type' => 'string',
 			),
-			'buttonColor'		  => array(
+			'buttonColor'         => array(
 				'type' => 'string',
 			),
-			'buttonTextColor'	  => array(
+			'buttonTextColor'     => array(
 				'type' => 'string',
 			),
-			'emailPlaceholder'	  => array(
-				'type' 	  => 'string',
+			'emailPlaceholder'    => array(
+				'type'    => 'string',
 				'default' => __( 'Your email (optional)', 'crowdsignal-forms' ),
 			),
 			'feedbackPlaceholder' => array(
-				'type' 	  => 'string',
-				'default' => __( 'Please let us know how we can do better...', 'crowdsignal-forms' ),
+				'type'    => 'string',
+				'default' => __( 'Please let us know how we can do better…', 'crowdsignal-forms' ),
 			),
-			'header'			  => array(
-				'type' 	  => 'string',
+			'header'              => array(
+				'type'    => 'string',
 				'default' => __( 'Hello there!', 'crowdsignal-forms' ),
 			),
-			'hideBranding'		  => array(
+			'hideBranding'        => array(
 				'type'    => 'boolean',
 				'default' => false,
 			),
-			'submitButtonLabel'	  => array(
-				'type' 	  => 'string',
+			'submitButtonLabel'   => array(
+				'type'    => 'string',
 				'default' => __( 'Submit', 'crowdsignal-forms' ),
 			),
-			'surveyId'			  => array(
+			'surveyId'            => array(
 				'type'    => 'number',
 				'default' => null,
 			),
-			'textColor'			  => array(
+			'textColor'           => array(
 				'type' => 'string',
 			),
-			'title'				  => array(
+			'title'               => array(
 				'type'    => 'string',
 				'default' => '',
 			),
-			'x'					  => array(
-				'type'	  => 'string',
+			'x'                   => array(
+				'type'    => 'string',
 				'default' => 'right',
 			),
-			'y'					  => array(
-				'type'	  => 'string',
+			'y'                   => array(
+				'type'    => 'string',
 				'default' => 'bottom',
 			),
 		);

--- a/includes/frontend/class-crowdsignal-forms-blocks.php
+++ b/includes/frontend/class-crowdsignal-forms-blocks.php
@@ -45,6 +45,7 @@ class Crowdsignal_Forms_Blocks {
 			new Blocks\Crowdsignal_Forms_Vote_Item_Block(),
 			new Blocks\Crowdsignal_Forms_Applause_Block(),
 			new Blocks\Crowdsignal_Forms_Nps_Block(),
+			new Blocks\Crowdsignal_Forms_Feedback_Block(),
 		);
 
 		return self::$blocks;


### PR DESCRIPTION
This patch implements the feedback question view as well as the basic color settings to control it. You should be able to edit any text/color of the popup.

Solves c/qA8oB2p8-tr and c/8dZT9xDQ-tr.

![Screen Shot 2021-04-01 at 10 52 06 PM](https://user-images.githubusercontent.com/8056203/113354862-1d146d00-9340-11eb-9894-31fc08a8a31e.png)

I did try to improve the positioning inside the editor and the page a little - the corners should work ok now but the vertically centered one is still a bit wonky. I have a feeling CSS is probably the wrong approach here so I'll need to add a JS solution and do things a little different.  
For the editor, I'm almost satisfied except the script should take into account the popup's height when using vertically centered position. For the page, the idea would be to position the 'trigger' dynamically (so we can more easily accommodate different sizes in the future) and then have the popover be an actual popover placed relatively to the trigger rather than the page. The editor and the page have unique behaviors but they also don't share components which is why this approach actually makes sense.

# Testing

Apply the patch and add a feedback block to your post. You should be able to edit the header, feedback and email placeholders, and the submit button label.  
You should also be able to edit the block colors by opening the "Color Settings" in the sidebar.

Save the post and open the preview - make sure the block reflects your selected settings.