### PR TITLE
Update placement toolbar icon based on block position

### DIFF
--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -107,7 +107,7 @@
 	}
 
 	&.bottom-left svg {
-		transform: rotate(270deg);		
+		transform: rotate(270deg);
 	}
 }
 

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -96,6 +96,21 @@
 	grid-template-rows: auto auto;
 }
 
+.crowdsignal-forms-feedback__toolbar-position-toggle {
+
+	&.top-right svg {
+		transform: rotate(90deg);
+	}
+
+	&.bottom-right svg {
+		transform: rotate(180deg);
+	}
+
+	&.bottom-left svg {
+		transform: rotate(270deg);		
+	}
+}
+
 .crowdsignal-forms-feedback__position-button {
 	align-items: center;
 	box-shadow: none !important;

--- a/client/blocks/feedback/toolbar.js
+++ b/client/blocks/feedback/toolbar.js
@@ -20,7 +20,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { TopLeftPlacementIcon } from 'components/icon/placement';
+import PlacementIcon from 'components/icon/placement';
 import { views } from './constants';
 
 const blockPositions = [
@@ -39,8 +39,6 @@ const FeedbackToolbar = ( {
 	const handleViewChange = ( view ) => () => onViewChange( view );
 
 	const handleSetPosition = ( x, y ) => setAttributes( { x, y } );
-
-	// const { x, y } = attributes;
 
 	return (
 		<BlockControls>
@@ -71,9 +69,11 @@ const FeedbackToolbar = ( {
 						} }
 						renderToggle={ ( { onToggle } ) => (
 							<ToolbarButton
-								className="crowdsignal-forms-feedback__toolbar-position-toggle"
+								className={
+									`crowdsignal-forms-feedback__toolbar-position-toggle ${ attributes.y }-${ attributes.x }`
+								}
 								onClick={ onToggle }
-								icon={ TopLeftPlacementIcon }
+								icon={ PlacementIcon }
 							/>
 						) }
 						renderContent={ ( { onClose } ) => (

--- a/client/blocks/feedback/toolbar.js
+++ b/client/blocks/feedback/toolbar.js
@@ -69,9 +69,7 @@ const FeedbackToolbar = ( {
 						} }
 						renderToggle={ ( { onToggle } ) => (
 							<ToolbarButton
-								className={
-									`crowdsignal-forms-feedback__toolbar-position-toggle ${ attributes.y }-${ attributes.x }`
-								}
+								className={ `crowdsignal-forms-feedback__toolbar-position-toggle ${ attributes.y }-${ attributes.x }` }
 								onClick={ onToggle }
 								icon={ PlacementIcon }
 							/>

--- a/client/components/icon/placement.js
+++ b/client/components/icon/placement.js
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 
-export const TopLeftPlacementIcon = () => (
+const PlacementIcon = () => (
 	<svg
 		width="24"
 		height="24"
@@ -11,62 +11,11 @@ export const TopLeftPlacementIcon = () => (
 		fill="none"
 		xmlns="http://www.w3.org/2000/svg"
 	>
-		<rect x="4.5" y="11.25" width="1.5" height="1.5" fill="black" />
 		<rect x="3.75" y="3.75" width="3" height="3" fill="black" />
 		<rect x="18" y="4.5" width="1.5" height="1.5" fill="black" />
-		<rect x="18" y="11.25" width="1.5" height="1.5" fill="black" />
 		<rect x="18" y="18" width="1.5" height="1.5" fill="black" />
 		<rect x="4.5" y="18" width="1.5" height="1.5" fill="black" />
 	</svg>
 );
 
-export const TopRightPlacementIcon = () => (
-	<svg
-		width="24"
-		height="24"
-		viewBox="0 0 24 24"
-		fill="none"
-		xmlns="http://www.w3.org/2000/svg"
-	>
-		<rect x="4.5" y="11.25" width="1.5" height="1.5" fill="black" />
-		<rect x="4.5" y="4.5" width="1.5" height="1.5" fill="black" />
-		<rect x="17.25" y="3.75" width="3" height="3" fill="black" />
-		<rect x="18" y="11.25" width="1.5" height="1.5" fill="black" />
-		<rect x="18" y="18" width="1.5" height="1.5" fill="black" />
-		<rect x="4.5" y="18" width="1.5" height="1.5" fill="black" />
-	</svg>
-);
-
-export const BottomLeftPlacementIcon = () => (
-	<svg
-		width="24"
-		height="24"
-		viewBox="0 0 24 24"
-		fill="none"
-		xmlns="http://www.w3.org/2000/svg"
-	>
-		<rect x="4.5" y="11.25" width="1.5" height="1.5" fill="black" />
-		<rect x="4.5" y="4.5" width="1.5" height="1.5" fill="black" />
-		<rect x="18" y="4.5" width="1.5" height="1.5" fill="black" />
-		<rect x="18" y="11.25" width="1.5" height="1.5" fill="black" />
-		<rect x="18" y="18" width="1.5" height="1.5" fill="black" />
-		<rect x="3.75" y="17.25" width="3" height="3" fill="black" />
-	</svg>
-);
-
-export const BottomRightPlacementIcon = () => (
-	<svg
-		width="24"
-		height="24"
-		viewBox="0 0 24 24"
-		fill="none"
-		xmlns="http://www.w3.org/2000/svg"
-	>
-		<rect x="4.5" y="11.25" width="1.5" height="1.5" fill="black" />
-		<rect x="4.5" y="4.5" width="1.5" height="1.5" fill="black" />
-		<rect x="18" y="4.5" width="1.5" height="1.5" fill="black" />
-		<rect x="18" y="11.25" width="1.5" height="1.5" fill="black" />
-		<rect x="17.25" y="17.25" width="3" height="3" fill="black" />
-		<rect x="4.5" y="18" width="1.5" height="1.5" fill="black" />
-	</svg>
-);
+export default PlacementIcon;


### PR DESCRIPTION
This patch updates the icon of the placement popover to always reflect the current block position.

![Screen Shot 2021-04-23 at 8 31 17 PM](https://user-images.githubusercontent.com/8056203/115915010-0068e200-a473-11eb-863e-8369ee53b7f2.png)

# Testing

Try changing the block position and verify the correct dot is 'selected' on the icon.