### PR TITLE
Consistently name panel section "Settings" and subsection "Status"

### DIFF
--- a/client/blocks/applause/sidebar.js
+++ b/client/blocks/applause/sidebar.js
@@ -106,10 +106,10 @@ const SideBar = ( {
 					<SidebarPromote signalWarning={ signalWarning } />
 				) }
 			</PanelBody>
-			<PanelBody title={ __( 'Status', 'crowdsignal-forms' ) }>
+			<PanelBody title={ __( 'Settings', 'crowdsignal-forms' ) }>
 				<SelectControl
 					value={ attributes.pollStatus }
-					label={ __( 'Currently', 'crowdsignal-forms' ) }
+					label={ __( 'Status', 'crowdsignal-forms' ) }
 					options={ [
 						{
 							label: __( 'Open', 'crowdsignal-forms' ),

--- a/client/blocks/nps/sidebar.js
+++ b/client/blocks/nps/sidebar.js
@@ -115,7 +115,7 @@ const Sidebar = ( {
 			>
 				<SelectControl
 					value={ attributes.status }
-					label={ __( 'Survey Status', 'crowdsignal-forms' ) }
+					label={ __( 'Status', 'crowdsignal-forms' ) }
 					options={ [
 						{
 							label: __( 'Open', 'crowdsignal-forms' ),

--- a/client/blocks/poll/sidebar.js
+++ b/client/blocks/poll/sidebar.js
@@ -258,12 +258,12 @@ const SideBar = ( {
 				) }
 			</PanelBody>
 			<PanelBody
-				title={ __( 'Poll status', 'crowdsignal-forms' ) }
+				title={ __( 'Settings', 'crowdsignal-forms' ) }
 				initialOpen={ false }
 			>
 				<SelectControl
 					value={ attributes.pollStatus }
-					label={ __( 'Currently', 'crowdsignal-forms' ) }
+					label={ __( 'Status', 'crowdsignal-forms' ) }
 					options={ [
 						{
 							label: __( 'Open', 'crowdsignal-forms' ),

--- a/client/blocks/vote/sidebar.js
+++ b/client/blocks/vote/sidebar.js
@@ -97,10 +97,10 @@ const SideBar = ( {
 					<SidebarPromote signalWarning={ signalWarning } />
 				) }
 			</PanelBody>
-			<PanelBody title={ __( 'Status', 'crowdsignal-forms' ) }>
+			<PanelBody title={ __( 'Settings', 'crowdsignal-forms' ) }>
 				<SelectControl
 					value={ attributes.pollStatus }
-					label={ __( 'Currently', 'crowdsignal-forms' ) }
+					label={ __( 'Status', 'crowdsignal-forms' ) }
 					options={ [
 						{
 							label: __( 'Open', 'crowdsignal-forms' ),


### PR DESCRIPTION
This PR changes the Sidebar section to be consistently the same across all blocks

## Test instructions
Checkout and `make client`. Insert any/all plugin's block and check the Sidebar. There should always be a "Settings" section and, where applicable, a "Status" section to set if the poll/survey is open|closed|closed on.