### PR TITLE
Make branding enabled by default on atomic sites

### DIFF
--- a/includes/frontend/class-crowdsignal-forms-block.php
+++ b/includes/frontend/class-crowdsignal-forms-block.php
@@ -68,7 +68,8 @@ abstract class Crowdsignal_Forms_Block {
 	 * @return bool
 	 */
 	protected function should_hide_branding() {
-		$enable_branding = apply_filters( 'crowdsignal_forms_branding_enabled', false );
+		$enable_branding = defined( 'IS_ATOMIC' ) && IS_ATOMIC;
+		$enable_branding = apply_filters( 'crowdsignal_forms_branding_enabled', $enable_branding );
 		if ( ! $enable_branding ) {
 			return true;
 		}


### PR DESCRIPTION
This PR adds a default value to be passed to the filter `crowdsignal_forms_branding_enabled` based on defined constants. 

## Test instructions
This is mostly theoretical, as I still have to find a way to debug Atomic sites. 

Ref: p1620403053188500-slack-C7YPW6K40 