### PR TITLE
Update feedback block icons

### DIFF
--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -18,6 +18,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import ConnectToCrowdsignal from 'components/connect-to-crowdsignal';
+import SignalIcon from 'components/icon/signal';
 import { withFallbackStyles } from 'components/with-fallback-styles';
 import { getAlignmentClassNames } from 'components/feedback/util';
 import { useAccountInfo } from 'data/hooks';
@@ -276,7 +277,9 @@ const EditFeedbackBlock = ( props ) => {
 					</>
 				) }
 
-				<button className="crowdsignal-forms-feedback__trigger"></button>
+				<button className="crowdsignal-forms-feedback__trigger">
+					<SignalIcon />
+				</button>
 			</div>
 
 			{ props.renderStyleProbe() }

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -91,3 +91,19 @@
 		bottom: 10px;
 	}
 }
+
+.crowdsignal-forms-feedback__toolbar-popover-wrapper .components-popover__content {
+	min-width: auto !important;
+}
+
+.crowdsignal-forms-feedback__toolbar-popover {
+	display: grid;
+	grid-template-columns: min-content min-content;
+	grid-template-rows: auto auto;
+	padding: 2px;
+	width: fit-content;
+}
+
+.crowdsignal-forms-feedback__position-button {
+	width: fit-content;
+}

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -92,6 +92,10 @@
 	}
 }
 
+.crowdsignal-forms-feedback__toolbar-position-toggle svg {
+	margin-right: 0 !important;
+}
+
 .crowdsignal-forms-feedback__toolbar-popover-wrapper .components-popover__content {
 	min-width: auto !important;
 }

--- a/client/blocks/feedback/index.js
+++ b/client/blocks/feedback/index.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import PollIcon from 'components/icon/poll';
+import FeedbackIcon from 'components/icon/feedback';
 import attributes from './attributes';
 import EditFeedbackBlock from './edit';
 
@@ -15,7 +15,7 @@ export default {
 	description: __( 'Feedback block', 'crowdsignal-forms' ),
 	category: 'crowdsignal-forms',
 	keywords: [ 'crowdsignal', __( 'feedback', 'crowdsignal-forms' ) ],
-	icon: <PollIcon />,
+	icon: <FeedbackIcon />,
 	edit: EditFeedbackBlock,
 	supports: {
 		multiple: false,

--- a/client/blocks/feedback/toolbar.js
+++ b/client/blocks/feedback/toolbar.js
@@ -9,65 +9,83 @@ import React, { useState } from 'react';
 import { BlockControls } from '@wordpress/block-editor';
 import {
 	Button,
+	Icon,
 	Popover,
 	ToolbarButton,
 	ToolbarGroup,
 } from '@wordpress/components';
 
-const FeedbackToolbar = ( { onChangePosition } ) => {
+/**
+ * Internal dependencies
+ */
+import {
+	TopLeftPlacementIcon,
+	TopRightPlacementIcon,
+	BottomLeftPlacementIcon,
+	BottomRightPlacementIcon,
+} from 'components/icon/placement';
+
+const placementIcons = {
+	'top-left': TopLeftPlacementIcon,
+	'top-right': TopRightPlacementIcon,
+	'bottom-left': BottomLeftPlacementIcon,
+	'bottom-right': BottomRightPlacementIcon,
+};
+
+const FeedbackToolbar = ( { attributes, onChangePosition } ) => {
 	const [ showPosition, setShowPosition ] = useState( false );
 
 	const showPositionPopover = () => setShowPosition( true );
 	const hidePositionPopover = () => setShowPosition( false );
 
+	const { x, y } = attributes;
+
 	return (
 		<BlockControls>
 			<ToolbarGroup>
-				<ToolbarButton onClick={ showPositionPopover }>
+				<ToolbarButton
+					onClick={ showPositionPopover }
+					icon={ placementIcons[ `${ y }-${ x }` ] }
+				>
 					{ showPosition && (
-						<Popover onClose={ hidePositionPopover }>
-							<Button
-								onClick={ () =>
-									onChangePosition( 'left', 'top' )
-								}
-							>
-								Top Left
-							</Button>
-							<Button
-								onClick={ () =>
-									onChangePosition( 'left', 'center' )
-								}
-							>
-								Center Left
-							</Button>
-							<Button
-								onClick={ () =>
-									onChangePosition( 'left', 'bottom' )
-								}
-							>
-								Bottom left
-							</Button>
-							<Button
-								onClick={ () =>
-									onChangePosition( 'right', 'top' )
-								}
-							>
-								Top right
-							</Button>
-							<Button
-								onClick={ () =>
-									onChangePosition( 'right', 'center' )
-								}
-							>
-								Center right
-							</Button>
-							<Button
-								onClick={ () =>
-									onChangePosition( 'right', 'bottom' )
-								}
-							>
-								Bottom right
-							</Button>
+						<Popover
+							className="crowdsignal-forms-feedback__toolbar-popover-wrapper"
+							onClose={ hidePositionPopover }
+						>
+							<div className="crowdsignal-forms-feedback__toolbar-popover">
+								<Button
+									className="crowdsignal-forms-feedback__position-button"
+									onClick={ () =>
+										onChangePosition( 'left', 'top' )
+									}
+								>
+									<Icon icon={ TopLeftPlacementIcon } />
+								</Button>
+								<Button
+									className="crowdsignal-forms-feedback__position-button"
+									onClick={ () =>
+										onChangePosition( 'right', 'top' )
+									}
+								>
+									<Icon icon={ TopRightPlacementIcon } />
+								</Button>
+								<Button
+									className="crowdsignal-forms-feedback__position-button"
+									onClick={ () =>
+										onChangePosition( 'left', 'bottom' )
+									}
+								>
+									<Icon icon={ BottomLeftPlacementIcon } />
+								</Button>
+								<Button
+									className="crowdsignal-forms-feedback__position-button"
+									onClick={ () =>
+										onChangePosition( 'right', 'bottom' )
+									}
+								>
+									<Icon icon={ BottomRightPlacementIcon } />
+								</Button>
+							</div>
 						</Popover>
 					) }
 				</ToolbarButton>

--- a/client/blocks/feedback/toolbar.js
+++ b/client/blocks/feedback/toolbar.js
@@ -44,6 +44,7 @@ const FeedbackToolbar = ( { attributes, onChangePosition } ) => {
 		<BlockControls>
 			<ToolbarGroup>
 				<ToolbarButton
+					className="crowdsignal-forms-feedback__toolbar-position-toggle"
 					onClick={ showPositionPopover }
 					icon={ placementIcons[ `${ y }-${ x }` ] }
 				>

--- a/client/components/feedback/index.js
+++ b/client/components/feedback/index.js
@@ -14,6 +14,7 @@ import { TextControl, TextareaControl } from '@wordpress/components';
 /**
  * Internal dependencies
  */
+import SignalIcon from 'components/icon/signal';
 import { getStyleVars } from 'blocks/feedback/util';
 import { withFallbackStyles } from 'components/with-fallback-styles';
 import { getAlignmentClassNames } from './util';
@@ -89,7 +90,9 @@ const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 				<button
 					className="crowdsignal-forms-feedback__trigger"
 					onClick={ toggleDialog }
-				/>
+				>
+					<SignalIcon />
+				</button>
 			</div>
 
 			{ renderStyleProbe() }

--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -2,13 +2,14 @@
 
 .crowdsignal-forms-feedback__trigger {
 	border: 0;
-	border-radius: 25px;
+	border-radius: 50%;
 	box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.3);
 	cursor: pointer;
-	height: 50px;
+	height: 75px;
 	outline: 0;
+	padding: 0;
 	position: fixed;
-	width: 50px;
+	width: 75px;
 	z-index: 100;
 
 	.crowdsignal-forms-feedback.align-left & {

--- a/client/components/icon/feedback.js
+++ b/client/components/icon/feedback.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default () => (
+	<svg
+		width="24"
+		height="24"
+		viewBox="0 0 24 24"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<path
+			d="M18.5 4.5H4.5C4.22386 4.5 4 4.72386 4 5V19.5L6.70711 16.7929C6.89464 16.6054 7.149 16.5 7.41421 16.5H18.5C19.0523 16.5 19.5 16.0523 19.5 15.5V5.5C19.5 4.94772 19.0523 4.5 18.5 4.5Z"
+			stroke="black"
+			strokeWidth="1.5"
+			fill="none"
+		/>
+		<rect x="7" y="9.5" width="1.5" height="1.5" rx="0.75" fill="black" />
+		<rect x="11" y="9.5" width="1.5" height="1.5" rx="0.75" fill="black" />
+		<rect x="15" y="9.5" width="1.5" height="1.5" rx="0.75" fill="black" />
+	</svg>
+);

--- a/client/components/icon/placement.js
+++ b/client/components/icon/placement.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export const TopLeftPlacementIcon = () => (
+	<svg
+		width="24"
+		height="24"
+		viewBox="0 0 24 24"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<rect x="4.5" y="11.25" width="1.5" height="1.5" fill="black" />
+		<rect x="3.75" y="3.75" width="3" height="3" fill="black" />
+		<rect x="18" y="4.5" width="1.5" height="1.5" fill="black" />
+		<rect x="18" y="11.25" width="1.5" height="1.5" fill="black" />
+		<rect x="18" y="18" width="1.5" height="1.5" fill="black" />
+		<rect x="4.5" y="18" width="1.5" height="1.5" fill="black" />
+	</svg>
+);
+
+export const TopRightPlacementIcon = () => (
+	<svg
+		width="24"
+		height="24"
+		viewBox="0 0 24 24"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<rect x="4.5" y="11.25" width="1.5" height="1.5" fill="black" />
+		<rect x="4.5" y="4.5" width="1.5" height="1.5" fill="black" />
+		<rect x="17.25" y="3.75" width="3" height="3" fill="black" />
+		<rect x="18" y="11.25" width="1.5" height="1.5" fill="black" />
+		<rect x="18" y="18" width="1.5" height="1.5" fill="black" />
+		<rect x="4.5" y="18" width="1.5" height="1.5" fill="black" />
+	</svg>
+);
+
+export const BottomLeftPlacementIcon = () => (
+	<svg
+		width="24"
+		height="24"
+		viewBox="0 0 24 24"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<rect x="4.5" y="11.25" width="1.5" height="1.5" fill="black" />
+		<rect x="4.5" y="4.5" width="1.5" height="1.5" fill="black" />
+		<rect x="18" y="4.5" width="1.5" height="1.5" fill="black" />
+		<rect x="18" y="11.25" width="1.5" height="1.5" fill="black" />
+		<rect x="18" y="18" width="1.5" height="1.5" fill="black" />
+		<rect x="3.75" y="17.25" width="3" height="3" fill="black" />
+	</svg>
+);
+
+export const BottomRightPlacementIcon = () => (
+	<svg
+		width="24"
+		height="24"
+		viewBox="0 0 24 24"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<rect x="4.5" y="11.25" width="1.5" height="1.5" fill="black" />
+		<rect x="4.5" y="4.5" width="1.5" height="1.5" fill="black" />
+		<rect x="18" y="4.5" width="1.5" height="1.5" fill="black" />
+		<rect x="18" y="11.25" width="1.5" height="1.5" fill="black" />
+		<rect x="17.25" y="17.25" width="3" height="3" fill="black" />
+		<rect x="4.5" y="18" width="1.5" height="1.5" fill="black" />
+	</svg>
+);

--- a/client/components/icon/signal.js
+++ b/client/components/icon/signal.js
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default () => (
+	<svg
+		width="75"
+		height="75"
+		viewBox="0 0 75 75"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M37.5 74C57.6584 74 74 57.6584 74 37.5C74 17.3416 57.6584 1 37.5 1C17.3416 1 1 17.3416 1 37.5C1 57.6584 17.3416 74 37.5 74Z"
+			fill="white"
+		/>
+		<path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M37.5 69C54.897 69 69 54.897 69 37.5C69 20.103 54.897 6 37.5 6C20.103 6 6 20.103 6 37.5C6 54.897 20.103 69 37.5 69Z"
+			fill="white"
+			stroke="#001D2D"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			strokeDasharray="0.1 4"
+		/>
+		<path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M21.552 58.6638C33.2404 67.4717 49.856 65.1366 58.6639 53.4481C67.4718 41.7596 65.1366 25.1441 53.4482 16.3362C41.7597 7.52827 25.1441 9.86344 16.3362 21.5519C7.52835 33.2404 9.86352 49.8559 21.552 58.6638Z"
+			fill="white"
+			stroke="#001D2D"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			strokeDasharray="0.1 4"
+		/>
+		<path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M37.5 59C49.3741 59 59 49.3741 59 37.5C59 25.6259 49.3741 16 37.5 16C25.6259 16 16 25.6259 16 37.5C16 49.3741 25.6259 59 37.5 59Z"
+			fill="white"
+			stroke="#001D2D"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			strokeDasharray="0.1 4"
+		/>
+		<path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M37.5 54C46.6127 54 54 46.6127 54 37.5C54 28.3873 46.6127 21 37.5 21C28.3873 21 21 28.3873 21 37.5C21 46.6127 28.3873 54 37.5 54Z"
+			fill="white"
+			stroke="#001D2D"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			strokeDasharray="0.1 4"
+		/>
+		<path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M37.5 49C43.8513 49 49 43.8513 49 37.5C49 31.1487 43.8513 26 37.5 26C31.1487 26 26 31.1487 26 37.5C26 43.8513 31.1487 49 37.5 49Z"
+			fill="white"
+			stroke="#001D2D"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			strokeDasharray="0.1 4"
+		/>
+		<path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M37.5 44C38.5641 44 39.5686 43.7443 40.4552 43.2909C42.5595 42.2149 44 40.0257 44 37.5C44 33.9101 41.0898 31 37.5 31C33.9101 31 31 33.9101 31 37.5C31 41.0898 33.9101 44 37.5 44Z"
+			fill="#4CCEE4"
+		/>
+	</svg>
+);


### PR DESCRIPTION
This patch updates the feedback block with fresh icon for the block, trigger and the placement icons.  
For the placement icons, the icon in the toolbar should change according to the current block placement. I also removed the vertically centered options since they aren't quite so attractive with our current button option - as previously discussed with @digitalwaveride.

![Screen Shot 2021-04-12 at 9 02 06 PM](https://user-images.githubusercontent.com/8056203/114449328-e870a300-9bd4-11eb-88e1-dfc1df02f6d4.png)

The signal button icon is larger at 75px which affects the placement relative to the popover but I will be handling this separately as I'm redoing the whole positioning for the client side anyway.

# Testing

Verify the new icons are loading and show up as expected.