### PR TITLE
Untangle styles for the feedback toggle in the editor

### DIFF
--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -186,8 +186,6 @@ const EditFeedbackBlock = ( props ) => {
 
 	const classes = classnames(
 		'crowdsignal-forms-feedback',
-		'wp-block-button',
-		'crowdsignal-forms-feedback__button-wrapper',
 		`align-${ attributes.x }`,
 		`vertical-align-${ attributes.y }`,
 		{
@@ -218,15 +216,17 @@ const EditFeedbackBlock = ( props ) => {
 				className={ classes }
 				style={ getStyleVars( attributes, fallbackStyles ) }
 			>
-				<RichText
-					ref={ triggerButton }
-					className="wp-block-button__link crowdsignal-forms-feedback__trigger"
-					onChange={ handleChangeAttribute( 'triggerLabel' ) }
-					value={ triggerLabel }
-					allowedFormats={ [] }
-					multiline={ false }
-					disableLineBreaks={ true }
-				/>
+				<div className="wp-block-button crowdsignal-forms-feedback__trigger-wrapper">
+					<RichText
+						ref={ triggerButton }
+						className="wp-block-button__link crowdsignal-forms-feedback__trigger"
+						onChange={ handleChangeAttribute( 'triggerLabel' ) }
+						value={ triggerLabel }
+						allowedFormats={ [] }
+						multiline={ false }
+						disableLineBreaks={ true }
+					/>
+				</div>
 
 				{ ( isExample || isSelected ) && (
 					<>

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -26,10 +26,6 @@
 		z-index: -1;
 	}
 
-	.crowdsignal-forms-feedback__popover {
-		margin-top: 15px;
-	}
-
 	.crowdsignal-forms-feedback {
 		display: flex;
 		flex-direction: column;
@@ -50,15 +46,22 @@
 		}
 
 		&.vertical-align-top {
+
+			.crowdsignal-forms-feedback__trigger-wrapper {
+				margin-bottom: 15px !important;
+				margin-top: 0 !important;
+			}
+
 			justify-content: flex-start;
 		}
 
 		&.vertical-align-bottom {
 			justify-content: flex-end;
 
-			.crowdsignal-forms-feedback__trigger {
+			.crowdsignal-forms-feedback__trigger-wrapper {
 				order: 99;
-				margin-top: 15px;
+				margin-bottom: 0 !important;
+				margin-top: 15px !important;
 			}
 		}
 

--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -6,6 +6,10 @@
 	z-index: 100;
 }
 
+.crowdsignal-forms-feedback__trigger-wrapper {
+	margin: 0 !important;
+}
+
 .crowdsignal-forms-feedback__trigger {
 	box-shadow: 1px 1px 7px rgba(0, 0, 0, 0.3);
 	cursor: pointer;

--- a/client/components/feedback/toggle.js
+++ b/client/components/feedback/toggle.js
@@ -33,7 +33,7 @@ const FeedbackToggle = ( { attributes, className, isOpen, onClick }, ref ) => {
 	);
 
 	return (
-		<div className="wp-block-button crowdsignal-forms-feedback__button-wrapper">
+		<div className="wp-block-button crowdsignal-forms-feedback__trigger-wrapper">
 			<button ref={ ref } className={ classes } onClick={ onClick }>
 				{ isOpen ? (
 					<CloseButton />


### PR DESCRIPTION
This patch fixes an issue with weird spacing issues around the feedback popover that was introduced in #100 and later reported in #108.

The issue was in using the same `crowdsignal-forms-feedback__button-wrapper` for the wrapper around the toggle button which needs to have different styling, and trying to make the entire block edit component into the wrapper.  
Adding a new dedicated wrapper element as well as a unique class name with the correct styles for both the editor and the public fixes the issue.

# Testing

The block should no longer have any weird margins between itself and the toolbar in the editor, or around the trigger on the post page.