### PR TITLE
Refactor feedback block positioning

### DIFF
--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -23,37 +23,36 @@
 	}
 
 	.crowdsignal-forms-feedback__popover {
-		position: static;
+		margin-top: 15px;
 	}
 
 	.crowdsignal-forms-feedback {
+		display: flex;
+		flex-direction: column;
 		justify-content: center;
 		margin: 0 !important;
-		padding: 20px;
 		position: relative;
 
 		&.align-left {
-			padding-left: 60px;
+			align-items: flex-start;
 		}
 
 		&.align-right {
-			padding-right: 60px;
+			align-items: flex-end;
 		}
 
 		&.vertical-align-top {
-			padding-top: 60px;
-		}
-
-		&.align-left.vertical-align-center {
-			padding-left: 70px;
-		}
-
-		&.align-right.vertical-align-center {
-			padding-right: 70px;
+			justify-content: flex-start;
 		}
 
 		&.vertical-align-bottom {
-			padding-bottom: 60px;
+			justify-content: flex-end;
+			flex-direction: column-reverse;
+
+			.crowdsignal-forms-feedback__popover {
+				margin-bottom: 15px;
+				margin-top: 0;
+			}
 		}
 
 		.crowdsignal-forms__editor-notice {
@@ -67,28 +66,7 @@
 .crowdsignal-forms-feedback__trigger {
 
 	.editor-styles-wrapper & {
-		position: absolute;
-	}
-
-	.editor-styles-wrapper .crowdsignal-forms-feedback.align-left & {
-		left: 10px;
-	}
-
-	.editor-styles-wrapper .crowdsignal-forms-feedback.align-right & {
-		right: 10px;
-	}
-
-	.editor-styles-wrapper .crowdsignal-forms-feedback.vertical-align-top & {
-		top: 0;
-	}
-
-	.editor-styles-wrapper .crowdsignal-forms-feedback.vertical-align-center & {
-		margin-top: -25px;
-		top: 50%;
-	}
-
-	.editor-styles-wrapper .crowdsignal-forms-feedback.vertical-align-bottom & {
-		bottom: 10px;
+		position: static;
 	}
 }
 

--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -1,6 +1,7 @@
 /** Public styles */
 
 .crowdsignal-forms-feedback__trigger {
+	background: transparent !important;
 	border: 0;
 	border-radius: 50%;
 	box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.3);
@@ -11,31 +12,13 @@
 	position: fixed;
 	width: 75px;
 	z-index: 100;
+}
 
-	.crowdsignal-forms-feedback.align-left & {
-		left: 20px;
-	}
-
-	.crowdsignal-forms-feedback.align-right & {
-		right: 20px;
-	}
-
-	.crowdsignal-forms-feedback.vertical-align-center & {
-		margin-top: -25px;
-		top: 50%;
-	}
-
-	.crowdsignal-forms-feedback.vertical-align-bottom & {
-		bottom: 20px;
-	}
-
-	.crowdsignal-forms-feedback.vertical-align-top & {
-		top: 20px;
-
-		.admin-bar & {
-			top: 52px;
-		}
-	}
+.crowdsignal-forms-feedback__popover-wrapper.components-popover .components-popover__content {
+	background-color: transparent;
+	border: 0;
+	box-shadow: 0;
+	overflow: visible;
 }
 
 .crowdsignal-forms-feedback__popover {
@@ -46,33 +29,9 @@
 	box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.3);
 	color: var(--crowdsignal-forms-background-color);
 	padding: 24px;
-	position: fixed;
 	width: 380px;
+	text-align: left;
 	z-index: 100;
-
-	.crowdsignal-forms-feedback.align-left & {
-		left: 70px;
-	}
-
-	.crowdsignal-forms-feedback.align-right & {
-		right: 70px;
-	}
-
-	.crowdsignal-forms-feedback.vertical-align-center & {
-		top: 50%;
-	}
-
-	.crowdsignal-forms-feedback.vertical-align-bottom & {
-		bottom: 70px;
-	}
-
-	.crowdsignal-forms-feedback.vertical-align-top & {
-		top: 70px;
-
-		.admin-bar & {
-			top: 102px;
-		}
-	}
 }
 
 .crowdsignal-forms-feedback__header {

--- a/client/components/feedback/util.js
+++ b/client/components/feedback/util.js
@@ -1,3 +1,65 @@
-export const getAlignmentClassNames = ( x, y ) => {
-	return [ `align-${ x }`, `vertical-align-${ y }` ];
+/**
+ * External dependencies
+ */
+import { isObject } from 'lodash';
+
+const addFrameOffsets = ( offset, frame ) => {
+	const body = document.body;
+
+	return {
+		left: offset.left + frame.x,
+		right:
+			offset.right +
+			( window.innerWidth > frame.left + frame.width
+				? body.offsetWidth - frame.left - frame.width
+				: 0 ),
+		top: offset.top + frame.y,
+		bottom:
+			offset.bottom +
+			( window.innerHeight > frame.top + frame.height
+				? body.offsetHeight - frame.top - frame.height
+				: 0 ),
+	};
+};
+
+const getFeedbackButtonHorizontalPosition = ( align, width, offset ) => {
+	return {
+		left: align === 'left' ? offset.left : null,
+		right: align === 'right' ? offset.right : null,
+	};
+};
+
+const getFeedbackButtonVerticalPosition = ( verticalAlign, height, offset ) => {
+	return {
+		top: verticalAlign === 'top' ? offset.top : null,
+		bottom: verticalAlign === 'bottom' ? offset.bottom : null,
+	};
+};
+
+export const getFeedbackButtonPosition = (
+	align,
+	verticalAlign,
+	width,
+	height,
+	padding,
+	frameElement = null
+) => {
+	let offset = {
+		left: isObject( padding ) ? padding.left : padding,
+		right: isObject( padding ) ? padding.right : padding,
+		top: isObject( padding ) ? padding.top : padding,
+		bottom: isObject( padding ) ? padding.bottom : padding,
+	};
+
+	if ( frameElement ) {
+		offset = addFrameOffsets(
+			offset,
+			frameElement.getBoundingClientRect()
+		);
+	}
+
+	return {
+		...getFeedbackButtonHorizontalPosition( align, width, offset ),
+		...getFeedbackButtonVerticalPosition( verticalAlign, height, offset ),
+	};
 };


### PR DESCRIPTION
This patch is a major refactor of the positioning logic for the feedback block.  

I scrapped our previous css based solution and replaced it with some javascript. The `getFeedbackButtonPosition` also accepts a bounding DOM node as the last argument, making it reusable between the client and the editor which results in a much more consistent feel.

For now, I went with WordPress' native `<Popover />` component to power the popover on the client side as it fits the current design nicely. For alternative button/popover styles we'll probably want to implement our own but no need to do this right now.

Doing everything in JS also allowed me to implement a hopefully better solution for when the block is top-aligned in the editor where it previously had to be offset to the bottom to prevent the toolbar from getting obstructed by the header. Right now, the trigger will be displayed in the correct position and will only move down a bit when the block is selected. It's actually not nearly as distractive as I would've thought previously.

Bonus point: the popover will now close when you click outside of it on the client, however the button is acting a little weird which seems to be a bug with the actual `<Popover />` component from core. I'll need to find another way to address it.

![Screen Shot 2021-04-13 at 10 08 59 AM](https://user-images.githubusercontent.com/8056203/114521193-79ca2e80-9c42-11eb-9300-d17f33fe37b8.png)

# Testing

Create a post with a feedback block. Try various position options and verify the block feels consistent across them in both the editor as well as on the post page.