### PR TITLE
Update feedback block meta

### DIFF
--- a/client/blocks/feedback/index.js
+++ b/client/blocks/feedback/index.js
@@ -11,13 +11,25 @@ import attributes from './attributes';
 import EditFeedbackBlock from './edit';
 
 export default {
-	title: __( 'Feedback', 'crowdsignal-forms' ),
+	title: __( 'Feedback Button', 'crowdsignal-forms' ),
 	description: __(
 		'Allow your audience to share some feedback with you',
 		'crowdsignal-forms'
 	),
 	category: 'crowdsignal-forms',
-	keywords: [ 'crowdsignal', __( 'feedback', 'crowdsignal-forms' ) ],
+	keywords: [
+		'crowdsignal',
+		__( 'feedback', 'crowdsignal-forms' ),
+		__( 'floating', 'crowdsignal-forms' ),
+		__( 'contact', 'crowdsignal-forms' ),
+		__( 'call to action', 'crowdsignal-forms' ),
+		__( 'cta', 'crowdsignal-forms' ),
+		__( 'button', 'crowdsignal-forms' ),
+		__( 'subscribe', 'crowdsignal-forms' ),
+		__( 'form', 'crowdsignal-forms' ),
+		__( 'email', 'crowdsignal-forms' ),
+		__( 'message', 'crowdsignal-forms' ),
+	],
 	icon: <FeedbackIcon />,
 	edit: EditFeedbackBlock,
 	supports: {

--- a/client/blocks/feedback/sidebar.js
+++ b/client/blocks/feedback/sidebar.js
@@ -211,7 +211,7 @@ const Sidebar = ( {
 			>
 				<SelectControl
 					value={ attributes.status }
-					label={ __( 'Survey Status', 'crowdsignal-forms' ) }
+					label={ __( 'Status', 'crowdsignal-forms' ) }
 					options={ [
 						{
 							label: __( 'Open', 'crowdsignal-forms' ),


### PR DESCRIPTION
This patch updates the feedback block meta. Changes include:

- Changed block name to `Feedback Button`
- Updated keywords
- Renamed `Survey Status` sidebar section to `Status`

# Testing

Verify the naming changes and that new keywords work as expected.