### PR TITLE
Add a backdrop behind the feedback block when selected inside the editor

### DIFF
--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -201,7 +201,7 @@ const EditFeedbackBlock = ( props ) => {
 			>
 				{ isSelected && (
 					<>
-						// eslint-disable-next-line
+						{ /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */ }
 						<div
 							aria-modal="true"
 							role="dialog"

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -165,6 +165,9 @@ const EditFeedbackBlock = ( props ) => {
 
 	const setPosition = ( x, y ) => setAttributes( { x, y } );
 
+	const toggleBlock = () =>
+		dispatch( 'core/block-editor' ).clearSelectedBlock();
+
 	const handleChangeAttribute = ( key ) => ( value ) =>
 		setAttributes( { [ key ]: value } );
 
@@ -197,45 +200,54 @@ const EditFeedbackBlock = ( props ) => {
 				style={ getStyleVars( attributes, fallbackStyles ) }
 			>
 				{ isSelected && (
-					<div className="crowdsignal-forms-feedback__popover">
-						<RichText
-							tagName="h3"
-							className="crowdsignal-forms-feedback__header"
-							onChange={ handleChangeAttribute( 'header' ) }
-							value={ attributes.header }
-							allowedFormats={ [] }
+					<>
+						// eslint-disable-next-line
+						<div
+							aria-modal="true"
+							role="dialog"
+							className="crowdsignal-forms-feedback__popover-overlay"
+							onClick={ toggleBlock }
 						/>
-
-						<TextareaControl
-							className="crowdsignal-forms-feedback__input"
-							rows={ 6 }
-							onChange={ handleChangeAttribute(
-								'feedbackPlaceholder'
-							) }
-							value={ attributes.feedbackPlaceholder }
-						/>
-
-						<TextControl
-							className="crowdsignal-forms-feedback__input"
-							onChange={ handleChangeAttribute(
-								'emailPlaceholder'
-							) }
-							value={ attributes.emailPlaceholder }
-						/>
-
-						<div className="wp-block-button crowdsignal-forms-feedback__button-wrapper">
+						<div className="crowdsignal-forms-feedback__popover">
 							<RichText
-								className="wp-block-button__link crowdsignal-forms-feedback__feedback-button"
-								onChange={ handleChangeAttribute(
-									'submitButtonLabel'
-								) }
-								value={ attributes.submitButtonLabel }
+								tagName="h3"
+								className="crowdsignal-forms-feedback__header"
+								onChange={ handleChangeAttribute( 'header' ) }
+								value={ attributes.header }
 								allowedFormats={ [] }
-								multiline={ false }
-								disableLineBreaks={ true }
 							/>
+
+							<TextareaControl
+								className="crowdsignal-forms-feedback__input"
+								rows={ 6 }
+								onChange={ handleChangeAttribute(
+									'feedbackPlaceholder'
+								) }
+								value={ attributes.feedbackPlaceholder }
+							/>
+
+							<TextControl
+								className="crowdsignal-forms-feedback__input"
+								onChange={ handleChangeAttribute(
+									'emailPlaceholder'
+								) }
+								value={ attributes.emailPlaceholder }
+							/>
+
+							<div className="wp-block-button crowdsignal-forms-feedback__button-wrapper">
+								<RichText
+									className="wp-block-button__link crowdsignal-forms-feedback__feedback-button"
+									onChange={ handleChangeAttribute(
+										'submitButtonLabel'
+									) }
+									value={ attributes.submitButtonLabel }
+									allowedFormats={ [] }
+									multiline={ false }
+									disableLineBreaks={ true }
+								/>
+							</div>
 						</div>
-					</div>
+					</>
 				) }
 
 				<button className="crowdsignal-forms-feedback__trigger"></button>

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -4,6 +4,22 @@
 
 	.wp-block[data-type="crowdsignal-forms/feedback"] {
 		width: auto;
+		// This number is was carefully chosen so the block and its overlay
+		// don't block any editor UI elements but appear in front of regular
+		// content
+		z-index: 10;
+	}
+
+	.crowdsignal-forms-feedback__popover-overlay {
+		background-color: rgba(0, 0, 0, 0.3);
+		content: "";
+		display: block;
+		position: fixed;
+		bottom: 25px;
+		left: 0;
+		right: 0;
+		top: 0;
+		z-index: -1;
 	}
 
 	.crowdsignal-forms-feedback__popover {

--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -1,6 +1,7 @@
 /** Public styles */
 
 .crowdsignal-forms-feedback__trigger {
+	border: 0;
 	border-radius: 25px;
 	box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.3);
 	cursor: pointer;


### PR DESCRIPTION
This patch adds a backdrop to isolate the block from the background whenever it's selected inside the editor.  
It also addresses the issue with content popping in front of the block.

Before:

![Screen Shot 2021-04-08 at 1 56 16 PM](https://user-images.githubusercontent.com/8056203/114022590-3783a480-9872-11eb-9adf-2a0f1524d85c.png)

After:

![Screen Shot 2021-04-08 at 1 40 22 PM](https://user-images.githubusercontent.com/8056203/114022544-29ce1f00-9872-11eb-9165-87225fa05f95.png)

# Testing

Verify the backdrop display correctly whenever the block is selected and clicking on it dismisses the block.