### PR TITLE
Fix submit button hover

### DIFF
--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -56,6 +56,10 @@
 	justify-content: flex-end;
 	margin-top: 35px;
 	width: 100%;
+
+	&:hover {
+		color: var(--crowdsignal-forms-button-color);
+	}
 }
 
 .crowdsignal-forms-feedback__trigger-button {


### PR DESCRIPTION
The submit button inherits a `:hover` behavior that turns it invisible on 2021 theme. This PR applies the button color to the button wrapper text so the underlying button inherits a "viewable" color.

Try to read the above again, or watch the demos below.

Before:
![hover-before](https://user-images.githubusercontent.com/157240/115465689-59cbd980-a205-11eb-8249-5cec106e4af5.gif)

After:
![hover-after](https://user-images.githubusercontent.com/157240/115465755-749e4e00-a205-11eb-99a0-53efb3ef01fd.gif)

The change doesn't seem to affect other themes, like 2020, but worth checking.

## Test instructions
Checkout and `make client`. Visit a post with a Feedback block while using 2021 theme. Confirm the "Submit" button is visible when hover'd.
