### PR TITLE
Fix signal warning layout

### DIFF
--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -160,7 +160,22 @@ const EditNpsBlock = ( props ) => {
 			) }
 
 			{ ! isExample && (
-				<EditorNotice isDismissible={ false } icon="visibility">
+				<EditorNotice
+					isDismissible={ false }
+					icon="visibility"
+					componentActions={ [
+						<PostPreviewButton
+							key={ 1 }
+							className={ [
+								'is-secondary',
+								'components-notice__action',
+								'crowdsignal-forms-nps__preview-button',
+								attributes.surveyId ? '' : 'is-disabled',
+							] }
+							textContent={ __( 'Preview', 'crowdsignal-forms' ) }
+						/>,
+					] }
+				>
 					{ sprintf(
 						// translators: %d: number of pageviews
 						_n(
@@ -171,16 +186,6 @@ const EditNpsBlock = ( props ) => {
 						),
 						viewThreshold
 					) }
-
-					<PostPreviewButton
-						className={ [
-							'is-secondary',
-							'components-notice__action',
-							'crowdsignal-forms-nps__preview-button',
-							attributes.surveyId ? '' : 'is-disabled',
-						] }
-						textContent={ __( 'Preview', 'crowdsignal-forms' ) }
-					/>
 				</EditorNotice>
 			) }
 

--- a/client/components/editor-notice/index.js
+++ b/client/components/editor-notice/index.js
@@ -3,9 +3,12 @@
  */
 import { Notice, Icon } from '@wordpress/components';
 
-const EditorNotice = ( { icon, children, ...props } ) => {
-	const [ text, ...actions ] = children;
-
+const EditorNotice = ( {
+	icon,
+	children,
+	componentActions = [],
+	...props
+} ) => {
 	return (
 		<Notice className="crowdsignal-forms__editor-notice" { ...props }>
 			{ icon && (
@@ -14,10 +17,9 @@ const EditorNotice = ( { icon, children, ...props } ) => {
 				</div>
 			) }
 			<div className="crowdsignal-forms__editor-notice-text">
-				{ text }
+				{ children }
 			</div>
-
-			{ actions }
+			{ componentActions.map( ( component ) => component ) }
 		</Notice>
 	);
 };

--- a/client/components/editor-notice/style.scss
+++ b/client/components/editor-notice/style.scss
@@ -15,6 +15,7 @@
 
 .crowdsignal-forms__editor-notice-text {
 	flex-grow: 1;
+	color: var(--global--color-primary);
 
 	a {
 		text-decoration: underline;


### PR DESCRIPTION
This PR addresses an issue when the signal warning is rendered. The problem mostly happens because we use [Notice](https://github.com/WordPress/gutenberg/tree/trunk/packages/components/src/notice) default behavior (providing action buttons through an array) mixed with our need to use PostPreviewButton on one of the notices, which has its own behavior to build and open the preview URL.

The changes include a new prop for our EditorNotice: `componentActions` which behaves like the Notice's `actions` prop but assumes the items of the array to be components instead of objects to compose a button from.

## Test instructions
Confirm the issue before testing: when linked to a free Crowdsignal account with signals exhausted, the signal warning looks like this:
![image](https://user-images.githubusercontent.com/157240/113929882-f1bdd200-97c6-11eb-9581-2cad9e2ef7e6.png)

Checkout and `make client`. See that the notice renders properly:
![image](https://user-images.githubusercontent.com/157240/113930360-8de7d900-97c7-11eb-8cde-53d878b23f12.png)
