### PR TITLE
Add email feedback switch

### DIFF
--- a/client/blocks/feedback/attributes.js
+++ b/client/blocks/feedback/attributes.js
@@ -90,4 +90,8 @@ export default {
 		type: 'string',
 		default: null,
 	},
+	emailResponses: {
+		type: 'boolean',
+		default: true,
+	},
 };

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -53,6 +53,7 @@ const EditFeedbackBlock = ( props ) => {
 		title,
 		triggerBackgroundImage,
 		header,
+		emailResponses,
 	} = attributes;
 
 	const triggerButton = useRef( null );
@@ -70,6 +71,7 @@ const EditFeedbackBlock = ( props ) => {
 					sourceLink: data.sourceLink,
 					surveyId: data.surveyId,
 					title: data.title || data.header,
+					emailResponses: data.emailResponses,
 				} );
 
 				if ( ! data.surveyId ) {
@@ -86,6 +88,7 @@ const EditFeedbackBlock = ( props ) => {
 			surveyId,
 			title,
 			header,
+			emailResponses,
 		}
 	);
 

--- a/client/blocks/feedback/sidebar.js
+++ b/client/blocks/feedback/sidebar.js
@@ -8,12 +8,13 @@ import React from 'react';
  */
 import {
 	Button,
+	DateTimePicker,
 	ExternalLink,
 	Icon,
 	PanelBody,
 	SelectControl,
 	TextControl,
-	DateTimePicker,
+	ToggleControl,
 } from '@wordpress/components';
 import {
 	InspectorControls,
@@ -111,6 +112,14 @@ const Sidebar = ( {
 					value={ decodeEntities(
 						attributes.title || attributes.header
 					) }
+				/>
+				<ToggleControl
+					label={ __(
+						'Send me responses via email',
+						'crowdsignal-forms'
+					) }
+					checked={ attributes.emailResponses }
+					onChange={ handleChangeAttribute( 'emailResponses' ) }
 				/>
 				{ shouldPromote && (
 					<SidebarPromote signalWarning={ signalWarning } />

--- a/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
@@ -195,6 +195,10 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 				'type'    => 'string',
 				'default' => null,
 			),
+			'emailResponses'           => array(
+				'type'    => 'boolean',
+				'default' => true,
+			),
 		);
 	}
 

--- a/includes/models/class-feedback-survey.php
+++ b/includes/models/class-feedback-survey.php
@@ -60,6 +60,14 @@ class Feedback_Survey {
 	private $source_link = '';
 
 	/**
+	 * Whether or not responses should be sent by email.
+	 *
+	 * @since [next-version-number]
+	 * @var boolean
+	 */
+	private $email_responses = true;
+
+	/**
 	 * Creates a new Feedback_Survey object from an array of params.
 	 *
 	 * @param  array $data An array containing the survey data.
@@ -71,7 +79,8 @@ class Feedback_Survey {
 			$data['title'],
 			$data['feedback_text'],
 			$data['email_text'],
-			! empty( $data['source_link'] ) ? $data['source_link'] : ''
+			! empty( $data['source_link'] ) ? $data['source_link'] : '',
+			$data['email_responses']
 		);
 	}
 
@@ -87,7 +96,8 @@ class Feedback_Survey {
 			$attributes['title'],
 			$attributes['feedbackPlaceholder'],
 			$attributes['emailPlaceholder'],
-			! empty( $attributes['sourceLink'] ) ? $attributes['sourceLink'] : ''
+			! empty( $attributes['sourceLink'] ) ? $attributes['sourceLink'] : '',
+			$attributes['emailResponses']
 		);
 	}
 
@@ -102,13 +112,15 @@ class Feedback_Survey {
 	 * @param string $feedback_placeholder   Feedback question.
 	 * @param string $email_placeholder      Email question.
 	 * @param string $source_link            Blog post/page permalink.
+	 * @param string $email_responses        Enable sending responses via email.
 	 */
-	public function __construct( $id, $title, $feedback_placeholder, $email_placeholder, $source_link = '' ) {
+	public function __construct( $id, $title, $feedback_placeholder, $email_placeholder, $source_link = '', $email_responses = true ) {
 		$this->id                   = $id;
 		$this->title                = $title;
 		$this->feedback_placeholder = $feedback_placeholder;
 		$this->email_placeholder    = $email_placeholder;
 		$this->source_link          = $source_link;
+		$this->email_responses      = $email_responses;
 	}
 
 	/**
@@ -131,10 +143,11 @@ class Feedback_Survey {
 	 */
 	public function to_array() {
 		$data = array(
-			'title'         => $this->title,
-			'feedback_text' => $this->feedback_placeholder,
-			'email_text'    => $this->email_placeholder,
-			'source_link'   => $this->source_link,
+			'title'           => $this->title,
+			'feedback_text'   => $this->feedback_placeholder,
+			'email_text'      => $this->email_placeholder,
+			'source_link'     => $this->source_link,
+			'email_responses' => $this->email_responses,
 		);
 
 		if ( $this->id ) {
@@ -158,6 +171,7 @@ class Feedback_Survey {
 			'feedbackPlaceholder' => $this->feedback_placeholder,
 			'emailPlaceholder'    => $this->email_placeholder,
 			'sourceLink'          => $this->source_link,
+			'emailResponses'      => $this->email_responses,
 		);
 	}
 }


### PR DESCRIPTION
This PR adds the toggle to enable email notifications on every feedback submit, enabled by default.

## Test instructions
Checkout and `make client`. Test on docker against a sandboxed API D60245-code
Insert a Feedback block. Notice the toggle on the sidebar. Publish the post, visit and send feedback.
You should get an email with the feedback.
Edit the post, disable the toggle and send another feedback. This time you shouldn't get any email about it.