### PR TITLE
Add a submit view for the feedback block

### DIFF
--- a/client/blocks/feedback/attributes.js
+++ b/client/blocks/feedback/attributes.js
@@ -39,8 +39,12 @@ export default {
 		default: false,
 	},
 	submitButtonLabel: {
-		type: 'text',
+		type: 'string',
 		default: __( 'Submit', 'crowdsignal-forms' ),
+	},
+	submitText: {
+		type: 'string',
+		default: __( 'Thanks for letting us know!', 'crowdsignal-forms' ),
 	},
 	surveyId: {
 		type: 'number',

--- a/client/blocks/feedback/constants.js
+++ b/client/blocks/feedback/constants.js
@@ -1,0 +1,4 @@
+export const views = {
+	QUESTION: 'question',
+	SUBMIT: 'submit',
+};

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useLayoutEffect, useEffect } from 'react';
+import React, { useLayoutEffect, useEffect, useState } from 'react';
 import classnames from 'classnames';
 import { get } from 'lodash';
 
@@ -29,6 +29,7 @@ import { useAutosave } from 'components/use-autosave';
 import { updateFeedback } from 'data/feedback/edit';
 import SignalWarning from 'components/signal-warning';
 import EditorNotice from 'components/editor-notice';
+import { views } from './constants';
 
 // Probably dependent on the button style
 const PADDING = 20;
@@ -95,6 +96,8 @@ const getVerticalPadding = ( position ) => {
 };
 
 const EditFeedbackBlock = ( props ) => {
+	const [ view, setView ] = useState( views.QUESTION );
+
 	const {
 		attributes,
 		activeSidebar,
@@ -154,6 +157,14 @@ const EditFeedbackBlock = ( props ) => {
 		saveBlock();
 	}, [] );
 
+	useEffect( () => {
+		if ( isSelected ) {
+			return;
+		}
+
+		setView( views.QUESTION );
+	}, [ isSelected ] );
+
 	useLayoutEffect( () => {
 		props.setPosition( {
 			...getHorizontalPosition( attributes.x ),
@@ -192,7 +203,12 @@ const EditFeedbackBlock = ( props ) => {
 
 	return (
 		<ConnectToCrowdsignal>
-			<Toolbar onChangePosition={ setPosition } { ...props } />
+			<Toolbar
+				currentView={ view }
+				onChangePosition={ setPosition }
+				onViewChange={ setView }
+				{ ...props }
+			/>
 			<Sidebar
 				shouldPromote={ shouldPromote }
 				signalWarning={ signalWarning }
@@ -212,6 +228,7 @@ const EditFeedbackBlock = ( props ) => {
 							className="crowdsignal-forms-feedback__popover-overlay"
 							onClick={ toggleBlock }
 						/>
+
 						{ ! isExample && signalWarning && <SignalWarning /> }
 						{ ! isExample && saveError && (
 							<EditorNotice
@@ -235,45 +252,64 @@ const EditFeedbackBlock = ( props ) => {
 								) }
 							</EditorNotice>
 						) }
-						<div className="crowdsignal-forms-feedback__popover">
-							<RichText
-								tagName="h3"
-								className="crowdsignal-forms-feedback__header"
-								onChange={ handleChangeAttribute( 'header' ) }
-								value={ attributes.header }
-								allowedFormats={ [] }
-							/>
 
-							<TextareaControl
-								className="crowdsignal-forms-feedback__input"
-								rows={ 6 }
-								onChange={ handleChangeAttribute(
-									'feedbackPlaceholder'
-								) }
-								value={ attributes.feedbackPlaceholder }
-							/>
-
-							<TextControl
-								className="crowdsignal-forms-feedback__input"
-								onChange={ handleChangeAttribute(
-									'emailPlaceholder'
-								) }
-								value={ attributes.emailPlaceholder }
-							/>
-
-							<div className="wp-block-button crowdsignal-forms-feedback__button-wrapper">
+						{ view === views.QUESTION && (
+							<div className="crowdsignal-forms-feedback__popover">
 								<RichText
-									className="wp-block-button__link crowdsignal-forms-feedback__feedback-button"
+									tagName="h3"
+									className="crowdsignal-forms-feedback__header"
 									onChange={ handleChangeAttribute(
-										'submitButtonLabel'
+										'header'
 									) }
-									value={ attributes.submitButtonLabel }
+									value={ attributes.header }
 									allowedFormats={ [] }
-									multiline={ false }
-									disableLineBreaks={ true }
+								/>
+
+								<TextareaControl
+									className="crowdsignal-forms-feedback__input"
+									rows={ 6 }
+									onChange={ handleChangeAttribute(
+										'feedbackPlaceholder'
+									) }
+									value={ attributes.feedbackPlaceholder }
+								/>
+
+								<TextControl
+									className="crowdsignal-forms-feedback__input"
+									onChange={ handleChangeAttribute(
+										'emailPlaceholder'
+									) }
+									value={ attributes.emailPlaceholder }
+								/>
+
+								<div className="wp-block-button crowdsignal-forms-feedback__button-wrapper">
+									<RichText
+										className="wp-block-button__link crowdsignal-forms-feedback__feedback-button"
+										onChange={ handleChangeAttribute(
+											'submitButtonLabel'
+										) }
+										value={ attributes.submitButtonLabel }
+										allowedFormats={ [] }
+										multiline={ false }
+										disableLineBreaks={ true }
+									/>
+								</div>
+							</div>
+						) }
+
+						{ view === views.SUBMIT && (
+							<div className="crowdsignal-forms-feedback__popover">
+								<RichText
+									tagName="h3"
+									className="crowdsignal-forms-feedback__header"
+									onChange={ handleChangeAttribute(
+										'submitText'
+									) }
+									value={ attributes.submitText }
+									allowedFormats={ [] }
 								/>
 							</div>
-						</div>
+						) }
 					</>
 				) }
 

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -92,6 +92,12 @@
 	}
 }
 
+.crowdsignal-forms-feedback__toolbar-toggle {
+	font-weight: 600;
+	padding-left: 16px !important;
+	padding-right: 16px !important;
+}
+
 .crowdsignal-forms-feedback__toolbar-position-toggle svg {
 	margin-right: 0 !important;
 }

--- a/client/blocks/feedback/toolbar.js
+++ b/client/blocks/feedback/toolbar.js
@@ -14,6 +14,7 @@ import {
 	ToolbarButton,
 	ToolbarGroup,
 } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -24,6 +25,7 @@ import {
 	BottomLeftPlacementIcon,
 	BottomRightPlacementIcon,
 } from 'components/icon/placement';
+import { views } from './constants';
 
 const placementIcons = {
 	'top-left': TopLeftPlacementIcon,
@@ -32,8 +34,10 @@ const placementIcons = {
 	'bottom-right': BottomRightPlacementIcon,
 };
 
-const FeedbackToolbar = ( { attributes, onChangePosition } ) => {
+const FeedbackToolbar = ( { attributes, currentView, onChangePosition, onViewChange } ) => {
 	const [ showPosition, setShowPosition ] = useState( false );
+
+	const handleViewChange = ( view ) => () => onViewChange( view );
 
 	const showPositionPopover = () => setShowPosition( true );
 	const hidePositionPopover = () => setShowPosition( false );
@@ -42,6 +46,24 @@ const FeedbackToolbar = ( { attributes, onChangePosition } ) => {
 
 	return (
 		<BlockControls>
+			<ToolbarGroup label={ __( 'Current view', 'crowdsignal-forms' ) }>
+				<ToolbarButton
+					className="crowdsignal-forms-feedback__toolbar-toggle"
+					isActive={ currentView === views.QUESTION }
+					label={ __( 'Question', 'crowdsignal-forms' ) }
+					onClick={ handleViewChange( views.QUESTION ) }
+				>
+					{ __( 'Question', 'crowdsignal-forms' ) }
+				</ToolbarButton>
+				<ToolbarButton
+					className="crowdsignal-forms-feedback__toolbar-toggle"
+					isActive={ currentView === views.SUBMIT }
+					label={ __( 'Submit', 'crowdsignal-forms' ) }
+					onClick={ handleViewChange( views.SUBMIT ) }
+				>
+					{ __( 'Submit', 'crowdsignal-forms' ) }
+				</ToolbarButton>
+			</ToolbarGroup>
 			<ToolbarGroup>
 				<ToolbarButton
 					className="crowdsignal-forms-feedback__toolbar-position-toggle"

--- a/client/blocks/feedback/toolbar.js
+++ b/client/blocks/feedback/toolbar.js
@@ -34,7 +34,12 @@ const placementIcons = {
 	'bottom-right': BottomRightPlacementIcon,
 };
 
-const FeedbackToolbar = ( { attributes, currentView, onChangePosition, onViewChange } ) => {
+const FeedbackToolbar = ( {
+	attributes,
+	currentView,
+	onChangePosition,
+	onViewChange,
+} ) => {
 	const [ showPosition, setShowPosition ] = useState( false );
 
 	const handleViewChange = ( view ) => () => onViewChange( view );

--- a/client/components/feedback/index.js
+++ b/client/components/feedback/index.js
@@ -19,8 +19,10 @@ import { getStyleVars } from 'blocks/feedback/util';
 import { withFallbackStyles } from 'components/with-fallback-styles';
 import { getAlignmentClassNames } from './util';
 import { updateFeedbackResponse } from 'data/feedback';
+import { views } from 'blocks/feedback/constants';
 
 const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
+	const [ view, setView ] = useState( views.QUESTION );
 	const [ active, setActive ] = useState( false );
 
 	const [ feedback, setFeedback ] = useState( '' );
@@ -35,8 +37,7 @@ const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 			} );
 		}
 
-		// no thanks nor anything right now, needs improvement
-		toggleDialog();
+		setView( views.SUBMIT );
 	};
 
 	const toggleDialog = () => setActive( ! active );
@@ -52,7 +53,7 @@ const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 				className={ classes }
 				style={ getStyleVars( attributes, fallbackStyles ) }
 			>
-				{ active && (
+				{ active && view === views.QUESTION && (
 					<div className="crowdsignal-forms-feedback__popover">
 						<RichText.Content
 							tagName="h3"
@@ -84,6 +85,16 @@ const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 								{ attributes.submitButtonLabel }
 							</button>
 						</div>
+					</div>
+				) }
+
+				{ active && view === views.SUBMIT && (
+					<div className="crowdsignal-forms-feedback__popover">
+						<RichText.Content
+							tagName="h3"
+							className="crowdsignal-forms-feedback__header"
+							value={ attributes.submitText }
+						/>
 					</div>
 				) }
 

--- a/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
@@ -137,7 +137,7 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 			),
 			'submitText'          => array(
 				'type'    => 'string',
-				'default' => __( 'Thanks for letting us know!', 'crowdsignal-team' ),
+				'default' => __( 'Thanks for letting us know!', 'crowdsignal-forms' ),
 			),
 			'surveyId'            => array(
 				'type'    => 'number',

--- a/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
@@ -135,6 +135,10 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 				'type'    => 'string',
 				'default' => __( 'Submit', 'crowdsignal-forms' ),
 			),
+			'submitText'          => array(
+				'type'    => 'string',
+				'default' => __( 'Thanks for letting us know!', 'crowdsignal-team' ),
+			),
 			'surveyId'            => array(
 				'type'    => 'number',
 				'default' => null,


### PR DESCRIPTION
This patch adds a submit view to the feedback block. For now it just contains an editable thank you message.

![Screen Shot 2021-04-12 at 10 13 57 PM](https://user-images.githubusercontent.com/8056203/114456262-ef9baf00-9bdc-11eb-988c-e0641c717620.png)

# Testing

You should now be able to toggle the feedback block between question and submit view inside the editor. The thank you message is editable.  
When you save and preview the post, after clicking submit on the feedback form the thank you message should be displayed instead of closing the popup.