### PR TITLE
Add free signal notices

### DIFF
--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -12,6 +12,7 @@ import { RichText } from '@wordpress/block-editor';
 import { TextControl, TextareaControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withSelect, dispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -25,6 +26,8 @@ import Toolbar from './toolbar';
 import { getStyleVars } from './util';
 import { useAutosave } from 'components/use-autosave';
 import { updateFeedback } from 'data/feedback/edit';
+import SignalWarning from 'components/signal-warning';
+import EditorNotice from 'components/editor-notice';
 
 // Probably dependent on the button style
 const PADDING = 20;
@@ -112,7 +115,7 @@ const EditFeedbackBlock = ( props ) => {
 		title,
 	} = attributes;
 
-	const { save: saveBlock } = useAutosave(
+	const { error: saveError, save: saveBlock } = useAutosave(
 		async ( data ) => {
 			dispatch( 'core/editor' ).lockPostSaving( clientId );
 
@@ -209,6 +212,31 @@ const EditFeedbackBlock = ( props ) => {
 							onClick={ toggleBlock }
 						/>
 						<div className="crowdsignal-forms-feedback__popover">
+							{ ! isExample && signalWarning && (
+								<SignalWarning />
+							) }
+							{ ! isExample && saveError && (
+								<EditorNotice
+									status="error"
+									icon="warning"
+									isDismissible={ false }
+									actions={ [
+										{
+											className: 'is-destructive',
+											label: __(
+												'Retry',
+												'crowdsignal-forms'
+											),
+											onClick: saveBlock,
+										},
+									] }
+								>
+									{ __(
+										`Unfortunately, the block couldn't be saved to Crowdsignal.com.`,
+										'crowdsignal-forms'
+									) }
+								</EditorNotice>
+							) }
 							<RichText
 								tagName="h3"
 								className="crowdsignal-forms-feedback__header"

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -202,29 +202,6 @@ const EditFeedbackBlock = ( props ) => {
 				className={ classes }
 				style={ getStyleVars( attributes, fallbackStyles ) }
 			>
-				{ isSelected && ! isExample && signalWarning && (
-					<SignalWarning />
-				) }
-				{ isSelected && ! isExample && saveError && (
-					<EditorNotice
-						status="error"
-						icon="warning"
-						isDismissible={ false }
-						actions={ [
-							{
-								className: 'is-destructive',
-								label: __( 'Retry', 'crowdsignal-forms' ),
-								onClick: saveBlock,
-							},
-						] }
-					>
-						{ __(
-							`Unfortunately, the block couldn't be saved to Crowdsignal.com.`,
-							'crowdsignal-forms'
-						) }
-					</EditorNotice>
-				) }
-
 				{ isSelected && (
 					<>
 						{ /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */ }
@@ -234,32 +211,30 @@ const EditFeedbackBlock = ( props ) => {
 							className="crowdsignal-forms-feedback__popover-overlay"
 							onClick={ toggleBlock }
 						/>
+						{ ! isExample && signalWarning && <SignalWarning /> }
+						{ ! isExample && saveError && (
+							<EditorNotice
+								status="error"
+								icon="warning"
+								isDismissible={ false }
+								actions={ [
+									{
+										className: 'is-destructive',
+										label: __(
+											'Retry',
+											'crowdsignal-forms'
+										),
+										onClick: saveBlock,
+									},
+								] }
+							>
+								{ __(
+									`Unfortunately, the block couldn't be saved to Crowdsignal.com.`,
+									'crowdsignal-forms'
+								) }
+							</EditorNotice>
+						) }
 						<div className="crowdsignal-forms-feedback__popover">
-							{ ! isExample && signalWarning && (
-								<SignalWarning />
-							) }
-							{ ! isExample && saveError && (
-								<EditorNotice
-									status="error"
-									icon="warning"
-									isDismissible={ false }
-									actions={ [
-										{
-											className: 'is-destructive',
-											label: __(
-												'Retry',
-												'crowdsignal-forms'
-											),
-											onClick: saveBlock,
-										},
-									] }
-								>
-									{ __(
-										`Unfortunately, the block couldn't be saved to Crowdsignal.com.`,
-										'crowdsignal-forms'
-									) }
-								</EditorNotice>
-							) }
 							<RichText
 								tagName="h3"
 								className="crowdsignal-forms-feedback__header"

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -202,6 +202,29 @@ const EditFeedbackBlock = ( props ) => {
 				className={ classes }
 				style={ getStyleVars( attributes, fallbackStyles ) }
 			>
+				{ isSelected && ! isExample && signalWarning && (
+					<SignalWarning />
+				) }
+				{ isSelected && ! isExample && saveError && (
+					<EditorNotice
+						status="error"
+						icon="warning"
+						isDismissible={ false }
+						actions={ [
+							{
+								className: 'is-destructive',
+								label: __( 'Retry', 'crowdsignal-forms' ),
+								onClick: saveBlock,
+							},
+						] }
+					>
+						{ __(
+							`Unfortunately, the block couldn't be saved to Crowdsignal.com.`,
+							'crowdsignal-forms'
+						) }
+					</EditorNotice>
+				) }
+
 				{ isSelected && (
 					<>
 						{ /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */ }

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -55,6 +55,12 @@
 		&.vertical-align-bottom {
 			padding-bottom: 60px;
 		}
+
+		.crowdsignal-forms__editor-notice {
+			// this width must match the width of
+			// .crowdsignal-forms-feedback__popover on components/feedback/style.scss
+			width: 380px;
+		}
 	}
 }
 

--- a/client/components/editor-notice/style.scss
+++ b/client/components/editor-notice/style.scss
@@ -15,7 +15,7 @@
 
 .crowdsignal-forms__editor-notice-text {
 	flex-grow: 1;
-	color: var(--global--color-primary);
+	color: var(--crowdsignal-forms-text-color);
 
 	a {
 		text-decoration: underline;


### PR DESCRIPTION
This PR adds the notices we use for exhausted signals and errors while trying to sync to the Crowdsignal platform

## Test instructions
Checkout the branch and run `make client`

Use a free account with signals exhausted.

Insert a Feedback block. You should see the signal warning when you open the popup.

Disconnect, then make a change on the Feedback block settings. After 3 attempts (around 10-15 seconds) the sync error should appear on the popup. Connect again and hit the "Retry" button. Confirm your changes successfully synced by checking your dashboard.