### PR TITLE
Add status option

### DIFF
--- a/client/blocks/feedback/attributes.js
+++ b/client/blocks/feedback/attributes.js
@@ -4,6 +4,11 @@
 import { __ } from '@wordpress/i18n';
 
 /**
+ * Internal dependencies
+ */
+import { FeedbackStatus } from './constants';
+
+/**
  * Note: Any changes made to the attributes definition need to be duplicated in
  *       Crowdsignal_Forms\Frontend\Blocks\Crowdsignal_Forms_Feedback_Block::attributes()
  *       inside includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php.
@@ -76,5 +81,13 @@ export default {
 	y: {
 		type: 'string',
 		default: 'bottom',
+	},
+	status: {
+		type: 'string',
+		default: FeedbackStatus.OPEN,
+	},
+	closedAfterDateTime: {
+		type: 'string',
+		default: null,
 	},
 };

--- a/client/blocks/feedback/constants.js
+++ b/client/blocks/feedback/constants.js
@@ -2,3 +2,9 @@ export const views = {
 	QUESTION: 'question',
 	SUBMIT: 'submit',
 };
+
+export const FeedbackStatus = Object.freeze( {
+	OPEN: 'open',
+	CLOSED: 'closed',
+	CLOSED_AFTER: 'closed-after',
+} );

--- a/client/blocks/feedback/sidebar.js
+++ b/client/blocks/feedback/sidebar.js
@@ -11,7 +11,9 @@ import {
 	ExternalLink,
 	Icon,
 	PanelBody,
+	SelectControl,
 	TextControl,
+	DateTimePicker,
 } from '@wordpress/components';
 import {
 	InspectorControls,
@@ -28,6 +30,7 @@ import { __ } from '@wordpress/i18n';
 import SignalIcon from 'components/icon/signal';
 import SidebarPromote from 'components/sidebar-promote';
 import { getTriggerStyles } from './util';
+import { FeedbackStatus } from './constants';
 
 const Sidebar = ( {
 	attributes,
@@ -60,6 +63,13 @@ const Sidebar = ( {
 		} );
 
 	const triggerStyles = getTriggerStyles( attributes );
+
+	const handleChangeStatus = ( status ) => setAttributes( { status } );
+
+	const handleChangeCloseAfterDateTime = ( closedAfterDateTime ) => {
+		const dateTime = new Date( closedAfterDateTime );
+		setAttributes( { closedAfterDateTime: dateTime.toISOString() } );
+	};
 
 	return (
 		<InspectorControls>
@@ -173,6 +183,51 @@ const Sidebar = ( {
 					},
 				] }
 			/>
+			<PanelBody
+				title={ __( 'Settings', 'crowdsignal-forms' ) }
+				initialOpen={ false }
+			>
+				<SelectControl
+					value={ attributes.status }
+					label={ __( 'Survey Status', 'crowdsignal-forms' ) }
+					options={ [
+						{
+							label: __( 'Open', 'crowdsignal-forms' ),
+							value: FeedbackStatus.OPEN,
+						},
+						{
+							label: __( 'Closed after', 'crowdsignal-forms' ),
+							value: FeedbackStatus.CLOSED_AFTER,
+						},
+						{
+							label: __( 'Closed', 'crowdsignal-forms' ),
+							value: FeedbackStatus.CLOSED,
+						},
+					] }
+					onChange={ handleChangeStatus }
+					help={
+						FeedbackStatus.CLOSED_AFTER === attributes.status &&
+						null !== attributes.closedAfterDateTime &&
+						new Date().toISOString() >
+							attributes.closedAfterDateTime
+							? 'Currently closed as date has passed'
+							: ''
+					}
+				/>
+
+				{ FeedbackStatus.CLOSED_AFTER === attributes.status && (
+					<DateTimePicker
+						currentDate={
+							( attributes.closedAfterDateTime &&
+								new Date( attributes.closedAfterDateTime ) ) ||
+							new Date()
+						}
+						label={ __( 'Close on', 'crowdsignal-forms' ) }
+						onChange={ handleChangeCloseAfterDateTime }
+						is12Hour={ true }
+					/>
+				) }
+			</PanelBody>
 		</InspectorControls>
 	);
 };

--- a/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
@@ -187,11 +187,11 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 				'type'    => 'string',
 				'default' => 'bottom',
 			),
-			'status'              => array(
+			'status'                   => array(
 				'type'    => 'string',
 				'default' => 'open', // See: client/blocks/feedback/constants.js.
 			),
-			'closedAfterDateTime' => array(
+			'closedAfterDateTime'      => array(
 				'type'    => 'string',
 				'default' => null,
 			),

--- a/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
@@ -71,7 +71,7 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 	 * @return string
 	 */
 	public function render( $attributes ) {
-		if ( $this->should_hide_block() ) {
+		if ( $this->should_hide_block( $attributes ) ) {
 			return '';
 		}
 
@@ -90,10 +90,31 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 	/**
 	 * Determines if the Feedback block should be rendered or not.
 	 *
+	 * @param  array $attributes The block's attributes.
 	 * @return bool
 	 */
-	private function should_hide_block() {
-		return ! $this->is_cs_connected() || ! is_singular();
+	private function should_hide_block( $attributes = array() ) {
+		if ( ! $this->is_cs_connected() || ! is_singular() ) {
+			return true;
+		}
+
+		if ( isset( $attributes['status'] ) ) {
+			if ( self::STATUS_TYPE_CLOSED === $attributes['status'] ) {
+				return true;
+			} elseif ( self::STATUS_TYPE_SCHEDULED === $attributes['status'] && isset( $attributes['closedAfterDateTime'] ) ) {
+				try {
+					$close_date = \DateTime::createFromFormat( 'Y-m-d\TH:i:s+', $attributes['closedAfterDateTime'] );
+					$timestamp  = $close_date->getTimestamp();
+				} catch ( \Exception $e ) {
+					return false;
+				}
+
+				if ( time() > $timestamp ) {
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -165,6 +186,14 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 			'y'                        => array(
 				'type'    => 'string',
 				'default' => 'bottom',
+			),
+			'status'              => array(
+				'type'    => 'string',
+				'default' => 'open', // See: client/blocks/feedback/constants.js.
+			),
+			'closedAfterDateTime' => array(
+				'type'    => 'string',
+				'default' => null,
 			),
 		);
 	}

--- a/includes/frontend/class-crowdsignal-forms-block.php
+++ b/includes/frontend/class-crowdsignal-forms-block.php
@@ -25,6 +25,10 @@ abstract class Crowdsignal_Forms_Block {
 	const HIDE_BRANDING_YES       = 'YES';
 	const HIDE_BRANDING_NO        = 'NO';
 
+	const STATUS_TYPE_OPEN      = 'open';
+	const STATUS_TYPE_CLOSED    = 'closed';
+	const STATUS_TYPE_SCHEDULED = 'closed-after';
+
 	/**
 	 * Lazy-loaded state to determine if the api connection is set up.
 	 *


### PR DESCRIPTION
This PR adds the status sidebar panel (Settings section) to set open|closed|closed-after option.

## Testing instructions
Checkout and `make client`. Create a post and insert a Feedback block. Notice the "Settings" section. Test the different statuses and check the public view honors the selected option.