### PR TITLE
Implement a toggle for making feedback email mandatory

### DIFF
--- a/client/blocks/feedback/attributes.js
+++ b/client/blocks/feedback/attributes.js
@@ -28,6 +28,10 @@ export default {
 		type: 'string',
 		default: __( 'Your Email (optional)', 'crowdsignal-forms' ),
 	},
+	emailRequired: {
+		type: 'boolean',
+		default: false,
+	},
 	feedbackPlaceholder: {
 		type: 'string',
 		default: __(

--- a/client/blocks/feedback/attributes.js
+++ b/client/blocks/feedback/attributes.js
@@ -26,7 +26,7 @@ export default {
 	},
 	emailPlaceholder: {
 		type: 'string',
-		default: __( 'Your Email (optional)', 'crowdsignal-forms' ),
+		default: __( 'Your Email', 'crowdsignal-forms' ),
 	},
 	emailRequired: {
 		type: 'boolean',

--- a/client/blocks/feedback/sidebar.js
+++ b/client/blocks/feedback/sidebar.js
@@ -202,10 +202,7 @@ const Sidebar = ( {
 				) }
 
 				<ToggleControl
-					label={ __(
-						'Require email address',
-						'crowdsignal-forms'
-					) }
+					label={ __( 'Require email address', 'crowdsignal-forms' ) }
 					checked={ attributes.emailRequired }
 					onChange={ handleChangeAttribute( 'emailRequired' ) }
 				/>

--- a/client/blocks/feedback/sidebar.js
+++ b/client/blocks/feedback/sidebar.js
@@ -200,6 +200,15 @@ const Sidebar = ( {
 						is12Hour={ true }
 					/>
 				) }
+
+				<ToggleControl
+					label={ __(
+						'Require email address',
+						'crowdsignal-forms'
+					) }
+					checked={ attributes.emailRequired }
+					onChange={ handleChangeAttribute( 'emailRequired' ) }
+				/>
 			</PanelBody>
 		</InspectorControls>
 	);

--- a/client/components/feedback/form.js
+++ b/client/components/feedback/form.js
@@ -3,6 +3,7 @@
  */
 import React, { useState } from 'react';
 import { isEmpty } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -18,9 +19,19 @@ import { updateFeedbackResponse } from 'data/feedback';
 const FeedbackForm = ( { attributes, onSubmit } ) => {
 	const [ feedback, setFeedback ] = useState( '' );
 	const [ email, setEmail ] = useState( '' );
+	const [ errors, setErrors ] = useState( {} );
 
-	const handleSubmit = async () => {
-		if ( isEmpty( feedback ) ) {
+	const handleSubmit = async ( event ) => {
+		event.preventDefault();
+
+		const validation = {
+			feedback: isEmpty( feedback ),
+			email: attributes.emailRequired &&
+				( isEmpty( email ) || email.match( /^\s+@\s+$/ ) ),
+		};
+		setErrors( validation );
+
+		if ( validation.feedback || validation.email ) {
 			return;
 		}
 
@@ -33,8 +44,16 @@ const FeedbackForm = ( { attributes, onSubmit } ) => {
 		onSubmit();
 	};
 
+	const feedbackClasses = classnames( 'crowdsignal-forms-feedback__input', {
+		'is-error': errors.feedback,
+	} );
+
+	const emailClasses = classnames( 'crowdsignal-forms-feedback__input', {
+		'is-error': errors.email,
+	} );
+
 	return (
-		<>
+		<form onSubmit={ handleSubmit }>
 			<RichText.Content
 				tagName="h3"
 				className="crowdsignal-forms-feedback__header"
@@ -42,7 +61,7 @@ const FeedbackForm = ( { attributes, onSubmit } ) => {
 			/>
 
 			<TextareaControl
-				className="crowdsignal-forms-feedback__input"
+				className={ feedbackClasses }
 				rows={ 6 }
 				placeholder={ attributes.feedbackPlaceholder }
 				value={ feedback }
@@ -50,7 +69,7 @@ const FeedbackForm = ( { attributes, onSubmit } ) => {
 			/>
 
 			<TextControl
-				className="crowdsignal-forms-feedback__input"
+				className={ emailClasses }
 				placeholder={ attributes.emailPlaceholder }
 				value={ email }
 				onChange={ setEmail }
@@ -59,13 +78,12 @@ const FeedbackForm = ( { attributes, onSubmit } ) => {
 			<div className="wp-block-button crowdsignal-forms-feedback__button-wrapper">
 				<button
 					className="wp-block-button__link crowdsignal-forms-feedback__feedback-button"
-					type="button"
-					onClick={ handleSubmit }
+					type="submit"
 				>
 					{ attributes.submitButtonLabel }
 				</button>
 			</div>
-		</>
+		</form>
 	);
 };
 

--- a/client/components/feedback/form.js
+++ b/client/components/feedback/form.js
@@ -26,7 +26,8 @@ const FeedbackForm = ( { attributes, onSubmit } ) => {
 
 		const validation = {
 			feedback: isEmpty( feedback ),
-			email: attributes.emailRequired &&
+			email:
+				attributes.emailRequired &&
 				( isEmpty( email ) || email.match( /^\s+@\s+$/ ) ),
 		};
 		setErrors( validation );

--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -78,7 +78,22 @@
 
 .crowdsignal-forms-feedback__input {
 	margin-top: 16px;
+	position: relative;
 	width: 100%;
+	z-index: 1;
+
+	&.is-error::before {
+		border: 3px solid #d63638;
+		box-sizing: border-box;
+		content: "";
+		display: block;
+		position: absolute;
+		top: -4px;
+		left: -4px;
+		bottom: -4px;
+		right: -4px;
+		z-index: -1;
+	}
 
 	input,
 	textarea {

--- a/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
@@ -140,6 +140,10 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 				'type'    => 'string',
 				'default' => __( 'Your Email (optional)', 'crowdsignal-forms' ),
 			),
+			'emailRequired'          => array(
+				'type'    => 'boolean',
+				'default' => false,
+			),
 			'feedbackPlaceholder'    => array(
 				'type'    => 'string',
 				'default' => __( 'Please let us know how we can do better…', 'crowdsignal-forms' ),


### PR DESCRIPTION
This patch solves #99 by adding a toggle to make the email field in the feedback block required or optional under in the settings area of the sidebar. It also adds validation on the feedback block frontend, so if the feedback or the required email field are left empty, they should light up red after attempting to submit the form (#125).

I also used this opportunity to update the markup so it contains a proper `<form>` element which should help with possible submission issues that were reported in #129.

# Testing

Verify the new setting and validation for the email field works.