### PR TITLE
Fix verify info request logic

### DIFF
--- a/client/blocks/applause/edit.js
+++ b/client/blocks/applause/edit.js
@@ -36,7 +36,7 @@ const EditApplauseBlock = ( props ) => {
 		setAttributes
 	);
 
-	const accountInfo = useAccountInfo();
+	const accountInfo = get( useAccountInfo(), 'data', {} );
 
 	const shouldPromote = get( accountInfo, [
 		'signalCount',

--- a/client/blocks/applause/edit.js
+++ b/client/blocks/applause/edit.js
@@ -36,7 +36,7 @@ const EditApplauseBlock = ( props ) => {
 		setAttributes
 	);
 
-	const accountInfo = get( useAccountInfo(), 'data', {} );
+	const { accountInfo } = useAccountInfo();
 
 	const shouldPromote = get( accountInfo, [
 		'signalCount',

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -30,6 +30,7 @@ import SignalWarning from 'components/signal-warning';
 import { views, FeedbackStatus } from './constants';
 import RetryNotice from 'components/retry-notice';
 import FooterBranding from 'components/footer-branding';
+import FeedbackIcon from 'components/icon/feedback';
 
 const EditFeedbackBlock = ( props ) => {
 	const [ view, setView ] = useState( views.QUESTION );
@@ -253,7 +254,10 @@ const EditFeedbackBlock = ( props ) => {
 	);
 
 	return (
-		<ConnectToCrowdsignal>
+		<ConnectToCrowdsignal
+			blockName={ __( 'Feedback Button', 'crowdsignal-forms' ) }
+			blockIcon=<FeedbackIcon />
+		>
 			<Toolbar
 				currentView={ view }
 				onViewChange={ setView }

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -256,7 +256,7 @@ const EditFeedbackBlock = ( props ) => {
 	return (
 		<ConnectToCrowdsignal
 			blockName={ __( 'Feedback Button', 'crowdsignal-forms' ) }
-			blockIcon=<FeedbackIcon />
+			blockIcon={ <FeedbackIcon /> }
 		>
 			<Toolbar
 				currentView={ view }

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -65,8 +65,6 @@ const EditFeedbackBlock = ( props ) => {
 	const triggerButton = useRef( null );
 	const popover = useRef( null );
 
-	const accountInfo = useAccountInfo();
-
 	const { error: saveError, save: saveBlock } = useAutosave(
 		async ( data ) => {
 			dispatch( 'core/editor' ).lockPostSaving( clientId );
@@ -210,6 +208,8 @@ const EditFeedbackBlock = ( props ) => {
 	const handleChangeAttribute = ( key ) => ( value ) =>
 		setAttributes( { [ key ]: value } );
 
+	const accountInfo = get( useAccountInfo(), 'data', {} );
+
 	const shouldPromote = get( accountInfo, [
 		'signalCount',
 		'shouldDisplay',
@@ -248,7 +248,7 @@ const EditFeedbackBlock = ( props ) => {
 			null !== attributes.closedAfterDateTime &&
 			new Date().toISOString() > attributes.closedAfterDateTime );
 
-	const hideBranding = get( accountInfo, 'capabilities' ).includes(
+	const hideBranding = get( accountInfo, 'capabilities', [] ).includes(
 		'hide-branding'
 	);
 

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -208,7 +208,7 @@ const EditFeedbackBlock = ( props ) => {
 	const handleChangeAttribute = ( key ) => ( value ) =>
 		setAttributes( { [ key ]: value } );
 
-	const accountInfo = get( useAccountInfo(), 'data', {} );
+	const { accountInfo } = useAccountInfo();
 
 	const shouldPromote = get( accountInfo, [
 		'signalCount',

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -116,7 +116,7 @@ const EditFeedbackBlock = ( props ) => {
 	}, [ isSelected ] );
 
 	useLayoutEffect( () => {
-		if ( isExample ) {
+		if ( isExample || ! triggerButton.current ) {
 			return;
 		}
 

--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -109,9 +109,9 @@ const EditNpsBlock = ( props ) => {
 		'is-inactive': ! isExample && ! isSelected,
 	} );
 
-	const accountInfo = useAccountInfo();
+	const accountInfo = get( useAccountInfo(), 'data', {} );
 
-	const hideBranding = get( accountInfo, 'capabilities' ).includes(
+	const hideBranding = get( accountInfo, 'capabilities', [] ).includes(
 		'hide-branding'
 	);
 

--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -109,7 +109,7 @@ const EditNpsBlock = ( props ) => {
 		'is-inactive': ! isExample && ! isSelected,
 	} );
 
-	const accountInfo = get( useAccountInfo(), 'data', {} );
+	const { accountInfo } = useAccountInfo();
 
 	const hideBranding = get( accountInfo, 'capabilities', [] ).includes(
 		'hide-branding'

--- a/client/blocks/poll/constants.js
+++ b/client/blocks/poll/constants.js
@@ -99,12 +99,6 @@ export const ClosedPollState = Object.freeze( {
 	HIDDEN: 'hidden',
 } );
 
-export const ConnectedAccountState = Object.freeze( {
-	CONNECTED: 'connected',
-	NOT_CONNECTED: 'not-connected',
-	NOT_VERIFIED: 'not-verified',
-} );
-
 export const AnswerStyle = Object.freeze( {
 	RADIO: 'radio',
 	BUTTON: 'button',

--- a/client/blocks/poll/edit.js
+++ b/client/blocks/poll/edit.js
@@ -124,9 +124,9 @@ const PollBlock = ( props ) => {
 	const isHidden =
 		isClosed && ClosedPollState.HIDDEN === attributes.closedPollState;
 
-	const accountInfo = useAccountInfo();
+	const accountInfo = get( useAccountInfo(), 'data', {} );
 
-	const hideBranding = get( accountInfo, 'capabilities' ).includes(
+	const hideBranding = get( accountInfo, 'capabilities', [] ).includes(
 		'hide-branding'
 	);
 

--- a/client/blocks/poll/edit.js
+++ b/client/blocks/poll/edit.js
@@ -124,7 +124,7 @@ const PollBlock = ( props ) => {
 	const isHidden =
 		isClosed && ClosedPollState.HIDDEN === attributes.closedPollState;
 
-	const accountInfo = get( useAccountInfo(), 'data', {} );
+	const { accountInfo } = useAccountInfo();
 
 	const hideBranding = get( accountInfo, 'capabilities', [] ).includes(
 		'hide-branding'

--- a/client/blocks/vote/edit.js
+++ b/client/blocks/vote/edit.js
@@ -56,7 +56,7 @@ const EditVoteBlock = ( props ) => {
 
 	const voteItemStyleVars = getVoteStyleVars( attributes );
 
-	const accountInfo = useAccountInfo();
+	const accountInfo = get( useAccountInfo(), 'data', {} );
 
 	const shouldPromote = get( accountInfo, [
 		'signalCount',

--- a/client/blocks/vote/edit.js
+++ b/client/blocks/vote/edit.js
@@ -56,7 +56,7 @@ const EditVoteBlock = ( props ) => {
 
 	const voteItemStyleVars = getVoteStyleVars( attributes );
 
-	const accountInfo = get( useAccountInfo(), 'data', {} );
+	const { accountInfo } = useAccountInfo();
 
 	const shouldPromote = get( accountInfo, [
 		'signalCount',

--- a/client/components/connect-to-crowdsignal/index.js
+++ b/client/components/connect-to-crowdsignal/index.js
@@ -7,19 +7,21 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { useIsCsConnected } from 'data/hooks';
+import { useAccountInfo } from 'data/hooks';
 
 const ConnectToCrowdsignal = ( props ) => {
 	const { blockIcon, blockName, children } = props;
-	const {
-		isConnected,
-		isAccountVerified,
-		checkIsConnected,
-	} = useIsCsConnected();
+
+	const accountInfo = useAccountInfo();
+	const isConnected = accountInfo.data && accountInfo.data.id !== 0;
+	const isAccountVerified = !! accountInfo.data.is_verified;
 
 	const handleConnectClick = async () => {
 		const initialConnectedState = isConnected;
-		const { isNowConnected, isNowVerified } = await checkIsConnected();
+		const newAccountInfo = await accountInfo.reloadAccountInfo();
+
+		const isNowConnected = newAccountInfo.id !== 0;
+		const isNowVerified = !! newAccountInfo.is_verified;
 
 		if ( ! isNowConnected ) {
 			window.open( '/wp-admin/admin.php?page=crowdsignal-forms-setup' );

--- a/client/components/connect-to-crowdsignal/index.js
+++ b/client/components/connect-to-crowdsignal/index.js
@@ -12,13 +12,13 @@ import { useAccountInfo } from 'data/hooks';
 const ConnectToCrowdsignal = ( props ) => {
 	const { blockIcon, blockName, children } = props;
 
-	const accountInfo = useAccountInfo();
-	const isConnected = accountInfo.data && accountInfo.data.id !== 0;
-	const isAccountVerified = !! accountInfo.data.is_verified;
+	const { accountInfo, reloadAccountInfo } = useAccountInfo();
+	const isConnected = accountInfo && accountInfo.id !== 0;
+	const isAccountVerified = !! accountInfo.is_verified;
 
 	const handleConnectClick = async () => {
 		const initialConnectedState = isConnected;
-		const newAccountInfo = await accountInfo.reloadAccountInfo();
+		const newAccountInfo = await reloadAccountInfo();
 
 		const isNowConnected = newAccountInfo.id !== 0;
 		const isNowVerified = !! newAccountInfo.is_verified;

--- a/client/data/hooks/index.js
+++ b/client/data/hooks/index.js
@@ -86,35 +86,6 @@ export const usePollVote = (
 	};
 };
 
-export const useIsCsConnected = () => {
-	/* assume connection is enabled, so placeholder doesn't flash while we add a block and wait for the request */
-	const [ isConnected, setIsConnected ] = useState( true );
-	const [ isAccountVerified, setIsAccountVerified ] = useState( true );
-
-	const checkIsConnected = async () => {
-		const connectedState = await requestIsCsConnected();
-
-		const isNowConnected =
-			ConnectedAccountState.CONNECTED === connectedState ||
-			ConnectedAccountState.NOT_VERIFIED === connectedState;
-		const isNowVerified =
-			ConnectedAccountState.CONNECTED === connectedState;
-
-		setIsConnected( isNowConnected );
-		setIsAccountVerified( isNowVerified );
-
-		return {
-			isNowConnected,
-			isNowVerified,
-		};
-	};
-
-	useEffect( () => {
-		checkIsConnected();
-	}, [] );
-	return { isConnected, isAccountVerified, checkIsConnected };
-};
-
 const defaultAccountInfo = {
 	is_verified: true,
 	capabilities: [ 'hide-branding' ],

--- a/client/data/hooks/index.js
+++ b/client/data/hooks/index.js
@@ -132,10 +132,11 @@ export const useAccountInfo = () => {
 	const getAccountInfo = async () => {
 		const info = await requestAccountInfo();
 		setAccountInfo( info );
+		return info;
 	};
 
 	useEffect( () => {
 		getAccountInfo();
 	}, [] );
-	return accountInfo;
+	return { data: accountInfo, reloadAccountInfo: getAccountInfo };
 };

--- a/client/data/hooks/index.js
+++ b/client/data/hooks/index.js
@@ -107,5 +107,5 @@ export const useAccountInfo = () => {
 	useEffect( () => {
 		getAccountInfo();
 	}, [] );
-	return { data: accountInfo, reloadAccountInfo: getAccountInfo };
+	return { accountInfo, reloadAccountInfo: getAccountInfo };
 };

--- a/client/data/hooks/index.js
+++ b/client/data/hooks/index.js
@@ -11,11 +11,9 @@ import {
 	requestResults,
 	requestVoteNonce,
 	requestVote,
-	requestIsCsConnected,
 	requestAccountInfo,
 } from 'data/poll';
 import { useFetch } from './util';
-import { ConnectedAccountState } from 'blocks/poll/constants';
 
 export const usePollResults = ( pollId, doFetch = true ) => {
 	const { data, error, loading } = useFetch(

--- a/includes/auth/class-default-api-auth-provider.php
+++ b/includes/auth/class-default-api-auth-provider.php
@@ -71,6 +71,9 @@ class Default_Api_Auth_Provider implements Api_Auth_Provider_Interface {
 				'headers' => array( 'Content-Type' => 'application/json' ),
 			)
 		);
+		if ( is_wp_error( $data ) ) {
+			return array();
+		}
 		return json_decode( $data['body'] );
 	}
 }

--- a/includes/frontend/blocks/class-crowdsignal-forms-poll-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-poll-block.php
@@ -100,7 +100,7 @@ class Crowdsignal_Forms_Poll_Block extends Crowdsignal_Forms_Block {
 			return true;
 		}
 
-		return ! parent::is_cs_connected();
+		return ! $this->is_cs_connected();
 	}
 
 	/**

--- a/includes/frontend/class-crowdsignal-forms-block.php
+++ b/includes/frontend/class-crowdsignal-forms-block.php
@@ -74,6 +74,9 @@ abstract class Crowdsignal_Forms_Block {
 			return true;
 		}
 
+		// TODO code review note:
+		// now that the gateway is caching get_account_info, hence, get_capabilities,
+		// should we remove this block?
 		if ( get_transient( self::TRANSIENT_HIDE_BRANDING ) ) {
 			return self::HIDE_BRANDING_YES === get_transient( self::TRANSIENT_HIDE_BRANDING );
 		}

--- a/includes/frontend/class-crowdsignal-forms-block.php
+++ b/includes/frontend/class-crowdsignal-forms-block.php
@@ -21,10 +21,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since   0.9.0
  */
 abstract class Crowdsignal_Forms_Block {
-	const TRANSIENT_HIDE_BRANDING = 'cs-hide-branding';
-	const HIDE_BRANDING_YES       = 'YES';
-	const HIDE_BRANDING_NO        = 'NO';
-
 	const STATUS_TYPE_OPEN      = 'open';
 	const STATUS_TYPE_CLOSED    = 'closed';
 	const STATUS_TYPE_SCHEDULED = 'closed-after';
@@ -74,28 +70,15 @@ abstract class Crowdsignal_Forms_Block {
 			return true;
 		}
 
-		// TODO code review note:
-		// now that the gateway is caching get_account_info, hence, get_capabilities,
-		// should we remove this block?
-		if ( get_transient( self::TRANSIENT_HIDE_BRANDING ) ) {
-			return self::HIDE_BRANDING_YES === get_transient( self::TRANSIENT_HIDE_BRANDING );
-		}
-
 		try {
 			$capabilities  = Crowdsignal_Forms::instance()->get_api_gateway()->get_capabilities();
-			$hide_branding = false !== array_search( 'hide-branding', $capabilities, true )
-				? self::HIDE_BRANDING_YES
-				: self::HIDE_BRANDING_NO;
+			$hide_branding = in_array( 'hide-branding', $capabilities, true );
 		} catch ( \Exception $ex ) {
 			// ignore error, we'll get the updated value next time.
-			$hide_branding = self::HIDE_BRANDING_YES;
+			$hide_branding = true;
 		}
-		set_transient(
-			self::TRANSIENT_HIDE_BRANDING,
-			$hide_branding,
-			MINUTE_IN_SECONDS
-		);
-		return self::HIDE_BRANDING_YES === $hide_branding;
+
+		return $hide_branding;
 	}
 
 	/**

--- a/includes/gateways/class-api-gateway.php
+++ b/includes/gateways/class-api-gateway.php
@@ -416,22 +416,11 @@ class Api_Gateway implements Api_Gateway_Interface {
 	 * @return array|\WP_Error
 	 */
 	public function get_capabilities() {
-		$response = $this->perform_request( 'GET', '/account/capabilities' );
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
+		$response_data = $this->get_account_info();
 
-		$body          = wp_remote_retrieve_body( $response );
-		$response_data = json_decode( $body, true );
-
-		if ( null === $response_data || ! is_array( $response_data ) ) {
-			if ( isset( $response_data['error'] ) ) {
-				return new \WP_Error( $response_data['error'], $response_data );
-			}
-			return new \WP_Error( 'decode-failed' );
-		}
-
-		return $response_data;
+		return isset( $response_data['capabilities'] )
+			? (bool) $response_data['capabilities']
+			: array();
 	}
 
 	/**
@@ -524,22 +513,11 @@ class Api_Gateway implements Api_Gateway_Interface {
 	 * @return bool|\WP_Error
 	 */
 	public function get_is_user_verified() {
-		$response = $this->perform_request( 'GET', '/account/verified' );
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
+		$response_data = $this->get_account_info();
 
-		$body          = wp_remote_retrieve_body( $response );
-		$response_data = json_decode( $body, true );
-
-		if ( null === $response_data || ! is_array( $response_data ) ) {
-			if ( isset( $response_data['error'] ) ) {
-				return new \WP_Error( $response_data['error'], $response_data );
-			}
-			return new \WP_Error( 'decode-failed' );
-		}
-
-		return $response_data['is_verified'];
+		return isset( $response_data['is_verified'] )
+			? (bool) $response_data['is_verified']
+			: false;
 	}
 
 	/**

--- a/includes/gateways/class-api-gateway.php
+++ b/includes/gateways/class-api-gateway.php
@@ -532,7 +532,6 @@ class Api_Gateway implements Api_Gateway_Interface {
 		$transient_key          = 'cs-forms-account-info-' . get_current_user_id();
 		$transient_account_info = get_transient( $transient_key );
 		if ( $transient_account_info ) {
-			error_log( 'from cached transient' );
 			return $transient_account_info;
 		}
 

--- a/includes/gateways/class-api-gateway.php
+++ b/includes/gateways/class-api-gateway.php
@@ -419,7 +419,7 @@ class Api_Gateway implements Api_Gateway_Interface {
 		$response_data = $this->get_account_info();
 
 		return isset( $response_data['capabilities'] )
-			? (bool) $response_data['capabilities']
+			? $response_data['capabilities']
 			: array();
 	}
 

--- a/includes/gateways/class-api-gateway.php
+++ b/includes/gateways/class-api-gateway.php
@@ -560,7 +560,11 @@ class Api_Gateway implements Api_Gateway_Interface {
 
 		} catch ( \Exception $ex ) {
 			// ignore error, we'll get the updated value next time.
-			$response_data = array( 'id' => 0 );
+			// Provide dummy response with safe defaults.
+			$response_data = array(
+				'id'           => 0,
+				'capabilities' => array( 'hide-branding' ),
+			);
 		}
 
 		return $response_data;


### PR DESCRIPTION
# Improves backend interaction with less requests

NOTE: enqueued for next release

This PR addresses a couple of hiccups when performing basic checks on the editor.

Mostly, this new implementation aims to be able to differentiate between a wrongly set up API Key and an unverified user. Right now, users with a wrong API Key would receive a notice stating the user has not verified its email, which leads to confusion among users and HEs.

One of the small refactors has been made on the *API gateway* file, which now uses the API request `/account/info` to get all related information and cache it for a minute. Related methods to get capabilities and user email verification status now rely on `get_account_info` and get the responses from there. This brings down the connection request checks from 2-5 seconds to 1s (uncached) and some 100-200ms once cached (testing on local, I expect to see improvements on remote scenarios as well).

All the logic made by ConnectToCrowdsignal component has been refactored to not use the particular request `/connected` and now evaluates the response from `/info` to derive the status.

## Test instructions
There are several use cases/scenarios we can test:

  - Failed connection to CS API: while working on docker/local environment, merely disable global http connections to CS API (sandboxed). This is unrecoverable and should never happen, but we want to react nicely just in case.
  - Setup the plugin to use a key, then delete the key: you should now get the right message stating that you should configure the plugin
