### PR TITLE
Add email address hint

### DIFF
--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -154,6 +154,8 @@ const EditFeedbackBlock = ( props ) => {
 		get( accountInfo, [ 'signalCount', 'count' ] ) >=
 			get( accountInfo, [ 'signalCount', 'userLimit' ] );
 
+	const email = get( accountInfo, [ 'account', 'email' ] );
+
 	const classes = classnames(
 		'crowdsignal-forms-feedback',
 		`align-${ attributes.x }`,
@@ -173,6 +175,7 @@ const EditFeedbackBlock = ( props ) => {
 			<Sidebar
 				shouldPromote={ shouldPromote }
 				signalWarning={ signalWarning }
+				email={ email }
 				{ ...props }
 			/>
 

--- a/client/blocks/feedback/sidebar.js
+++ b/client/blocks/feedback/sidebar.js
@@ -23,7 +23,7 @@ import {
 	PanelColorSettings,
 } from '@wordpress/block-editor';
 import { decodeEntities } from '@wordpress/html-entities';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -38,6 +38,7 @@ const Sidebar = ( {
 	setAttributes,
 	shouldPromote,
 	signalWarning,
+	email,
 } ) => {
 	const { triggerBackgroundImage, triggerBackgroundImageId } = attributes;
 
@@ -120,6 +121,18 @@ const Sidebar = ( {
 					) }
 					checked={ attributes.emailResponses }
 					onChange={ handleChangeAttribute( 'emailResponses' ) }
+					help={
+						attributes.emailResponses &&
+						email &&
+						sprintf(
+							// translators: %s: email address
+							__(
+								'Responses will be sent to %s',
+								'crowdsignal-forms'
+							),
+							email
+						)
+					}
 				/>
 				{ shouldPromote && (
 					<SidebarPromote signalWarning={ signalWarning } />


### PR DESCRIPTION
This PR adds the email address responses will be sent to if available.

The email address is part of the account info securely retrieved from the platform.

## Test instructions
Checkout and `make client`. Edit a post with a Feedback block, check the email notifications toggle on the sidebar. It should show a hint under the toggle.

Fixes #89 