### PR TITLE
Fix poll styling issues

### DIFF
--- a/client/components/poll/answer.js
+++ b/client/components/poll/answer.js
@@ -87,10 +87,10 @@ const PollAnswer = ( {
 	);
 
 	return (
-		<>
+		<div className={ classes }>
 			{ AnswerStyle.RADIO === answerStyle && renderRadioAnswers() }
 			{ AnswerStyle.BUTTON === answerStyle && renderButtonAnswers() }
-		</>
+		</div>
 	);
 };
 

--- a/client/components/poll/answer.js
+++ b/client/components/poll/answer.js
@@ -87,10 +87,10 @@ const PollAnswer = ( {
 	);
 
 	return (
-		<div className={ classes }>
+		<>
 			{ AnswerStyle.RADIO === answerStyle && renderRadioAnswers() }
 			{ AnswerStyle.BUTTON === answerStyle && renderButtonAnswers() }
-		</div>
+		</>
 	);
 };
 

--- a/client/components/poll/style.scss
+++ b/client/components/poll/style.scss
@@ -163,6 +163,10 @@
 		margin-block-end: 12px;
 	}
 
+	& > .crowdsignal-forms-poll__answer {
+		margin-block-end: 0;
+	}
+
 	&:hover,
 	&.is-focused {
 		color: var(--crowdsignal-forms-submit-button-bg-color);

--- a/client/components/poll/style.scss
+++ b/client/components/poll/style.scss
@@ -27,7 +27,7 @@
 	}
 
 	h3.crowdsignal-forms-poll__question {
-		margin: 0 0 28px;
+		margin: 0 0 44px;
 
 		&:first-child {
 			margin-top: 0;
@@ -160,7 +160,7 @@
 	}
 
 	&:not(.is-button) {
-		margin-block-end: 16px;
+		margin-block-end: 12px;
 	}
 
 	&:hover,
@@ -276,6 +276,8 @@ div.crowdsignal-forms-poll__answer-label-wrapper {
 .crowdsignal-forms-poll__actions {
 	display: flex;
 	justify-content: flex-end;
+	margin-top: 32px;
+	margin-bottom: 16px;
 }
 
 .editor-styles-wrapper .crowdsignal-forms-poll .crowdsignal-forms-poll__actions,

--- a/client/components/poll/style.scss
+++ b/client/components/poll/style.scss
@@ -164,7 +164,7 @@
 		width: 100%;
 	}
 
-	& > .crowdsignal-forms-poll__answer {
+	> .crowdsignal-forms-poll__answer {
 		margin-block-end: 0;
 	}
 

--- a/client/components/poll/style.scss
+++ b/client/components/poll/style.scss
@@ -285,6 +285,7 @@ div.crowdsignal-forms-poll__answer-label-wrapper {
 
 	.wp-block-button.crowdsignal-forms-poll__block-button {
 		margin: 0;
+		line-height: 0;
 	}
 }
 

--- a/client/components/poll/style.scss
+++ b/client/components/poll/style.scss
@@ -44,6 +44,7 @@
 
 		.crowdsignal-forms-poll__question {
 			font-family: var(--crowdsignal-forms-question-font-family);
+			line-height: 1.4;
 		}
 
 		.crowdsignal-forms-poll__answer-label,

--- a/client/components/poll/style.scss
+++ b/client/components/poll/style.scss
@@ -134,7 +134,6 @@
 }
 
 .crowdsignal-forms-poll__answer {
-	cursor: pointer;
 	display: flex;
 	font-size: inherit;
 	font-weight: 600;
@@ -160,7 +159,9 @@
 	}
 
 	&:not(.is-button) {
+		cursor: pointer;
 		margin-block-end: 12px;
+		width: 100%;
 	}
 
 	& > .crowdsignal-forms-poll__answer {


### PR DESCRIPTION
This PR

  - adds a line-height directive for the poll question, consistently rendering the same height on both editor and public frontend
  - remove redundant wrapper class on answers so editor and public frontend for a more wysiwyg experience

It will also address a long overdue fix: answers could be clicked anywhere on the row, but only recognize the click when clicking ON the label/input.

## Test instructions
Checkout and `make client`. Insert a Poll block. Activate 2019 theme. Compare editor and public frontend. Line height should show the same height on both.
Check the height/separation on the answers, they should display (almost) exactly the same height on editor and public frontend