### PR TITLE
Fix notices placement in the editor for the feedback block

### DIFF
--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -51,11 +51,10 @@
 
 		&.vertical-align-bottom {
 			justify-content: flex-end;
-			flex-direction: column-reverse;
 
-			.crowdsignal-forms-feedback__popover {
-				margin-bottom: 15px;
-				margin-top: 0 1;
+			.crowdsignal-forms-feedback__trigger {
+				order: 99;
+				margin-top: 15px;
 			}
 		}
 


### PR DESCRIPTION
This patch fixes an issue with notices appearing below the block when it's positioned on the bottom.

Before:

![image](https://user-images.githubusercontent.com/8056203/115918280-a3bbf600-a477-11eb-80bd-3449d9d89960.png)

After:

![Screen Shot 2021-04-23 at 9 03 55 PM](https://user-images.githubusercontent.com/8056203/115918253-9b63bb00-a477-11eb-92d4-8ff0a11b873a.png)

# Testing

Trigger a notice by, for example, going into offline mode and making changes in the block. Make sure it appears correctly.
