### PR TITLE
Add close status notification

### DIFF
--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -201,7 +201,7 @@ const EditFeedbackBlock = ( props ) => {
 		height,
 	};
 
-	const isCurrentlyClosed =
+	const isClosed =
 		FeedbackStatus.CLOSED === attributes.status ||
 		( FeedbackStatus.CLOSED_AFTER === attributes.status &&
 			null !== attributes.closedAfterDateTime &&
@@ -314,7 +314,7 @@ const EditFeedbackBlock = ( props ) => {
 								/>
 							</div>
 						) }
-						{ isCurrentlyClosed && (
+						{ isClosed && (
 							<div className="crowdsignal-forms-feedback__closed-notice">
 								{ __(
 									'This Feedback Form is Closed',

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -317,7 +317,7 @@ const EditFeedbackBlock = ( props ) => {
 						{ isCurrentlyClosed && (
 							<div className="crowdsignal-forms-feedback__closed-notice">
 								{ __(
-									'This Feedback is set to "Closed"',
+									'This Feedback Form is Closed',
 									'crowdsignal-forms'
 								) }
 							</div>

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -12,6 +12,7 @@ import { RichText } from '@wordpress/block-editor';
 import { TextControl, TextareaControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withSelect, dispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -26,7 +27,7 @@ import { getStyleVars } from './util';
 import { useAutosave } from 'components/use-autosave';
 import { updateFeedback } from 'data/feedback/edit';
 import SignalWarning from 'components/signal-warning';
-import { views } from './constants';
+import { views, FeedbackStatus } from './constants';
 import RetryNotice from 'components/retry-notice';
 
 const EditFeedbackBlock = ( props ) => {
@@ -200,6 +201,12 @@ const EditFeedbackBlock = ( props ) => {
 		height,
 	};
 
+	const isCurrentlyClosed =
+		FeedbackStatus.CLOSED === attributes.status ||
+		( FeedbackStatus.CLOSED_AFTER === attributes.status &&
+			null !== attributes.closedAfterDateTime &&
+			new Date().toISOString() > attributes.closedAfterDateTime );
+
 	return (
 		<ConnectToCrowdsignal>
 			<Toolbar
@@ -305,6 +312,14 @@ const EditFeedbackBlock = ( props ) => {
 									value={ attributes.submitText }
 									allowedFormats={ [] }
 								/>
+							</div>
+						) }
+						{ isCurrentlyClosed && (
+							<div className="crowdsignal-forms-feedback__closed-notice">
+								{ __(
+									'This Feedback is set to "Closed"',
+									'crowdsignal-forms'
+								) }
 							</div>
 						) }
 					</>

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -160,8 +160,8 @@
 }
 
 .crowdsignal-forms-feedback__closed-notice {
-	background-color: #b00;
-	color: #fff;
+	background-color: var(--crowdsignal-forms-button-color);
+	color: var(--crowdsignal-forms-button-text-color);
 	text-align: center;
 	width: 100%;
 }

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -160,8 +160,11 @@
 }
 
 .crowdsignal-forms-feedback__closed-notice {
-	background-color: var(--crowdsignal-forms-button-color);
-	color: var(--crowdsignal-forms-button-text-color);
+	background-color: #1e1e1e;
+	color: #fff;
 	text-align: center;
 	width: 100%;
+	font-size: 14px;
+	line-height: 1.5;
+	padding: 6px;
 }

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -158,3 +158,10 @@
 	padding: 0;
 	width: 70px;
 }
+
+.crowdsignal-forms-feedback__closed-notice {
+	background-color: #B00;
+	color: #FFF;
+	text-align: center;
+	width: 100%;
+}

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -160,8 +160,8 @@
 }
 
 .crowdsignal-forms-feedback__closed-notice {
-	background-color: #B00;
-	color: #FFF;
+	background-color: #b00;
+	color: #fff;
 	text-align: center;
 	width: 100%;
 }

--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -4,6 +4,11 @@
 	display: flex;
 	position: fixed;
 	z-index: 100;
+
+	> div:last-child:not(.crowdsignal-forms-feedback__trigger) {
+		border-bottom-left-radius: 10px;
+		border-bottom-right-radius: 10px;
+	}
 }
 
 .crowdsignal-forms-feedback__trigger {
@@ -42,11 +47,9 @@
 
 .crowdsignal-forms-feedback__popover {
 	background-color: var(--crowdsignal-forms-background-color);
-	border-bottom-left-radius: 10px;
-	border-bottom-right-radius: 10px;
 	border-top: 10px solid var(--crowdsignal-forms-button-color);
 	box-shadow: 1px 1px 7px rgba(0, 0, 0, 0.3);
-	color: var(--crowdsignal-forms-background-color);
+	color: var(--crowdsignal-forms-text-color);
 	outline: 0;
 	padding: 24px;
 	width: 380px;


### PR DESCRIPTION
This PR adds a notice at the bottom of the popover to indicate if the Feedback block is closed or its expiry date has passed

## Test instructions
Checkout and `make client`. On a Feedback block, change settings to "Closed" or "Closed after" and a past date. The notice should be noticeable