### PR TITLE
Change feedback default title

### DIFF
--- a/client/blocks/feedback/attributes.js
+++ b/client/blocks/feedback/attributes.js
@@ -51,7 +51,7 @@ export default {
 	},
 	title: {
 		type: 'string',
-		default: __( 'Untitled Feedback', 'crowdsignal-forms' ),
+		default: '',
 	},
 	x: {
 		type: 'string',

--- a/client/blocks/feedback/attributes.js
+++ b/client/blocks/feedback/attributes.js
@@ -51,7 +51,7 @@ export default {
 	},
 	title: {
 		type: 'string',
-		default: '',
+		default: __( 'Untitled Feedback', 'crowdsignal-forms' ),
 	},
 	x: {
 		type: 'string',

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -114,6 +114,7 @@ const EditFeedbackBlock = ( props ) => {
 		emailPlaceholder,
 		surveyId,
 		title,
+		header,
 	} = attributes;
 
 	const { error: saveError, save: saveBlock } = useAutosave(
@@ -126,7 +127,7 @@ const EditFeedbackBlock = ( props ) => {
 					emailPlaceholder: data.emailPlaceholder,
 					sourceLink: data.sourceLink,
 					surveyId: data.surveyId,
-					title: data.title || data.feedbackPlaceholder,
+					title: data.title || data.header,
 				} );
 
 				if ( ! data.surveyId ) {
@@ -142,6 +143,7 @@ const EditFeedbackBlock = ( props ) => {
 			sourceLink,
 			surveyId,
 			title,
+			header,
 		}
 	);
 

--- a/client/blocks/feedback/sidebar.js
+++ b/client/blocks/feedback/sidebar.js
@@ -74,7 +74,7 @@ const Sidebar = ( {
 					label={ __( 'Title (optional)', 'crowdsignal-forms' ) }
 					onChange={ handleChangeTitle }
 					value={ decodeEntities(
-						attributes.title ?? attributes.ratingQuestion
+						attributes.title || attributes.header
 					) }
 				/>
 				{ shouldPromote && (

--- a/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
@@ -159,7 +159,7 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 
 	/**
 	 * Verifies a nonce based on the NONCE.
-	 * The nonce creation is first attempted through crowdsignal_forms_nps_nonce filter.
+	 * The nonce creation is first attempted through crowdsignal_forms_feedback_nonce filter.
 	 *
 	 * @since [next-version-number]
 	 * @param string $nonce


### PR DESCRIPTION
This PR will change how the Feedback block title is set and defaulted.

The changes add a default title "Untitled Feedback" among the attributes. As soon as you add a Feedback block, the default title can be seen on the sidebar.

This change will make `title` and `header` (the prompt shown on the feedback modal) independent from each other. If the Title is set to empty, then it will default to the prompt as it we don't (can't) allow for empty titles, as opposed to default to the feedback `placeholder`.



## Test instructions
Checkout and `make client`. Insert a new Feedback block.

  - The title shown on the sidebar should be "Untitled Feedback".
  - The title should be the same that is shown on the Crowdsignal dashboard
  - Using an empty title should update the survey title with the `header` attribute (the modal prompt)

