### PR TITLE
Enable custom feedback trigger images

### DIFF
--- a/client/blocks/feedback/attributes.js
+++ b/client/blocks/feedback/attributes.js
@@ -53,6 +53,18 @@ export default {
 	textColor: {
 		type: 'string',
 	},
+	triggerBackgroundImageId: {
+		type: 'number',
+		default: 0,
+	},
+	triggerBackgroundImage: {
+		type: 'string',
+		default: '',
+	},
+	triggerShadow: {
+		type: 'boolean',
+		default: true,
+	},
 	title: {
 		type: 'string',
 		default: '',

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -183,7 +183,9 @@ const EditFeedbackBlock = ( props ) => {
 					className="crowdsignal-forms-feedback__trigger"
 					style={ triggerStyles }
 				>
-					{ ! triggerBackgroundImage && <Icon icon={ SignalIcon } size={ 75 } /> }
+					{ ! triggerBackgroundImage && (
+						<Icon icon={ SignalIcon } size={ 75 } />
+					) }
 				</button>
 
 				{ isSelected && (
@@ -287,7 +289,7 @@ const EditFeedbackBlock = ( props ) => {
 };
 
 export default compose( [
-	withSelect( ( select, { attributes } ) => ( {
+	withSelect( ( select ) => ( {
 		activeSidebar: select( 'core/edit-post' ).getActiveGeneralSidebarName(),
 		editorFeatures: select( 'core/edit-post' ).getPreference( 'features' ),
 		sourceLink: select( 'core/editor' ).getPermalink(),

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -9,7 +9,7 @@ import { get } from 'lodash';
  * WordPress depenencies
  */
 import { RichText } from '@wordpress/block-editor';
-import { TextControl, TextareaControl } from '@wordpress/components';
+import { Icon, TextControl, TextareaControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withSelect, dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -24,7 +24,7 @@ import { getFeedbackButtonPosition } from 'components/feedback/util';
 import { useAccountInfo } from 'data/hooks';
 import Sidebar from './sidebar';
 import Toolbar from './toolbar';
-import { getStyleVars } from './util';
+import { getStyleVars, getTriggerStyles } from './util';
 import { useAutosave } from 'components/use-autosave';
 import { updateFeedback } from 'data/feedback/edit';
 import SignalWarning from 'components/signal-warning';
@@ -51,6 +51,7 @@ const EditFeedbackBlock = ( props ) => {
 		emailPlaceholder,
 		surveyId,
 		title,
+		triggerBackgroundImage,
 		header,
 	} = attributes;
 
@@ -157,6 +158,8 @@ const EditFeedbackBlock = ( props ) => {
 		`vertical-align-${ attributes.y }`
 	);
 
+	const triggerStyles = getTriggerStyles( attributes );
+
 	return (
 		<ConnectToCrowdsignal>
 			<Toolbar
@@ -178,8 +181,9 @@ const EditFeedbackBlock = ( props ) => {
 				<button
 					ref={ triggerButton }
 					className="crowdsignal-forms-feedback__trigger"
+					style={ triggerStyles }
 				>
-					<SignalIcon />
+					{ ! triggerBackgroundImage && <Icon icon={ SignalIcon } size={ 75 } /> }
 				</button>
 
 				{ isSelected && (
@@ -283,7 +287,7 @@ const EditFeedbackBlock = ( props ) => {
 };
 
 export default compose( [
-	withSelect( ( select ) => ( {
+	withSelect( ( select, { attributes } ) => ( {
 		activeSidebar: select( 'core/edit-post' ).getActiveGeneralSidebarName(),
 		editorFeatures: select( 'core/edit-post' ).getPreference( 'features' ),
 		sourceLink: select( 'core/editor' ).getPermalink(),

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -95,3 +95,19 @@
 .crowdsignal-forms-feedback__position-button {
 	width: fit-content;
 }
+
+.crowdsignal-forms-feedback__trigger-settings {
+	align-items: center;
+	display: flex;
+}
+
+.crowdsignal-forms-feedback__trigger-settings-trigger {
+	background-size: cover;
+	border: 1px solid #c4c4c4;
+	border-radius: 50%;
+	height: 70px;
+	margin-right: 12px;
+	overflow: hidden;
+	padding: 0;
+	width: 70px;
+}

--- a/client/blocks/feedback/sidebar.js
+++ b/client/blocks/feedback/sidebar.js
@@ -9,17 +9,20 @@ import React from 'react';
 import {
 	Button,
 	ExternalLink,
+	Icon,
 	PanelBody,
 	TextControl,
 } from '@wordpress/components';
-import { InspectorControls, PanelColorSettings } from '@wordpress/block-editor';
+import { InspectorControls, MediaUpload, MediaUploadCheck, PanelColorSettings } from '@wordpress/block-editor';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import SignalIcon from 'components/icon/signal';
 import SidebarPromote from 'components/sidebar-promote';
+import { getTriggerStyles } from './util';
 
 const Sidebar = ( {
 	attributes,
@@ -27,6 +30,11 @@ const Sidebar = ( {
 	shouldPromote,
 	signalWarning,
 } ) => {
+	const {
+		triggerBackgroundImage,
+		triggerBackgroundImageId,
+	} = attributes;
+
 	const handleChangeTitle = ( title ) => setAttributes( { title } );
 
 	const resultsUrl = `https://app.crowdsignal.com/surveys/${ attributes.surveyId }/report/overview`;
@@ -35,6 +43,22 @@ const Sidebar = ( {
 		setAttributes( {
 			[ attribute ]: value,
 		} );
+
+	const handleSelectTriggerImage = ( media ) => {
+		setAttributes( {
+			triggerBackgroundImageId: media.id,
+			triggerBackgroundImage: media.url,
+		} );
+
+	};
+
+	const clearTriggerImage = () =>
+		setAttributes( {
+			triggerBackgroundImageId: 0,
+			triggerBackgroundImage: '',
+		} );
+
+	const triggerStyles = getTriggerStyles( attributes );
 
 	return (
 		<InspectorControls>
@@ -80,6 +104,44 @@ const Sidebar = ( {
 				{ shouldPromote && (
 					<SidebarPromote signalWarning={ signalWarning } />
 				) }
+			</PanelBody>
+			<PanelBody
+				title={ __( 'Feedback Button', 'crowdsignal-forms' ) }
+				initialOpen={ true }
+			>
+				<div className="crowdsignal-forms-feedback__trigger-settings">
+					<MediaUploadCheck>
+						<MediaUpload
+							allowedTypes={ [ 'image' ] }
+							onSelect={ handleSelectTriggerImage }
+							value={ triggerBackgroundImageId }
+							render={ ( { open } ) => (
+								<React.Fragment>
+									<Button
+										className="crowdsignal-forms-feedback__trigger-settings-trigger"
+										onClick={ open }
+										style={ triggerStyles }
+									>
+										{ ! triggerBackgroundImage && (
+											<Icon icon={ SignalIcon } size={ 70 } />
+										) }
+									</Button>
+
+									<Button
+										isSecondary
+										onClick={ open }
+									>
+										{ __( 'Upload Image', 'crowdsignal-forms' ) }
+									</Button>
+
+									<Button onClick={ clearTriggerImage }>
+										{ __( 'Clear', 'crowdsignal-forms' ) }
+									</Button>
+								</React.Fragment>
+							) }
+						/>
+					</MediaUploadCheck>
+				</div>
 			</PanelBody>
 			<PanelColorSettings
 				title={ __( 'Block styling', 'crowdsignal-forms' ) }

--- a/client/blocks/feedback/sidebar.js
+++ b/client/blocks/feedback/sidebar.js
@@ -13,7 +13,12 @@ import {
 	PanelBody,
 	TextControl,
 } from '@wordpress/components';
-import { InspectorControls, MediaUpload, MediaUploadCheck, PanelColorSettings } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	MediaUpload,
+	MediaUploadCheck,
+	PanelColorSettings,
+} from '@wordpress/block-editor';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 
@@ -30,10 +35,7 @@ const Sidebar = ( {
 	shouldPromote,
 	signalWarning,
 } ) => {
-	const {
-		triggerBackgroundImage,
-		triggerBackgroundImageId,
-	} = attributes;
+	const { triggerBackgroundImage, triggerBackgroundImageId } = attributes;
 
 	const handleChangeTitle = ( title ) => setAttributes( { title } );
 
@@ -49,7 +51,6 @@ const Sidebar = ( {
 			triggerBackgroundImageId: media.id,
 			triggerBackgroundImage: media.url,
 		} );
-
 	};
 
 	const clearTriggerImage = () =>
@@ -123,15 +124,18 @@ const Sidebar = ( {
 										style={ triggerStyles }
 									>
 										{ ! triggerBackgroundImage && (
-											<Icon icon={ SignalIcon } size={ 70 } />
+											<Icon
+												icon={ SignalIcon }
+												size={ 70 }
+											/>
 										) }
 									</Button>
 
-									<Button
-										isSecondary
-										onClick={ open }
-									>
-										{ __( 'Upload Image', 'crowdsignal-forms' ) }
+									<Button isSecondary onClick={ open }>
+										{ __(
+											'Upload Image',
+											'crowdsignal-forms'
+										) }
 									</Button>
 
 									<Button onClick={ clearTriggerImage }>

--- a/client/blocks/feedback/util.js
+++ b/client/blocks/feedback/util.js
@@ -17,5 +17,7 @@ export const getStyleVars = ( attributes, fallbackStyles ) =>
 	);
 
 export const getTriggerStyles = ( { triggerBackgroundImage } ) => ( {
-	backgroundImage: triggerBackgroundImage ? `url("${ triggerBackgroundImage }")` : 'none',
+	backgroundImage: triggerBackgroundImage
+		? `url("${ triggerBackgroundImage }")`
+		: 'none',
 } );

--- a/client/blocks/feedback/util.js
+++ b/client/blocks/feedback/util.js
@@ -15,3 +15,7 @@ export const getStyleVars = ( attributes, fallbackStyles ) =>
 		},
 		( _, key ) => `--crowdsignal-forms-${ kebabCase( key ) }`
 	);
+
+export const getTriggerStyles = ( { triggerBackgroundImage } ) => ( {
+	backgroundImage: triggerBackgroundImage ? `url("${ triggerBackgroundImage }")` : 'none',
+} );

--- a/client/components/feedback/index.js
+++ b/client/components/feedback/index.js
@@ -9,13 +9,13 @@ import { isEmpty } from 'lodash';
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
-import { Popover, TextControl, TextareaControl } from '@wordpress/components';
+import { Icon, Popover, TextControl, TextareaControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import SignalIcon from 'components/icon/signal';
-import { getStyleVars } from 'blocks/feedback/util';
+import { getStyleVars, getTriggerStyles } from 'blocks/feedback/util';
 import { withFallbackStyles } from 'components/with-fallback-styles';
 import { getFeedbackButtonPosition } from './util';
 import { updateFeedbackResponse } from 'data/feedback';
@@ -60,6 +60,11 @@ const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 
 	const classes = classnames( 'crowdsignal-forms-feedback' );
 
+	const triggerStyles = {
+		...position,
+		...getTriggerStyles( attributes ),
+	};
+
 	return (
 		<>
 			<div
@@ -70,9 +75,9 @@ const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 					ref={ triggerButton }
 					className="crowdsignal-forms-feedback__trigger"
 					onClick={ showDialog }
-					style={ position }
+					style={ triggerStyles }
 				>
-					<SignalIcon />
+					{ ! attributes.triggerBackgroundImage && <Icon icon={ SignalIcon } size={ 75 } /> }
 
 					{ active && (
 						<Popover

--- a/client/components/feedback/index.js
+++ b/client/components/feedback/index.js
@@ -9,7 +9,12 @@ import { isEmpty } from 'lodash';
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
-import { Icon, Popover, TextControl, TextareaControl } from '@wordpress/components';
+import {
+	Icon,
+	Popover,
+	TextControl,
+	TextareaControl,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -77,7 +82,9 @@ const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 					onClick={ showDialog }
 					style={ triggerStyles }
 				>
-					{ ! attributes.triggerBackgroundImage && <Icon icon={ SignalIcon } size={ 75 } /> }
+					{ ! attributes.triggerBackgroundImage && (
+						<Icon icon={ SignalIcon } size={ 75 } />
+					) }
 
 					{ active && (
 						<Popover

--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -1,7 +1,8 @@
 /** Public styles */
 
 .crowdsignal-forms-feedback__trigger {
-	background: transparent !important;
+	background: transparent;
+	background-size: cover;
 	border: 0;
 	border-radius: 50%;
 	box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.3);
@@ -12,6 +13,10 @@
 	position: fixed;
 	width: 75px;
 	z-index: 100;
+
+	&:hover {
+		background-size: cover;
+	}
 }
 
 .crowdsignal-forms-feedback__popover-wrapper.components-popover .components-popover__content {
@@ -55,6 +60,7 @@
 
 .crowdsignal-forms-feedback__trigger-button {
 	background-color: #fff;
+	background-size: cover;
 	border-radius: 25px;
 	box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.3);
 	height: 50px;

--- a/client/components/icon/signal.js
+++ b/client/components/icon/signal.js
@@ -3,10 +3,10 @@
  */
 import React from 'react';
 
-export default () => (
+export default ( { size = 24 } ) => (
 	<svg
-		width="75"
-		height="75"
+		width={ size }
+		height={ size }
 		viewBox="0 0 75 75"
 		fill="none"
 		xmlns="http://www.w3.org/2000/svg"

--- a/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
@@ -106,55 +106,63 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 	 */
 	private function attributes() {
 		return array(
-			'backgroundColor'     => array(
+			'backgroundColor'          => array(
 				'type' => 'string',
 			),
-			'buttonColor'         => array(
+			'buttonColor'              => array(
 				'type' => 'string',
 			),
-			'buttonTextColor'     => array(
+			'buttonTextColor'          => array(
 				'type' => 'string',
 			),
-			'emailPlaceholder'    => array(
+			'emailPlaceholder'         => array(
 				'type'    => 'string',
 				'default' => __( 'Your email (optional)', 'crowdsignal-forms' ),
 			),
-			'feedbackPlaceholder' => array(
+			'feedbackPlaceholder'      => array(
 				'type'    => 'string',
 				'default' => __( 'Please let us know how we can do better…', 'crowdsignal-forms' ),
 			),
-			'header'              => array(
+			'header'                   => array(
 				'type'    => 'string',
 				'default' => __( 'Hello there!', 'crowdsignal-forms' ),
 			),
-			'hideBranding'        => array(
+			'hideBranding'             => array(
 				'type'    => 'boolean',
 				'default' => false,
 			),
-			'submitButtonLabel'   => array(
+			'submitButtonLabel'        => array(
 				'type'    => 'string',
 				'default' => __( 'Submit', 'crowdsignal-forms' ),
 			),
-			'submitText'          => array(
+			'submitText'               => array(
 				'type'    => 'string',
 				'default' => __( 'Thanks for letting us know!', 'crowdsignal-forms' ),
 			),
-			'surveyId'            => array(
+			'surveyId'                 => array(
 				'type'    => 'number',
 				'default' => null,
 			),
-			'textColor'           => array(
+			'textColor'                => array(
 				'type' => 'string',
 			),
-			'title'               => array(
+			'triggerBackgroundImageId' => array(
+				'type'    => 'number',
+				'default' => 0,
+			),
+			'triggerBackgroundImage'   => array(
 				'type'    => 'string',
 				'default' => '',
 			),
-			'x'                   => array(
+			'title'                    => array(
+				'type'    => 'string',
+				'default' => '',
+			),
+			'x'                        => array(
 				'type'    => 'string',
 				'default' => 'right',
 			),
-			'y'                   => array(
+			'y'                        => array(
 				'type'    => 'string',
 				'default' => 'bottom',
 			),


### PR DESCRIPTION
This PR adds support for uploading custom images for the feedback dialog trigger button.  
There's now a `Feedback Button` section in the sidebar which will allow you to select a custom background for the dialog trigger button from your WordPress media library.

![Screen Shot 2021-04-16 at 8 20 00 PM](https://user-images.githubusercontent.com/8056203/115068517-a86e3080-9ef2-11eb-9ffe-b2b73b11ce24.png)

# Testing

Verify the new section in the sidebar is displayed correctly.
Try uploading an image and verify it's displayed on the post as well.
Removing the image should revert to the default 'signal button'.