### PR TITLE
Revamp notices

### DIFF
--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -12,7 +12,6 @@ import { RichText } from '@wordpress/block-editor';
 import { TextControl, TextareaControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withSelect, dispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -28,8 +27,8 @@ import { getStyleVars } from './util';
 import { useAutosave } from 'components/use-autosave';
 import { updateFeedback } from 'data/feedback/edit';
 import SignalWarning from 'components/signal-warning';
-import EditorNotice from 'components/editor-notice';
 import { views } from './constants';
+import RetryNotice from 'components/retry-notice';
 
 const EditFeedbackBlock = ( props ) => {
 	const [ view, setView ] = useState( views.QUESTION );
@@ -194,26 +193,7 @@ const EditFeedbackBlock = ( props ) => {
 
 						{ ! isExample && signalWarning && <SignalWarning /> }
 						{ ! isExample && saveError && (
-							<EditorNotice
-								status="error"
-								icon="warning"
-								isDismissible={ false }
-								actions={ [
-									{
-										className: 'is-destructive',
-										label: __(
-											'Retry',
-											'crowdsignal-forms'
-										),
-										onClick: saveBlock,
-									},
-								] }
-							>
-								{ __(
-									`Unfortunately, the block couldn't be saved to Crowdsignal.com.`,
-									'crowdsignal-forms'
-								) }
-							</EditorNotice>
+							<RetryNotice retryHandler={ saveBlock } />
 						) }
 
 						{ view === views.QUESTION && (

--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -30,6 +30,7 @@ import { useAccountInfo } from 'data/hooks';
 import EditorNotice from 'components/editor-notice';
 import FooterBranding from 'components/footer-branding';
 import SignalWarning from 'components/signal-warning';
+import RetryNotice from 'components/retry-notice';
 
 const EditNpsBlock = ( props ) => {
 	const [ view, setView ] = useState( views.RATING );
@@ -140,23 +141,7 @@ const EditNpsBlock = ( props ) => {
 			/>
 			{ ! isExample && signalWarning && <SignalWarning /> }
 			{ ! isExample && saveError && (
-				<EditorNotice
-					status="error"
-					icon="warning"
-					isDismissible={ false }
-					actions={ [
-						{
-							className: 'is-destructive',
-							label: __( 'Retry', 'crowdsignal-forms' ),
-							onClick: saveBlock,
-						},
-					] }
-				>
-					{ __(
-						`Unfortunately, the block couldn't be saved to Crowdsignal.com.`,
-						'crowdsignal-forms'
-					) }
-				</EditorNotice>
+				<RetryNotice retryHandler={ saveBlock } />
 			) }
 
 			{ ! isExample && (

--- a/client/components/editor-notice/style.scss
+++ b/client/components/editor-notice/style.scss
@@ -11,6 +11,10 @@
 .crowdsignal-forms__editor-notice-icon {
 	line-height: 0;
 	padding: 8px 16px 8px 8px;
+
+	.is-warn & {
+		color: var(--wp-admin-theme-color);
+	}
 }
 
 .crowdsignal-forms__editor-notice-text {

--- a/client/components/retry-notice/index.js
+++ b/client/components/retry-notice/index.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import EditorNotice from 'components/editor-notice';
+
+const RetryNotice = ( { retryHandler } ) => {
+	return (
+		<EditorNotice
+			status="error"
+			icon="warning"
+			isDismissible={ false }
+			actions={ [
+				{
+					className: 'is-destructive',
+					label: __( 'Retry', 'crowdsignal-forms' ),
+					onClick: retryHandler,
+				},
+			] }
+		>
+			{ __(
+				`Unfortunately, the block couldn't be saved to Crowdsignal.com.`,
+				'crowdsignal-forms'
+			) }
+		</EditorNotice>
+	);
+};
+
+export default RetryNotice;

--- a/client/components/signal-warning/index.js
+++ b/client/components/signal-warning/index.js
@@ -11,7 +11,19 @@ import EditorNotice from 'components/editor-notice';
 
 const SignalWarning = () => {
 	return (
-		<EditorNotice icon="warning" status="warn" isDismissible={ false }>
+		<EditorNotice
+			icon="warning"
+			status="warn"
+			isDismissible={ false }
+			actions={ [
+				{
+					label: __( 'Please upgrade', 'crowdsignal-forms' ),
+					url: 'https://crowdsignal.com/pricing',
+					className: 'is-secondary',
+					noDefaultClasses: true,
+				},
+			] }
+		>
 			{ __(
 				'Your free Crowdsignal account has exceeded ',
 				'crowdsignal-forms'
@@ -19,12 +31,6 @@ const SignalWarning = () => {
 			<ExternalLink href="https://crowdsignal.com/support/what-is-a-signal/">
 				{ __( 'the limit of 2500 signals.', 'crowdsignal-forms' ) }
 			</ExternalLink>
-			<br />
-			<strong>
-				<ExternalLink href="https://crowdsignal.com/pricing">
-					{ __( 'Please upgrade.', 'crowdsignal-forms' ) }
-				</ExternalLink>
-			</strong>
 		</EditorNotice>
 	);
 };

--- a/client/components/signal-warning/index.js
+++ b/client/components/signal-warning/index.js
@@ -8,15 +8,10 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import EditorNotice from 'components/editor-notice';
-import WarningIcon from 'components/icon/warning-circle';
 
 const SignalWarning = () => {
 	return (
-		<EditorNotice
-			icon={ <WarningIcon /> }
-			status="warn"
-			isDismissible={ false }
-		>
+		<EditorNotice icon="warning" status="warn" isDismissible={ false }>
 			{ __(
 				'Your free Crowdsignal account has exceeded ',
 				'crowdsignal-forms'


### PR DESCRIPTION
This PR makes our notices more consistent and aligned.

`RetryNotice` component was created for less fuzz and the custom icon from the `SignalWarning` was removed in favor of the *built in* icon behavior of Notices through `icon` prop.

Note: we talked about removing the carriage return from the `SignalWarning` message (to prevent a 3 line message on the Feedback block), but it just looked too odd. Maybe it would be a good option to turn the second link into a button?
Suggested change **(not actually included on this PR)**:
![image](https://user-images.githubusercontent.com/157240/114618647-f7f8f600-9c7f-11eb-82d1-2cacd12d84d6.png)


## Test instructions
Insert a Feedback block and an NPS block. Force notices to show up by:

  - use a free account with exhausted signals
  - either block requests from your sandboxed API by `sudo global-http disable` or go *offline* from the Developer Tools, then make a change on the blocks (title?) to trigger a sync request (10-15 seconds later the new `RetryNotice` should appear)
  - on the NPS block, the threshold notice should always be present and in line with the other 2 notices (when shown)

Preview:
![image](https://user-images.githubusercontent.com/157240/114617228-3f7e8280-9c7e-11eb-8d2f-d4fdabf244c3.png)
