### PR TITLE
Prevent inputs from overflowing the popover on legacy themes

### DIFF
--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -74,6 +74,7 @@
 
 	input,
 	textarea {
+		box-sizing: border-box;
 		font-size: var(--crowdsignal-forms-text-size) !important;
 		padding: 16px !important;
 	}


### PR DESCRIPTION
Fixes c/LsSBBKkQ-tr. Looks like some of the old themes have some old-school styling rules as one might expect which is causing the input and the textarea to overflow the dialog.
Forcing `box-sizing: border-box` manually fixes the issue.

# Testing

The issue was found on Twenty Eleven. Install and activate the theme and verify the input and the textarea now fit correctly.