### PR TITLE
Add trigger custom styles

### DIFF
--- a/client/blocks/feedback/attributes.js
+++ b/client/blocks/feedback/attributes.js
@@ -62,13 +62,15 @@ export default {
 	textColor: {
 		type: 'string',
 	},
-	triggerShadow: {
-		type: 'boolean',
-		default: true,
-	},
 	triggerLabel: {
 		type: 'string',
 		default: __( 'Feedback', 'crowdsignal-forms' ),
+	},
+	triggerBackgroundColor: {
+		type: 'string',
+	},
+	triggerTextColor: {
+		type: 'string',
 	},
 	title: {
 		type: 'string',

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -202,7 +202,7 @@ const EditFeedbackBlock = ( props ) => {
 			>
 				<RichText
 					ref={ triggerButton }
-					className="wp-block-button__link crowdsignal-forms-feedback__feedback-button crowdsignal-forms-feedback__trigger"
+					className="wp-block-button__link crowdsignal-forms-feedback__trigger"
 					onChange={ handleChangeAttribute( 'triggerLabel' ) }
 					value={ triggerLabel }
 					allowedFormats={ [] }

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -138,7 +138,7 @@
 	}
 }
 
-.crowdsignal-forms-feedback__feedback-button {
+.crowdsignal-forms-feedback__trigger {
 
 	.is-active & {
 		cursor: text !important;

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -37,6 +37,10 @@
 		margin: 0 !important;
 		position: relative;
 
+		&.is-active .crowdsignal-forms-feedback__trigger {
+			cursor: text !important;
+		}
+
 		&.align-left {
 			align-items: flex-start;
 		}
@@ -135,13 +139,6 @@
 	&.is-active::before {
 		background-color: #000;
 		box-shadow: #000 0 0 0 2px;
-	}
-}
-
-.crowdsignal-forms-feedback__trigger {
-
-	.is-active & {
-		cursor: text !important;
 	}
 }
 

--- a/client/blocks/feedback/sidebar.js
+++ b/client/blocks/feedback/sidebar.js
@@ -107,16 +107,31 @@ const Sidebar = ( {
 					<SidebarPromote signalWarning={ signalWarning } />
 				) }
 			</PanelBody>
-			<PanelBody
+
+			<PanelColorSettings
 				title={ __( 'Feedback Button', 'crowdsignal-forms' ) }
-				initialOpen={ true }
+				initialOpen={ false }
+				colorSettings={ [
+					{
+						label: __( 'Background color', 'crowdsignal-forms' ),
+						onChange: handleChangeAttribute(
+							'triggerBackgroundColor'
+						),
+						value: attributes.triggerBackgroundColor,
+					},
+					{
+						label: __( 'Text color', 'crowdsignal-forms' ),
+						onChange: handleChangeAttribute( 'triggerTextColor' ),
+						value: attributes.triggerTextColor,
+					},
+				] }
 			>
 				<ToggleControl
 					label={ __( 'Hide Shadow', 'crowdsignal-forms' ) }
 					checked={ attributes.hideTriggerShadow }
 					onChange={ handleChangeAttribute( 'hideTriggerShadow' ) }
 				/>
-			</PanelBody>
+			</PanelColorSettings>
 			<PanelColorSettings
 				title={ __( 'Block styling', 'crowdsignal-forms' ) }
 				initialOpen={ false }

--- a/client/blocks/feedback/util.js
+++ b/client/blocks/feedback/util.js
@@ -12,6 +12,10 @@ export const getStyleVars = ( attributes, fallbackStyles ) =>
 				attributes.buttonTextColor || fallbackStyles.textColorInverted,
 			textColor: attributes.textColor || fallbackStyles.textColor,
 			textSize: fallbackStyles.textSize,
+			triggerBackgroundColor:
+				attributes.triggerBackgroundColor || fallbackStyles.accentColor,
+			triggerTextColor:
+				attributes.triggerTextColor || fallbackStyles.textColorInverted,
 		},
 		( _, key ) => `--crowdsignal-forms-${ kebabCase( key ) }`
 	);

--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -9,21 +9,22 @@
 .crowdsignal-forms-feedback__trigger {
 	box-shadow: 1px 1px 7px rgba(0, 0, 0, 0.3);
 	cursor: pointer;
-	background-color: var(--crowdsignal-forms-button-color) !important;
-	color: var(--crowdsignal-forms-button-text-color) !important;
-	display: flex;
+	background-color: var(--crowdsignal-forms-trigger-background-color) !important;
+	color: var(--crowdsignal-forms-trigger-text-color) !important;
+	display: flex !important;
 	align-items: center;
 	font-size: 16px !important;
-	line-height: 150 !important;
+	line-height: 1.5 !important;
 	padding: 12px 16px !important;
 
+	> svg {
+		fill: currentColor;
+	}
+
 	&.is-active {
-		background: var(--crowdsignal-forms-button-color) !important;
+		background: var(--crowdsignal-forms-trigger-background-color) !important;
 		padding-left: 12px !important;
 
-		> svg {
-			fill: var(--crowdsignal-forms-button-text-color);
-		}
 	}
 
 	.crowdsignal-forms-feedback.no-shadow & {

--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -15,7 +15,7 @@
 	align-items: center;
 	font-size: 16px !important;
 	line-height: 1.5 !important;
-	padding: 12px 16px !important;
+	padding: 10px 16px !important;
 
 	> svg {
 		fill: currentColor;

--- a/client/components/feedback/toggle.js
+++ b/client/components/feedback/toggle.js
@@ -24,9 +24,8 @@ const CloseButton = () => (
 
 const FeedbackToggle = ( { attributes, className, isOpen, onClick }, ref ) => {
 	const classes = classnames(
-		'wp-block-button__link',
-		'crowdsignal-forms-feedback__feedback-button',
 		'crowdsignal-forms-feedback__trigger',
+		'wp-block-button__link',
 		className,
 		{
 			'is-active': isOpen,

--- a/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
@@ -127,83 +127,81 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 	 */
 	private function attributes() {
 		return array(
-			'backgroundColor'          => array(
+			'backgroundColor'        => array(
 				'type' => 'string',
 			),
-			'buttonColor'              => array(
+			'buttonColor'            => array(
 				'type' => 'string',
 			),
-			'buttonTextColor'          => array(
+			'buttonTextColor'        => array(
 				'type' => 'string',
 			),
-			'emailPlaceholder'         => array(
+			'emailPlaceholder'       => array(
 				'type'    => 'string',
 				'default' => __( 'Your Email (optional)', 'crowdsignal-forms' ),
 			),
-			'feedbackPlaceholder'      => array(
+			'feedbackPlaceholder'    => array(
 				'type'    => 'string',
 				'default' => __( 'Please let us know how we can do better…', 'crowdsignal-forms' ),
 			),
-			'header'                   => array(
+			'header'                 => array(
 				'type'    => 'string',
 				'default' => __( '👋 Hey there!', 'crowdsignal-forms' ),
 			),
-			'hideBranding'             => array(
+			'hideBranding'           => array(
 				'type'    => 'boolean',
 				'default' => false,
 			),
-			'hideTriggerShadow'        => array(
+			'hideTriggerShadow'      => array(
 				'type'    => 'boolean',
 				'default' => false,
 			),
-			'submitButtonLabel'        => array(
+			'submitButtonLabel'      => array(
 				'type'    => 'string',
 				'default' => __( 'Submit', 'crowdsignal-forms' ),
 			),
-			'submitText'               => array(
+			'submitText'             => array(
 				'type'    => 'string',
 				'default' => __( 'Thanks for letting us know!', 'crowdsignal-forms' ),
 			),
-			'surveyId'                 => array(
+			'surveyId'               => array(
 				'type'    => 'number',
 				'default' => null,
 			),
-			'textColor'                => array(
+			'textColor'              => array(
 				'type' => 'string',
 			),
-			'triggerBackgroundImageId' => array(
-				'type'    => 'number',
-				'default' => 0,
-			),
-			'triggerBackgroundImage'   => array(
-				'type'    => 'string',
-				'default' => '',
-			),
-			'triggerLabel'             => array(
+			'triggerLabel'           => array(
 				'type'    => 'string',
 				'default' => __( 'Feedback', 'crowdsignal-forms' ),
 			),
-			'title'                    => array(
+			'triggerBackgroundColor' => array(
+				'type' => 'string',
+			),
+			'triggerTextColor'       => array(
+				'type' => 'string',
+			),
+			'title'                  => array(
 				'type'    => 'string',
 				'default' => '',
 			),
-			'x'                        => array(
+			'x'                      => array(
 				'type'    => 'string',
 				'default' => 'right',
 			),
-			'y'                        => array(
+			'y'                      => array(
 				'type'    => 'string',
 				'default' => 'bottom',
 			),
-			'status'                   => array(
+			'status'                 => array(
 				'type'    => 'string',
 				'default' => 'open', // See: client/blocks/feedback/constants.js.
 			),
-			'closedAfterDateTime'      => array(
+			'closedAfterDateTime'    => array(
 				'type'    => 'string',
 				'default' => null,
 			),
-			'emailResponses'           => array(
+			'emailResponses'         => array(
 				'type'    => 'boolean',
 				'default' => true,
 			),


### PR DESCRIPTION
This PR will:

  - add 2 new attributes: triggerBackgroundColor and triggerTextColor
  - remove unused attribuet triggerShadow
  - fix svg color on trigger button
  - add Sidebar section to customize colors and shadow
  - isolate submit and trigger button styles
 
## Test instructions
Checkout and `make client`. Use a Feedback block on a post. Confirm Sidebar section and apply styles to the trigger button.

Tested on themes:

  - 2021
  - 2020
  - Astra
  - Seedlet
  - 2017
  - 2019
  - Neve