### PR TITLE
Change default feedback button position to bottom left

### DIFF
--- a/client/blocks/feedback/attributes.js
+++ b/client/blocks/feedback/attributes.js
@@ -78,7 +78,7 @@ export default {
 	},
 	x: {
 		type: 'string',
-		default: 'right',
+		default: 'left',
 	},
 	y: {
 		type: 'string',

--- a/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
@@ -187,7 +187,7 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 			),
 			'x'                      => array(
 				'type'    => 'string',
-				'default' => 'right',
+				'default' => 'left',
 			),
 			'y'                      => array(
 				'type'    => 'string',


### PR DESCRIPTION
This patch updates the default feedback button placement from bottom right to bottom left - as we learned other content is potentially more likely to appear in that corner.

# Testing

Create a new feedback button block - it should appear in the bottom left corner.