### PR TITLE
Add different toggle settings for the feedback button block

### DIFF
--- a/client/blocks/feedback/attributes.js
+++ b/client/blocks/feedback/attributes.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { FeedbackStatus } from './constants';
+import { FeedbackStatus, FeedbackToggleMode } from './constants';
 
 /**
  * Note: Any changes made to the attributes definition need to be duplicated in
@@ -65,6 +65,10 @@ export default {
 	},
 	textColor: {
 		type: 'string',
+	},
+	toggleOn: {
+		type: 'string',
+		default: FeedbackToggleMode.CLICK,
 	},
 	triggerLabel: {
 		type: 'string',

--- a/client/blocks/feedback/constants.js
+++ b/client/blocks/feedback/constants.js
@@ -8,3 +8,9 @@ export const FeedbackStatus = Object.freeze( {
 	CLOSED: 'closed',
 	CLOSED_AFTER: 'closed-after',
 } );
+
+export const FeedbackToggleMode = Object.freeze( {
+	CLICK: 'click',
+	HOVER: 'hover',
+	PAGE_LOAD: 'load',
+} );

--- a/client/blocks/feedback/sidebar.js
+++ b/client/blocks/feedback/sidebar.js
@@ -23,7 +23,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import SidebarPromote from 'components/sidebar-promote';
-import { FeedbackStatus } from './constants';
+import { FeedbackStatus, FeedbackToggleMode } from './constants';
 
 const Sidebar = ( {
 	attributes,
@@ -128,6 +128,26 @@ const Sidebar = ( {
 					label={ __( 'Hide Shadow', 'crowdsignal-forms' ) }
 					checked={ attributes.hideTriggerShadow }
 					onChange={ handleChangeAttribute( 'hideTriggerShadow' ) }
+				/>
+
+				<SelectControl
+					value={ attributes.toggleOn }
+					label={ __( 'Toggle on', 'crowdsignal-forms' ) }
+					options={ [
+						{
+							label: __( 'Click', 'crowdsignal-forms' ),
+							value: FeedbackToggleMode.CLICK,
+						},
+						{
+							label: __( 'Hover', 'crowdsignal-forms' ),
+							value: FeedbackToggleMode.HOVER,
+						},
+						{
+							label: __( 'Page load', 'crowdsignal-forms' ),
+							value: FeedbackToggleMode.PAGE_LOAD,
+						},
+					] }
+					onChange={ handleChangeAttribute( 'toggleOn' ) }
 				/>
 			</PanelColorSettings>
 			<PanelColorSettings

--- a/client/blocks/feedback/sidebar.js
+++ b/client/blocks/feedback/sidebar.js
@@ -129,26 +129,6 @@ const Sidebar = ( {
 					checked={ attributes.hideTriggerShadow }
 					onChange={ handleChangeAttribute( 'hideTriggerShadow' ) }
 				/>
-
-				<SelectControl
-					value={ attributes.toggleOn }
-					label={ __( 'Toggle on', 'crowdsignal-forms' ) }
-					options={ [
-						{
-							label: __( 'Click', 'crowdsignal-forms' ),
-							value: FeedbackToggleMode.CLICK,
-						},
-						{
-							label: __( 'Hover', 'crowdsignal-forms' ),
-							value: FeedbackToggleMode.HOVER,
-						},
-						{
-							label: __( 'Page load', 'crowdsignal-forms' ),
-							value: FeedbackToggleMode.PAGE_LOAD,
-						},
-					] }
-					onChange={ handleChangeAttribute( 'toggleOn' ) }
-				/>
 			</PanelColorSettings>
 			<PanelColorSettings
 				title={ __( 'Block styling', 'crowdsignal-forms' ) }
@@ -220,6 +200,29 @@ const Sidebar = ( {
 						is12Hour={ true }
 					/>
 				) }
+
+				<SelectControl
+					value={ attributes.toggleOn }
+					label={ __(
+						'Show feedback form on:',
+						'crowdsignal-forms'
+					) }
+					options={ [
+						{
+							label: __( 'Click', 'crowdsignal-forms' ),
+							value: FeedbackToggleMode.CLICK,
+						},
+						{
+							label: __( 'Hover', 'crowdsignal-forms' ),
+							value: FeedbackToggleMode.HOVER,
+						},
+						{
+							label: __( 'Page load', 'crowdsignal-forms' ),
+							value: FeedbackToggleMode.PAGE_LOAD,
+						},
+					] }
+					onChange={ handleChangeAttribute( 'toggleOn' ) }
+				/>
 
 				<ToggleControl
 					label={ __( 'Require email address', 'crowdsignal-forms' ) }

--- a/client/components/feedback/toggle.js
+++ b/client/components/feedback/toggle.js
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import React, { forwardRef, useLayoutEffect } from 'react';
+import React, {
+	forwardRef,
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+} from 'react';
 import classnames from 'classnames';
 
 /**
@@ -14,12 +19,29 @@ import { RichText } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import CloseIcon from 'components/icon/close-small';
+import { FeedbackToggleMode } from 'blocks/feedback/constants';
 
 const FeedbackToggle = (
 	{ attributes, className, isOpen, onClick, onToggle },
 	ref
 ) => {
 	useLayoutEffect( onToggle, [ isOpen ] );
+
+	useEffect( () => {
+		if ( isOpen || attributes.toggleOn !== FeedbackToggleMode.PAGE_LOAD ) {
+			return;
+		}
+
+		onClick();
+	}, [] );
+
+	const handleHover = useCallback( () => {
+		if ( isOpen || attributes.toggleOn !== FeedbackToggleMode.HOVER ) {
+			return;
+		}
+
+		onClick();
+	}, [ attributes.toggleOn, isOpen ] );
 
 	const classes = classnames(
 		'crowdsignal-forms-feedback__trigger',
@@ -33,7 +55,12 @@ const FeedbackToggle = (
 	return (
 		<div className="wp-block-button crowdsignal-forms-feedback__trigger-wrapper">
 			{ ! isOpen && (
-				<button ref={ ref } className={ classes } onClick={ onClick }>
+				<button
+					ref={ ref }
+					className={ classes }
+					onClick={ onClick }
+					onMouseEnter={ handleHover }
+				>
 					<RichText.Content
 						className="crowdsignal-forms-feedback__trigger-text"
 						value={ attributes.triggerLabel }

--- a/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
@@ -175,6 +175,10 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 			'textColor'              => array(
 				'type' => 'string',
 			),
+			'toggleOn'               => array(
+				'type'    => 'string',
+				'default' => 'click',
+			),
 			'triggerLabel'           => array(
 				'type'    => 'string',
 				'default' => __( 'Feedback', 'crowdsignal-forms' ),


### PR DESCRIPTION
This patch adds a new setting under the 'feedback button' section of the sidebar which allows to change how the feedback popup is triggered. The current options are:

- on click
- on hover
- on page load

Solves c/emTOHVUi-tr.

# Testing

Verify the new options work as described.