### PR TITLE
Hide CS logo on the popup form

### DIFF
--- a/client/components/feedback/popover.js
+++ b/client/components/feedback/popover.js
@@ -49,7 +49,7 @@ const FeedbackPopover = ( { attributes } ) => {
 			{ ! attributes.hideBranding && (
 				<FooterBranding
 					trackRef="cs-forms-feedback"
-					showLogo={ true }
+					showLogo={ view === views.SUBMIT }
 					message={ __(
 						'Collect your own feedback with Crowdsignal',
 						'crowdsignal-forms'


### PR DESCRIPTION
This PR hides the Crowdsignal logo on the form view and would only show it on the submit view

## Test instructions
Checkout and `make client`. Self hosted (as our docker) won't show branding, so you'd need to edit the blocks class to force a `return false` on `should_hide_branding` method:

`includes/frontend/class-crowdsignal-forms-block.php`, around line 71, add:
```php
	protected function should_hide_branding() {
		return false; // <-- ADD THIS LINE HERE
		$enable_branding = apply_filters( 'crowdsignal_forms_branding_enabled', false );
		if ( ! $enable_branding ) { ...
```

Visit the public view of a post with a Feedback block. See that the branding at the footer of the form does not show the logo on the right. Submit the form, the submit view should now display the logo on the right.