### PR TITLE
Fix feedback block's editor overlay issues on Safari

### DIFF
--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -160,7 +160,7 @@ const EditFeedbackBlock = ( props ) => {
 			right: window.innerWidth - ( contentBox.left + contentBox.width ),
 			top: contentBox.top,
 		} );
-	}, [ activeSidebar, editorFeatures.fullscreenMode, isSelected ] );
+	}, [ activeSidebar, editorFeatures.fullscreenMode, isSelected ] );
 
 	const toggleBlock = () => {
 		dispatch( 'core/block-editor' ).clearSelectedBlock();

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -33,6 +33,7 @@ import RetryNotice from 'components/retry-notice';
 const EditFeedbackBlock = ( props ) => {
 	const [ view, setView ] = useState( views.QUESTION );
 	const [ height, setHeight ] = useState( null );
+	const [ overlayPosition, setOverlayPosition ] = useState( {} );
 
 	const {
 		attributes,
@@ -147,6 +148,20 @@ const EditFeedbackBlock = ( props ) => {
 		setHeight( popover.current.offsetHeight );
 	}, [ attributes.header, popover.current ] );
 
+	useLayoutEffect( () => {
+		const contentWrapper = document.getElementsByClassName(
+			'interface-interface-skeleton__content'
+		)[ 0 ];
+		const contentBox = contentWrapper.getBoundingClientRect();
+
+		setOverlayPosition( {
+			bottom: window.innerHeight - ( contentBox.top + contentBox.height ),
+			left: contentBox.left,
+			right: window.innerWidth - ( contentBox.left + contentBox.width ),
+			top: contentBox.top,
+		} );
+	}, [ activeSidebar, editorFeatures.fullscreenMode, isSelected ] );
+
 	const toggleBlock = () => {
 		dispatch( 'core/block-editor' ).clearSelectedBlock();
 		triggerButton.current.parentElement.parentElement.parentElement.blur();
@@ -217,6 +232,7 @@ const EditFeedbackBlock = ( props ) => {
 							role="dialog"
 							className="crowdsignal-forms-feedback__popover-overlay"
 							onClick={ toggleBlock }
+							style={ overlayPosition }
 						/>
 
 						{ ! isExample && signalWarning && <SignalWarning /> }

--- a/client/components/feedback/util.js
+++ b/client/components/feedback/util.js
@@ -3,24 +3,20 @@
  */
 import { isObject } from 'lodash';
 
-const addFrameOffsets = ( offset, frame ) => {
-	const body = document.body;
-
-	return {
-		left: offset.left + frame.x + window.scrollX,
-		right:
-			offset.right +
-			( window.innerWidth > frame.left + frame.width
-				? body.offsetWidth - frame.left - frame.width
-				: 0 ),
-		top: offset.top + frame.y + window.scrollY,
-		bottom:
-			offset.bottom +
-			( window.innerHeight > frame.top + frame.height
-				? body.offsetHeight - frame.top - frame.height
-				: 0 ),
-	};
-};
+const addFrameOffsets = ( offset, frame ) => ( {
+	left: offset.left + frame.x + window.scrollX,
+	right:
+		offset.right +
+		( window.innerWidth > frame.left + frame.width
+			? window.innerWidth - frame.left - frame.width
+			: 0 ),
+	top: offset.top + frame.y + window.scrollY,
+	bottom:
+		offset.bottom +
+		( window.innerHeight > frame.top + frame.height
+			? window.innerHeight - frame.top - frame.height
+			: 0 ),
+} );
 
 const getFeedbackButtonHorizontalPosition = ( align, width, offset ) => {
 	return {


### PR DESCRIPTION
Addresses c/r5SXo3AO-tr. The issue only appears on Safari where the overlay covers portions of the editor UI such as the header bar or the sidebar when the feedback block is active due to Safari's `z-index` implementation.

Since we don't have control over the rest of the editor, I updated our block to manually position the overlay and only cover the content part of the editor.  
While at it I also fixed another issue I noticed, which was the button appearing too low if full screen mode was off.

## Testing

Verify the block overlay no longer covers editor controls on Safari.  
The button should now be correctly positioned in the editor when using a bottom position and with full screen mode off.