### PR TITLE
Change sidebar URL for Crowdsignal

### DIFF
--- a/client/blocks/applause/sidebar.js
+++ b/client/blocks/applause/sidebar.js
@@ -79,13 +79,7 @@ const SideBar = ( {
 								'Publish this post to enable results on ',
 								'crowdsignal-forms'
 						  ) }
-					<ExternalLink
-						href={
-							resultsLinkEnabled
-								? viewResultsUrl
-								: 'https://www.crowdsignal.com'
-						}
-					>
+					<ExternalLink href="https://www.crowdsignal.com">
 						crowdsignal.com
 					</ExternalLink>
 				</p>

--- a/client/blocks/feedback/sidebar.js
+++ b/client/blocks/feedback/sidebar.js
@@ -86,13 +86,7 @@ const Sidebar = ( {
 								'Save the block to track results on ',
 								'crowdsignal-forms'
 						  ) }
-					<ExternalLink
-						href={
-							attributes.surveyId
-								? resultsUrl
-								: 'https://www.crowdsignal.com'
-						}
-					>
+					<ExternalLink href="https://www.crowdsignal.com">
 						crowdsignal.com
 					</ExternalLink>
 				</p>

--- a/client/blocks/nps/sidebar.js
+++ b/client/blocks/nps/sidebar.js
@@ -59,13 +59,7 @@ const Sidebar = ( {
 								'Save the block to track results on ',
 								'crowdsignal-forms'
 						  ) }
-					<ExternalLink
-						href={
-							attributes.surveyId
-								? resultsUrl
-								: 'https://www.crowdsignal.com'
-						}
-					>
+					<ExternalLink href="https://www.crowdsignal.com">
 						crowdsignal.com
 					</ExternalLink>
 				</p>

--- a/client/blocks/poll/sidebar.js
+++ b/client/blocks/poll/sidebar.js
@@ -167,13 +167,7 @@ const SideBar = ( {
 								'Publish this post to enable results on ',
 								'crowdsignal-forms'
 						  ) }
-					<ExternalLink
-						href={
-							resultsLinkEnabled
-								? viewResultsUrl
-								: 'https://www.crowdsignal.com'
-						}
-					>
+					<ExternalLink href="https://www.crowdsignal.com">
 						crowdsignal.com
 					</ExternalLink>
 				</p>

--- a/client/blocks/vote/sidebar.js
+++ b/client/blocks/vote/sidebar.js
@@ -70,13 +70,7 @@ const SideBar = ( {
 								'Publish this post to enable results on ',
 								'crowdsignal-forms'
 						  ) }
-					<ExternalLink
-						href={
-							resultsLinkEnabled
-								? viewResultsUrl
-								: 'https://www.crowdsignal.com'
-						}
-					>
+					<ExternalLink href="https://www.crowdsignal.com">
 						crowdsignal.com
 					</ExternalLink>
 				</p>


### PR DESCRIPTION
This PR

  - changes the URL to crowdsignal.com so it doesn't mutate to that of the results.

## Test instructions
Checkout and `make client`. Insert all our blocks on a post. The link to Crowdsignal on the "Results" section of the sidebar should always point to crowdsignal.com
