### PR TITLE
Fix close button hover state when a custom image is used

### DIFF
--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -28,7 +28,7 @@
 	}
 
 	&.is-active {
-		background: var(--crowdsignal-forms-button-color);
+		background: var(--crowdsignal-forms-button-color) !important;
 
 		> svg {
 			fill: var(--crowdsignal-forms-button-text-color);


### PR DESCRIPTION
This change fixes the issue with the close button for the feedback block where it'd not change background correctly when activated while a background image is set.

# Testing

Create a feedback block and set a custom image for the feedback button.  
Verify that when the block is triggered, the button displays an 'x' icon on a solid background - same color as the other buttons.