### PR TITLE
Add a vertical middle position for the feedback block

### DIFF
--- a/assets/stylesheets/editor.scss
+++ b/assets/stylesheets/editor.scss
@@ -2,6 +2,7 @@
 @import "./shared/variables.scss";
 
 // Components
+@import "components/block-alignment-control/style.scss";
 @import "components/connect-to-crowdsignal/style.scss";
 @import "components/editor-notice/style.scss";
 @import "components/sidebar-promote/style.scss";

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -128,8 +128,8 @@ const EditFeedbackBlock = ( props ) => {
 					blockRef.current.offsetWidth,
 					blockRef.current.offsetHeight,
 					{
-						left: 20,
-						right: 20,
+						left: attributes.y === 'center' ? 0 : 20,
+						right: attributes.y === 'center' ? 0 : 20,
 						top: isSelected ? 80 : 20,
 						bottom: 20,
 					},

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -3,7 +3,7 @@
  */
 import React, { useLayoutEffect, useEffect, useRef, useState } from 'react';
 import classnames from 'classnames';
-import { get } from 'lodash';
+import { get, max } from 'lodash';
 
 /**
  * WordPress depenencies
@@ -141,7 +141,20 @@ const EditFeedbackBlock = ( props ) => {
 			triggerButton.current.offsetHeight
 		);
 
+		const verticalTogglePadding =
+			( max( [
+				triggerButton.current.offsetWidth,
+				blockElement.current.offsetHeight,
+			] ) -
+				triggerButton.current.offsetWidth ) /
+			2;
+
 		setMargin( {
+			'--crowdsignal-forms-feedback__toggle-padding': `${ verticalTogglePadding }px`,
+			minHeight:
+				attributes.y === 'center'
+					? triggerButton.current.offsetWidth
+					: 0,
 			marginLeft:
 				attributes.y === 'center' && attributes.x === 'left'
 					? triggerButton.current.offsetHeight -
@@ -164,6 +177,7 @@ const EditFeedbackBlock = ( props ) => {
 		attributes.y,
 		triggerButton.current,
 		blockElement.current,
+		triggerLabel,
 	] );
 
 	useLayoutEffect( () => {

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -30,7 +30,6 @@ import SignalWarning from 'components/signal-warning';
 import { views, FeedbackStatus } from './constants';
 import RetryNotice from 'components/retry-notice';
 import FooterBranding from 'components/footer-branding';
-import { adjustFrameOffset } from 'components/feedback';
 
 const EditFeedbackBlock = ( props ) => {
 	const [ view, setView ] = useState( views.QUESTION );
@@ -60,7 +59,9 @@ const EditFeedbackBlock = ( props ) => {
 		triggerLabel,
 	} = attributes;
 
-	const blockRef = useRef( null );
+	const [ margin, setMargin ] = useState( {} );
+
+	const blockElement = useRef( null );
 	const triggerButton = useRef( null );
 	const popover = useRef( null );
 
@@ -121,27 +122,39 @@ const EditFeedbackBlock = ( props ) => {
 		}
 
 		setPosition(
-			adjustFrameOffset(
-				getFeedbackButtonPosition(
-					attributes.x,
-					attributes.y,
-					blockRef.current.offsetWidth,
-					blockRef.current.offsetHeight,
-					{
-						left: attributes.y === 'center' ? 0 : 20,
-						right: attributes.y === 'center' ? 0 : 20,
-						top: isSelected ? 80 : 20,
-						bottom: 20,
-					},
-					document.getElementsByClassName(
-						'interface-interface-skeleton__content'
-					)[ 0 ]
-				),
+			getFeedbackButtonPosition(
+				attributes.x,
 				attributes.y,
-				triggerButton.current.offsetWidth,
-				triggerButton.current.offsetHeight
-			)
+				blockElement.current.offsetWidth,
+				blockElement.current.offsetHeight,
+				{
+					left: attributes.y === 'center' ? 10 : 20,
+					right: attributes.y === 'center' ? 10 : 20,
+					top: isSelected ? 80 : 20,
+					bottom: 20,
+				},
+				document.getElementsByClassName(
+					'interface-interface-skeleton__content'
+				)[ 0 ]
+			),
+			triggerButton.current.offsetWidth,
+			triggerButton.current.offsetHeight
 		);
+
+		setMargin( {
+			marginLeft:
+				attributes.y === 'center' && attributes.x === 'left'
+					? triggerButton.current.offsetHeight -
+					  triggerButton.current.offsetWidth -
+					  10
+					: 0,
+			marginRight:
+				attributes.y === 'center' && attributes.x === 'right'
+					? triggerButton.current.offsetHeight -
+					  triggerButton.current.offsetWidth -
+					  10
+					: 0,
+		} );
 	}, [
 		activeSidebar,
 		editorFeatures.fullscreenMode,
@@ -150,7 +163,7 @@ const EditFeedbackBlock = ( props ) => {
 		attributes.x,
 		attributes.y,
 		triggerButton.current,
-		blockRef.current,
+		blockElement.current,
 	] );
 
 	useLayoutEffect( () => {
@@ -206,6 +219,11 @@ const EditFeedbackBlock = ( props ) => {
 		}
 	);
 
+	const styles = {
+		...getStyleVars( attributes, fallbackStyles ),
+		...margin,
+	};
+
 	const popoverStyles = {
 		height,
 	};
@@ -234,11 +252,7 @@ const EditFeedbackBlock = ( props ) => {
 				{ ...props }
 			/>
 
-			<div
-				ref={ blockRef }
-				className={ classes }
-				style={ getStyleVars( attributes, fallbackStyles ) }
-			>
+			<div ref={ blockElement } className={ classes } style={ styles }>
 				<div className="crowdsignal-forms-feedback__trigger-preview">
 					<div className="wp-block-button crowdsignal-forms-feedback__trigger-wrapper">
 						<RichText

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -75,7 +75,8 @@
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
-		margin: 0 !important;
+		margin-top: 0 !important;
+		margin-bottom: 0 !important;
 		position: relative;
 
 		&.is-active .crowdsignal-forms-feedback__trigger {

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -19,7 +19,8 @@
 	}
 
 	.crowdsignal-forms-feedback.is-vertical & {
-		align-items: center;
+		align-items: flex-start;
+		padding: var( --crowdsignal-forms-feedback__toggle-padding ) 0;
 		margin-right: 20px;
 	}
 

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -41,7 +41,7 @@
 		align-items: flex-start;
 	}
 
-	.crowdsignal-forms-feedback.align-right {
+	.crowdsignal-forms-feedback.align-right & {
 		align-items: flex-end;
 	}
 }

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -1,16 +1,47 @@
 /** Editor styles */
 
 .crowdsignal-forms-feedback__trigger-preview {
+	display: flex;
+
+	.crowdsignal-forms-feedback.align-right & {
+		justify-content: flex-end;
+	}
+
+	.crowdsignal-forms-feedback.vertical-align-top & {
+		margin-bottom: 15px !important;
+		margin-top: 0 !important;
+	}
+
+	.crowdsignal-forms-feedback.vertical-align-bottom & {
+		order: 99;
+		margin-bottom: 0 !important;
+		margin-top: 15px !important;
+	}
 
 	.crowdsignal-forms-feedback.is-vertical & {
 		align-items: center;
-		display: flex;
 		margin-right: 20px;
 	}
 
 	.crowdsignal-forms-feedback.is-vertical.align-right & {
 		margin-left: 20px;
 		margin-right: 0;
+	}
+}
+
+.crowdsignal-forms-feedback__popover-preview {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	margin: 0 !important;
+	position: relative;
+
+	.crowdsignal-forms-feedback.align-left & {
+		align-items: flex-start;
+	}
+
+	.crowdsignal-forms-feedback.align-right {
+		align-items: flex-end;
 	}
 }
 
@@ -73,42 +104,6 @@
 			// this width must match the width of
 			// .crowdsignal-forms-feedback__popover on components/feedback/style.scss
 			width: 380px;
-		}
-	}
-
-	.crowdsignal-forms-feedback__popover-preview {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		margin: 0 !important;
-		position: relative;
-
-		&.align-left {
-			align-items: flex-start;
-		}
-
-		&.align-right {
-			align-items: flex-end;
-		}
-
-		&.vertical-align-top {
-
-			.crowdsignal-forms-feedback__trigger-preview {
-				margin-bottom: 15px !important;
-				margin-top: 0 !important;
-			}
-
-			justify-content: flex-start;
-		}
-
-		&.vertical-align-bottom {
-			justify-content: flex-end;
-
-			.crowdsignal-forms-feedback__trigger-preview {
-				order: 99;
-				margin-bottom: 0 !important;
-				margin-top: 15px !important;
-			}
 		}
 	}
 

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -97,59 +97,6 @@
 	}
 }
 
-.crowdsignal-forms-feedback__toolbar-popover-wrapper .components-popover__content {
-	min-width: auto !important;
-}
-
-.crowdsignal-forms-feedback__toolbar-popover {
-	display: grid;
-	grid-template-columns: min-content min-content;
-	grid-template-rows: auto auto;
-}
-
-.crowdsignal-forms-feedback__toolbar-position-toggle {
-
-	&.top-right svg {
-		transform: rotate(90deg);
-	}
-
-	&.bottom-right svg {
-		transform: rotate(180deg);
-	}
-
-	&.bottom-left svg {
-		transform: rotate(270deg);
-	}
-}
-
-.crowdsignal-forms-feedback__position-button {
-	align-items: center;
-	box-shadow: none !important;
-	display: flex;
-	height: 30px;
-	justify-content: center;
-	outline: 0;
-	transition: all 120ms linear 0s;
-	width: 30px;
-
-	&::before {
-		background-color: #b5bcc2;
-		display: block;
-		content: "";
-		height: 6px;
-		width: 6px;
-	}
-
-	&:hover::before {
-		background-color: #007cba;
-	}
-
-	&.is-active::before {
-		background-color: #000;
-		box-shadow: #000 0 0 0 2px;
-	}
-}
-
 .crowdsignal-forms-feedback__trigger-settings {
 	align-items: center;
 	display: flex;

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -20,7 +20,7 @@
 
 	.crowdsignal-forms-feedback.is-vertical & {
 		align-items: flex-start;
-		padding: var( --crowdsignal-forms-feedback__toggle-padding ) 0;
+		padding: var(--crowdsignal-forms-feedback__toggle-padding) 0;
 		margin-right: 20px;
 	}
 

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -1,5 +1,19 @@
 /** Editor styles */
 
+.crowdsignal-forms-feedback__trigger-preview {
+
+	.crowdsignal-forms-feedback.is-vertical & {
+		align-items: center;
+		display: flex;
+		margin-right: 20px;
+	}
+
+	.crowdsignal-forms-feedback.is-vertical.align-right & {
+		margin-left: 20px;
+		margin-right: 0;
+	}
+}
+
 .editor-styles-wrapper {
 
 	.wp-block[data-type="crowdsignal-forms/feedback"] {
@@ -37,6 +51,38 @@
 			cursor: text !important;
 		}
 
+		&.is-vertical {
+			flex-direction: row;
+
+			.crowdsignal-forms-feedback__trigger-wrapper {
+				transform-origin: top right;
+				transform: rotateZ(270deg) translateY(-100%);
+			}
+		}
+
+		&.is-vertical.align-right {
+			flex-direction: row-reverse;
+
+			.crowdsignal-forms-feedback__trigger-wrapper {
+				transform-origin: top left;
+				transform: rotateZ(270deg) translateX(-100%);
+			}
+		}
+
+		.crowdsignal-forms__editor-notice {
+			// this width must match the width of
+			// .crowdsignal-forms-feedback__popover on components/feedback/style.scss
+			width: 380px;
+		}
+	}
+
+	.crowdsignal-forms-feedback__popover-preview {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		margin: 0 !important;
+		position: relative;
+
 		&.align-left {
 			align-items: flex-start;
 		}
@@ -47,7 +93,7 @@
 
 		&.vertical-align-top {
 
-			.crowdsignal-forms-feedback__trigger-wrapper {
+			.crowdsignal-forms-feedback__trigger-preview {
 				margin-bottom: 15px !important;
 				margin-top: 0 !important;
 			}
@@ -58,17 +104,11 @@
 		&.vertical-align-bottom {
 			justify-content: flex-end;
 
-			.crowdsignal-forms-feedback__trigger-wrapper {
+			.crowdsignal-forms-feedback__trigger-preview {
 				order: 99;
 				margin-bottom: 0 !important;
 				margin-top: 15px !important;
 			}
-		}
-
-		.crowdsignal-forms__editor-notice {
-			// this width must match the width of
-			// .crowdsignal-forms-feedback__popover on components/feedback/style.scss
-			width: 380px;
 		}
 	}
 

--- a/client/blocks/feedback/toolbar.js
+++ b/client/blocks/feedback/toolbar.js
@@ -2,34 +2,21 @@
  * External dependencies
  */
 import React from 'react';
-import classnames from 'classnames';
-import { map } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { BlockControls } from '@wordpress/block-editor';
-import {
-	Button,
-	Dropdown,
-	ToolbarButton,
-	ToolbarGroup,
-	Tooltip,
-} from '@wordpress/components';
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import PlacementIcon from 'components/icon/placement';
+import BlockAlignmentControl, {
+	GRID,
+} from 'components/block-alignment-control';
 import { views } from './constants';
-
-const blockPositions = [
-	{ x: 'left', y: 'top' },
-	{ x: 'right', y: 'top' },
-	{ x: 'left', y: 'bottom' },
-	{ x: 'right', y: 'bottom' },
-];
 
 const FeedbackToolbar = ( {
 	attributes,
@@ -39,7 +26,11 @@ const FeedbackToolbar = ( {
 } ) => {
 	const handleViewChange = ( view ) => () => onViewChange( view );
 
-	const handleSetPosition = ( x, y ) => setAttributes( { x, y } );
+	const handleSetPosition = ( row, column ) =>
+		setAttributes( {
+			x: column,
+			y: row,
+		} );
 
 	return (
 		<BlockControls>
@@ -62,52 +53,19 @@ const FeedbackToolbar = ( {
 				</ToolbarButton>
 			</ToolbarGroup>
 			<ToolbarGroup>
-				<div className="crowdsignal-forms-feedback__toolbar-position-toggle-wrapper">
-					<Dropdown
-						popoverProps={ {
-							className:
-								'crowdsignal-forms-feedback__toolbar-popover-wrapper',
-						} }
-						renderToggle={ ( { onToggle } ) => (
-							<Tooltip
-								text={ __(
-									'Change button position',
-									'crowdsignal-forms'
-								) }
-							>
-								<ToolbarButton
-									className={ `crowdsignal-forms-feedback__toolbar-position-toggle ${ attributes.y }-${ attributes.x }` }
-									onClick={ onToggle }
-									icon={ PlacementIcon }
-								/>
-							</Tooltip>
-						) }
-						renderContent={ ( { onClose } ) => (
-							<div className="crowdsignal-forms-feedback__toolbar-popover">
-								{ map( blockPositions, ( { x, y } ) => {
-									const buttonClasses = classnames(
-										'crowdsignal-forms-feedback__position-button',
-										{
-											'is-active':
-												attributes.x === x &&
-												attributes.y === y,
-										}
-									);
-
-									return (
-										<Button
-											className={ buttonClasses }
-											onClick={ () => {
-												handleSetPosition( x, y );
-												onClose();
-											} }
-										/>
-									);
-								} ) }
-							</div>
-						) }
-					/>
-				</div>
+				<BlockAlignmentControl
+					closeOnSelectionChanged
+					onChange={ handleSetPosition }
+					label={ __(
+						'Change button position',
+						'crowdsignal-forms'
+					) }
+					value={ {
+						row: attributes.y,
+						column: attributes.x,
+					} }
+					{ ...GRID[ '2x3' ] }
+				/>
 			</ToolbarGroup>
 		</BlockControls>
 	);

--- a/client/components/block-alignment-control/constants.js
+++ b/client/components/block-alignment-control/constants.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const GRID = {
+	'2x2': {
+		rows: [
+			{
+				label: __( `Top`, 'crowdsignal-forms' ),
+				value: 'top',
+			},
+			{
+				label: __( `Bottom`, 'crowdsignal-forms' ),
+				value: 'bottom',
+			},
+		],
+		columns: [
+			{
+				label: __( `Left`, 'crowdsignal-forms' ),
+				value: 'left',
+			},
+			{
+				label: __( `Right`, 'crowdsignal-forms' ),
+				value: 'right',
+			},
+		],
+	},
+	'2x3': {
+		rows: [
+			{
+				label: __( `Top`, 'crowdsignal-forms' ),
+				value: 'top',
+			},
+			{
+				label: __( `Center`, 'crowdsignal-forms' ),
+				value: 'center',
+			},
+			{
+				label: __( `Bottom`, 'crowdsignal-forms' ),
+				value: 'bottom',
+			},
+		],
+		columns: [
+			{
+				label: __( `Left`, 'crowdsignal-forms' ),
+				value: 'left',
+			},
+			{
+				label: __( `Right`, 'crowdsignal-forms' ),
+				value: 'right',
+			},
+		],
+	},
+};

--- a/client/components/block-alignment-control/grid-button.js
+++ b/client/components/block-alignment-control/grid-button.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import React, { useCallback } from 'react';
+import { CompositeItem } from 'reakit';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Tooltip, VisuallyHidden } from '@wordpress/components';
+
+const BlockAlignmentControlGridButton = ( {
+	isActive,
+	column,
+	onSelect,
+	row,
+	...props
+} ) => {
+	const label = `${ row.label } ${ column.label }`;
+
+	const handleSelect = useCallback( () => {
+		onSelect( row.value, column.value );
+	}, [ onSelect, row.value, column.value ] );
+
+	const classes = classnames(
+		'crowdsignal-forms__block-alignment-control-button',
+		{
+			'is-active': isActive,
+		}
+	);
+
+	return (
+		<Tooltip text={ label }>
+			<CompositeItem
+				className={ classes }
+				role="gridcell"
+				onFocus={ handleSelect }
+				{ ...props }
+			>
+				<VisuallyHidden>{ label }</VisuallyHidden>
+			</CompositeItem>
+		</Tooltip>
+	);
+};
+
+export default BlockAlignmentControlGridButton;

--- a/client/components/block-alignment-control/grid.js
+++ b/client/components/block-alignment-control/grid.js
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect } from 'react';
+import { Composite, CompositeGroup, useCompositeState } from 'reakit';
+import { map } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useInstanceId } from '@wordpress/compose';
+import { isRTL } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import GridButton from './grid-button';
+
+const getButtonId = ( prefix, row, column ) =>
+	`${ prefix }-${ row }-${ column }`;
+
+function BlockAlignmentControlGrid( { columns, onChange, rows, value } ) {
+	const baseId = useInstanceId(
+		BlockAlignmentControlGrid,
+		'block-alignment-control-grid'
+	);
+
+	const composite = useCompositeState( {
+		baseId,
+		currentId: getButtonId( baseId, value.row, value.column ),
+		rtl: isRTL(),
+	} );
+
+	useEffect( () => {
+		composite.setCurrentId(
+			getButtonId( baseId, value.row, value.column )
+		);
+	}, [ value, composite.setCurrentId ] );
+
+	return (
+		<Composite
+			{ ...composite }
+			className="crowdsignal-forms__block-alignment-control-grid"
+		>
+			{ map( rows, ( row ) => (
+				<CompositeGroup
+					{ ...composite }
+					key={ `${ baseId }-${ row.value }` }
+					role="row"
+					className="crowdsignal-forms__block-alignment-control-row"
+				>
+					{ map( columns, ( column ) => {
+						const id = getButtonId(
+							baseId,
+							row.value,
+							column.value
+						);
+						const isActive =
+							composite.currentId ===
+							getButtonId( baseId, row.value, column.value );
+
+						return (
+							<GridButton
+								{ ...composite }
+								id={ id }
+								key={ id }
+								isActive={ isActive }
+								row={ row }
+								column={ column }
+								onSelect={ onChange }
+								tabIndex={ isActive ? 0 : -1 }
+							/>
+						);
+					} ) }
+				</CompositeGroup>
+			) ) }
+		</Composite>
+	);
+}
+
+export default BlockAlignmentControlGrid;

--- a/client/components/block-alignment-control/icon.js
+++ b/client/components/block-alignment-control/icon.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+import { map } from 'lodash';
+
+const BlockAlignmentControlIcon = ( { rows, columns, value } ) => {
+	return (
+		<div className="crowdsignal-forms__block-alignment-control-icon">
+			{ map( rows, ( row ) => (
+				<div className="crowdsignal-forms__block-alignment-control-icon-row">
+					{ map( columns, ( column ) => {
+						const isActive =
+							row.value === value.row &&
+							column.value === value.column;
+
+						const classes = classnames(
+							'crowdsignal-forms__block-alignment-control-icon-dot',
+							{
+								'is-active': isActive,
+							}
+						);
+
+						return <span className={ classes } />;
+					} ) }
+				</div>
+			) ) }
+		</div>
+	);
+};
+
+export default BlockAlignmentControlIcon;

--- a/client/components/block-alignment-control/index.js
+++ b/client/components/block-alignment-control/index.js
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { ToolbarButton, Dropdown, Tooltip } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { DOWN } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import Grid from './grid';
+import Icon from './icon';
+
+const BlockAlignmentControl = ( {
+	closeOnSelectionChanged,
+	disabled,
+	label,
+	onChange,
+	rows,
+	columns,
+	value,
+} ) => {
+	const toolbarIcon = (
+		<Icon rows={ rows } columns={ columns } value={ value } />
+	);
+
+	return (
+		<Dropdown
+			className="crowdsignal-forms__block-alignment-control"
+			popoverProps={ {
+				className: 'crowdsignal-forms__block-alignment-control-popover',
+			} }
+			renderToggle={ ( { onToggle, isOpen } ) => {
+				const openOnArrowDown = ( event ) => {
+					if ( isOpen || event.keyCode !== DOWN ) {
+						return;
+					}
+
+					event.preventDefault();
+					event.stopPropagation();
+					onToggle();
+				};
+
+				return (
+					<Tooltip text={ label }>
+						<ToolbarButton
+							showTooltip
+							aria-haspopup="true"
+							aria-expanded={ isOpen }
+							disabled={ disabled }
+							icon={ toolbarIcon }
+							onClick={ onToggle }
+							onKeyDown={ openOnArrowDown }
+						/>
+					</Tooltip>
+				);
+			} }
+			renderContent={ ( { onClose } ) => {
+				const handleChange = ( row, column ) => {
+					onChange( row, column );
+
+					if (
+						closeOnSelectionChanged &&
+						( value.row !== row || value.column !== column )
+					) {
+						onClose();
+					}
+				};
+
+				return (
+					<Grid
+						onChange={ handleChange }
+						rows={ rows }
+						columns={ columns }
+						value={ value }
+					/>
+				);
+			} }
+		/>
+	);
+};
+
+BlockAlignmentControl.defaultProps = {
+	closeOnSelectionChanged: false,
+	label: __( 'Change block position', 'crowdsignal-forms' ),
+	onChange: noop,
+};
+
+export default BlockAlignmentControl;
+
+export { GRID } from './constants';

--- a/client/components/block-alignment-control/style.scss
+++ b/client/components/block-alignment-control/style.scss
@@ -1,0 +1,73 @@
+.crowdsignal-forms__block-alignment-control-popover {
+	.components-popover__content {
+		min-width: auto !important;
+	}
+}
+
+.crowdsignal-forms__block-alignment-control-grid {
+	display: flex;
+	flex-direction: column;
+}
+
+.crowdsignal-forms__block-alignment-control-row {
+	display: flex;
+}
+
+.crowdsignal-forms__block-alignment-control-button {
+	align-items: center;
+	border: 0;
+	background: transparent;
+	cursor: pointer;
+	display: flex;
+	height: 30px;
+	justify-content: center;
+	width: 30px;
+
+	&::before {
+		background-color: #b5bcc2;
+		display: block;
+		content: "";
+		height: 6px;
+		width: 6px;
+	}
+
+	&:hover::before {
+		background-color: #007cba;
+	}
+
+	&.is-active::before {
+		background-color: #000;
+		box-shadow: #000 0 0 0 2px;
+	}
+}
+
+.crowdsignal-forms__block-alignment-control-icon {
+	display: flex;
+	flex-direction: column;
+	height: 24px;
+	justify-content: space-between;
+	width: 24px;
+}
+
+.crowdsignal-forms__block-alignment-control-icon-row {
+	display: flex;
+	justify-content: space-between;
+	width: 100%;
+}
+
+.crowdsignal-forms__block-alignment-control-icon-dot {
+	display: flex;
+	padding: 2px;
+
+	&::before {
+		background-color: #000;
+		content: "";
+		display: block;
+		height: 2px;
+		width: 2px;
+	}
+
+	&.is-active::before {
+		box-shadow: #000 0 0 0 2px;
+	}
+}

--- a/client/components/block-alignment-control/style.scss
+++ b/client/components/block-alignment-control/style.scss
@@ -1,4 +1,5 @@
 .crowdsignal-forms__block-alignment-control-popover {
+
 	.components-popover__content {
 		min-width: auto !important;
 	}

--- a/client/components/feedback/index.js
+++ b/client/components/feedback/index.js
@@ -50,7 +50,9 @@ const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 					attributes.x,
 					attributes.y,
 					toggle.current.offsetWidth,
-					toggle.current.offsetHeight,
+					attributes.y === 'center'
+						? toggle.current.offsetWidth
+						: toggle.current.offsetHeight,
 					20,
 					document.body
 				),

--- a/client/components/feedback/index.js
+++ b/client/components/feedback/index.js
@@ -72,11 +72,14 @@ const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 		updatePosition();
 	}, [ attributes.x, attributes.y, updatePosition ] );
 
-	const classes = classnames( 'crowdsignal-forms-feedback', {
-		'no-shadow': attributes.hideTriggerShadow,
-		'is-vertical': attributes.y === 'center',
-		'is-right-aligned': attributes.x === 'right',
-	} );
+	const classes = classnames(
+		'crowdsignal-forms-feedback',
+		`align-${ attributes.x }`,
+		{
+			'no-shadow': attributes.hideTriggerShadow,
+			'is-vertical': attributes.y === 'center',
+		}
+	);
 
 	const styles = {
 		...position,

--- a/client/components/feedback/index.js
+++ b/client/components/feedback/index.js
@@ -38,6 +38,8 @@ const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 
 	const classes = classnames( 'crowdsignal-forms-feedback', {
 		'no-shadow': attributes.hideTriggerShadow,
+		'is-vertical': attributes.y === 'center',
+		'is-right-aligned': attributes.x === 'right',
 	} );
 
 	const styles = {

--- a/client/components/feedback/index.js
+++ b/client/components/feedback/index.js
@@ -33,8 +33,8 @@ export const adjustFrameOffset = ( position, verticalAlign, width, height ) => {
 
 	return {
 		...position,
-		left: position.left ? position.left - width + height : null,
-		right: position.right ? position.right - width + height : null,
+		left: position.left !== null ? position.left - width + height : null,
+		right: position.right !== null ? position.right - width + height : null,
 	};
 };
 
@@ -53,7 +53,12 @@ const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 					attributes.y === 'center'
 						? toggle.current.offsetWidth
 						: toggle.current.offsetHeight,
-					20,
+					{
+						top: 20,
+						bottom: 20,
+						left: attributes.y === 'center' ? 0 : 20,
+						right: attributes.y === 'center' ? 0 : 20,
+					},
 					document.body
 				),
 				attributes.y,

--- a/client/components/feedback/index.js
+++ b/client/components/feedback/index.js
@@ -26,7 +26,7 @@ const getPopoverPosition = ( x, y ) => {
 	return x === 'left' ? 'middle right' : 'middle left';
 };
 
-export const adjustFrameOffset = ( position, verticalAlign, width, height ) => {
+const adjustFrameOffset = ( position, verticalAlign, width, height ) => {
 	if ( verticalAlign !== 'center' ) {
 		return position;
 	}

--- a/client/components/feedback/index.js
+++ b/client/components/feedback/index.js
@@ -26,7 +26,7 @@ const getPopoverPosition = ( x, y ) => {
 	return x === 'left' ? 'middle right' : 'middle left';
 };
 
-const adjustFrameOffset = ( position, verticalAlign, width, height ) => {
+export const adjustFrameOffset = ( position, verticalAlign, width, height ) => {
 	if ( verticalAlign !== 'center' ) {
 		return position;
 	}

--- a/client/components/feedback/index.js
+++ b/client/components/feedback/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useLayoutEffect, useState, useRef } from 'react';
+import React, { useCallback, useLayoutEffect, useState, useRef } from 'react';
 import classnames from 'classnames';
 
 /**
@@ -18,23 +18,52 @@ import FeedbackToggle from './toggle';
 import FeedbackPopover from './popover';
 import { getFeedbackButtonPosition } from './util';
 
+const getPopoverPosition = ( x, y ) => {
+	if ( y !== 'center' ) {
+		return '';
+	}
+
+	return x === 'left' ? 'middle right' : 'middle left';
+};
+
+const adjustFrameOffset = ( position, verticalAlign, width, height ) => {
+	if ( verticalAlign !== 'center' ) {
+		return position;
+	}
+
+	return {
+		...position,
+		left: position.left ? position.left - width + height : null,
+		right: position.right ? position.right - width + height : null,
+	};
+};
+
 const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 	const [ position, setPosition ] = useState( {} );
 
 	const toggle = useRef( null );
 
-	useLayoutEffect( () => {
+	const updatePosition = useCallback( () => {
 		setPosition(
-			getFeedbackButtonPosition(
-				attributes.x,
+			adjustFrameOffset(
+				getFeedbackButtonPosition(
+					attributes.x,
+					attributes.y,
+					toggle.current.offsetWidth,
+					toggle.current.offsetHeight,
+					20,
+					document.body
+				),
 				attributes.y,
 				toggle.current.offsetWidth,
-				toggle.current.offsetHeight,
-				20,
-				document.body
+				toggle.current.offsetHeight
 			)
 		);
 	}, [ attributes.x, attributes.y, toggle.current ] );
+
+	useLayoutEffect( () => {
+		updatePosition();
+	}, [ attributes.x, attributes.y, updatePosition ] );
 
 	const classes = classnames( 'crowdsignal-forms-feedback', {
 		'no-shadow': attributes.hideTriggerShadow,
@@ -54,12 +83,17 @@ const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 					popoverProps={ {
 						className:
 							'crowdsignal-forms-feedback__popover-wrapper',
+						position: getPopoverPosition(
+							attributes.x,
+							attributes.y
+						),
 					} }
 					renderToggle={ ( { isOpen, onToggle } ) => (
 						<FeedbackToggle
 							ref={ toggle }
 							isOpen={ isOpen }
 							onClick={ onToggle }
+							onToggle={ updatePosition }
 							attributes={ attributes }
 						/>
 					) }

--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -18,7 +18,9 @@
 }
 
 .crowdsignal-forms-feedback__trigger-wrapper {
+	height: 0;
 	margin: 0 !important;
+	padding: 50% 0;
 }
 
 .crowdsignal-forms-feedback__trigger {
@@ -44,6 +46,17 @@
 
 	.crowdsignal-forms-feedback.no-shadow & {
 		box-shadow: none;
+	}
+
+	.crowdsignal-forms-feedback.is-vertical & {
+		margin-top: -50%;
+		transform-origin: top left;
+		transform: rotateZ(270deg) translateX(-100%);
+	}
+
+	.crowdsignal-forms-feedback.is-vertical.is-right-aligned & {
+		transform-origin: top right;
+		transform: rotateZ(270deg) translateY(-100%);
 	}
 }
 

--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -26,7 +26,7 @@
 		transform: rotateZ(270deg) translateY(-100%);
 	}
 
-	.crowdsignal-forms-feedback.is-vertical.is-right-aligned & {
+	.crowdsignal-forms-feedback.is-vertical.align-right & {
 		transform-origin: top left;
 		transform: rotateZ(270deg) translateX(-100%);
 	}
@@ -42,6 +42,7 @@
 	font-size: 16px !important;
 	line-height: 1.5 !important;
 	padding: 10px 16px !important;
+	white-space: nowrap !important;
 
 	> svg {
 		fill: currentColor;
@@ -55,6 +56,16 @@
 
 	.crowdsignal-forms-feedback.no-shadow & {
 		box-shadow: none;
+	}
+
+	.crowdsignal-forms-feedback.is-vertical.align-left & {
+		border-top-left-radius: 0 !important;
+		border-top-right-radius: 0 !important;
+	}
+
+	.crowdsignal-forms-feedback.is-vertical.align-right & {
+		border-bottom-left-radius: 0 !important;
+		border-bottom-right-radius: 0 !important;
 	}
 }
 

--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -3,7 +3,7 @@
 .crowdsignal-forms-feedback {
 	display: flex;
 	position: fixed;
-	z-index: 100;
+	z-index: 1000;
 
 	> div:last-child:not(.crowdsignal-forms-feedback__trigger) {
 		border-bottom-left-radius: 10px;
@@ -18,9 +18,18 @@
 }
 
 .crowdsignal-forms-feedback__trigger-wrapper {
-	height: 0;
 	margin: 0 !important;
-	padding: 50% 0;
+
+	.crowdsignal-forms-feedback.is-vertical & {
+		margin-top: -50%;
+		transform-origin: top right;
+		transform: rotateZ(270deg) translateY(-100%);
+	}
+
+	.crowdsignal-forms-feedback.is-vertical.is-right-aligned & {
+		transform-origin: top left;
+		transform: rotateZ(270deg) translateX(-100%);
+	}
 }
 
 .crowdsignal-forms-feedback__trigger {
@@ -46,17 +55,6 @@
 
 	.crowdsignal-forms-feedback.no-shadow & {
 		box-shadow: none;
-	}
-
-	.crowdsignal-forms-feedback.is-vertical & {
-		margin-top: -50%;
-		transform-origin: top left;
-		transform: rotateZ(270deg) translateX(-100%);
-	}
-
-	.crowdsignal-forms-feedback.is-vertical.is-right-aligned & {
-		transform-origin: top right;
-		transform: rotateZ(270deg) translateY(-100%);
 	}
 }
 

--- a/client/components/feedback/toggle.js
+++ b/client/components/feedback/toggle.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useEffect } from 'react';
 import classnames from 'classnames';
 
 /**
@@ -15,7 +15,12 @@ import { RichText } from '@wordpress/block-editor';
  */
 import CloseIcon from 'components/icon/close-small';
 
-const FeedbackToggle = ( { attributes, className, isOpen, onClick }, ref ) => {
+const FeedbackToggle = (
+	{ attributes, className, isOpen, onClick, onToggle },
+	ref
+) => {
+	useEffect( onToggle, [ isOpen ] );
+
 	const classes = classnames(
 		'crowdsignal-forms-feedback__trigger',
 		'wp-block-button__link',

--- a/client/components/feedback/toggle.js
+++ b/client/components/feedback/toggle.js
@@ -15,13 +15,6 @@ import { RichText } from '@wordpress/block-editor';
  */
 import CloseIcon from 'components/icon/close-small';
 
-const CloseButton = () => (
-	<>
-		<CloseIcon />
-		{ __( 'Close', 'crowdsignal-forms' ) }
-	</>
-);
-
 const FeedbackToggle = ( { attributes, className, isOpen, onClick }, ref ) => {
 	const classes = classnames(
 		'crowdsignal-forms-feedback__trigger',
@@ -34,13 +27,20 @@ const FeedbackToggle = ( { attributes, className, isOpen, onClick }, ref ) => {
 
 	return (
 		<div className="wp-block-button crowdsignal-forms-feedback__trigger-wrapper">
-			<button ref={ ref } className={ classes } onClick={ onClick }>
-				{ isOpen ? (
-					<CloseButton />
-				) : (
-					<RichText.Content value={ attributes.triggerLabel } />
-				) }
-			</button>
+			{ ! isOpen && (
+				<button ref={ ref } className={ classes } onClick={ onClick }>
+					<RichText.Content
+						className="crowdsignal-forms-feedback__trigger-text"
+						value={ attributes.triggerLabel }
+					/>
+				</button>
+			) }
+			{ isOpen && (
+				<button ref={ ref } className={ classes } onClick={ onClick }>
+					<CloseIcon />
+					{ __( 'Close', 'crowdsignal-forms' ) }
+				</button>
+			) }
 		</div>
 	);
 };

--- a/client/components/feedback/toggle.js
+++ b/client/components/feedback/toggle.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { forwardRef, useEffect } from 'react';
+import React, { forwardRef, useLayoutEffect } from 'react';
 import classnames from 'classnames';
 
 /**
@@ -19,7 +19,7 @@ const FeedbackToggle = (
 	{ attributes, className, isOpen, onClick, onToggle },
 	ref
 ) => {
-	useEffect( onToggle, [ isOpen ] );
+	useLayoutEffect( onToggle, [ isOpen ] );
 
 	const classes = classnames(
 		'crowdsignal-forms-feedback__trigger',

--- a/client/components/feedback/util.js
+++ b/client/components/feedback/util.js
@@ -62,11 +62,7 @@ export const getFeedbackButtonPosition = (
 	}
 
 	return {
-		...getFeedbackButtonHorizontalPosition(
-			align,
-			verticalAlign === 'center' ? height : width,
-			offset
-		),
+		...getFeedbackButtonHorizontalPosition( align, width, offset ),
 		...getFeedbackButtonVerticalPosition(
 			verticalAlign,
 			verticalAlign === 'center' ? width : height,

--- a/client/components/feedback/util.js
+++ b/client/components/feedback/util.js
@@ -26,6 +26,13 @@ const getFeedbackButtonHorizontalPosition = ( align, width, offset ) => {
 };
 
 const getFeedbackButtonVerticalPosition = ( verticalAlign, height, offset ) => {
+	if ( verticalAlign === 'center' ) {
+		return {
+			top: ( window.innerHeight - height ) / 2,
+			bottom: null,
+		};
+	}
+
 	return {
 		top: verticalAlign === 'top' ? offset.top : null,
 		bottom: verticalAlign === 'bottom' ? offset.bottom : null,
@@ -55,7 +62,15 @@ export const getFeedbackButtonPosition = (
 	}
 
 	return {
-		...getFeedbackButtonHorizontalPosition( align, width, offset ),
-		...getFeedbackButtonVerticalPosition( verticalAlign, height, offset ),
+		...getFeedbackButtonHorizontalPosition(
+			align,
+			verticalAlign === 'center' ? height : width,
+			offset
+		),
+		...getFeedbackButtonVerticalPosition(
+			verticalAlign,
+			verticalAlign === 'center' ? width : height,
+			offset
+		),
 	};
 };

--- a/client/components/feedback/util.js
+++ b/client/components/feedback/util.js
@@ -63,10 +63,6 @@ export const getFeedbackButtonPosition = (
 
 	return {
 		...getFeedbackButtonHorizontalPosition( align, width, offset ),
-		...getFeedbackButtonVerticalPosition(
-			verticalAlign,
-			verticalAlign === 'center' ? width : height,
-			offset
-		),
+		...getFeedbackButtonVerticalPosition( verticalAlign, height, offset ),
 	};
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3160,6 +3160,11 @@
 				"fastq": "^1.6.0"
 			}
 		},
+		"@popperjs/core": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
+			"integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q=="
+		},
 		"@romainberger/css-diff": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@romainberger/css-diff/-/css-diff-1.0.3.tgz",
@@ -6852,6 +6857,11 @@
 					"dev": true
 				}
 			}
+		},
+		"body-scroll-lock": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz",
+			"integrity": "sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg=="
 		},
 		"boolbase": {
 			"version": "1.0.0",
@@ -18133,6 +18143,39 @@
 				"graceful-fs": "^4.1.11",
 				"micromatch": "^3.1.10",
 				"readable-stream": "^2.0.2"
+			}
+		},
+		"reakit": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.8.tgz",
+			"integrity": "sha512-8SVejx6FUaFi2+Q9eXoDAd4wWi/xAn6v8JgXH8x2xnzye8pb6v5bYvegACVpYVZnrS5w/JUgMTGh1Xy8MkkPww==",
+			"requires": {
+				"@popperjs/core": "^2.5.4",
+				"body-scroll-lock": "^3.1.5",
+				"reakit-system": "^0.15.1",
+				"reakit-utils": "^0.15.1",
+				"reakit-warning": "^0.6.1"
+			}
+		},
+		"reakit-system": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.1.tgz",
+			"integrity": "sha512-PkqfAyEohtcEu/gUvKriCv42NywDtUgvocEN3147BI45dOFAB89nrT7wRIbIcKJiUT598F+JlPXAZZVLWhc1Kg==",
+			"requires": {
+				"reakit-utils": "^0.15.1"
+			}
+		},
+		"reakit-utils": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.1.tgz",
+			"integrity": "sha512-6cZgKGvOkAMQgkwU9jdYbHfkuIN1Pr+vwcB19plLvcTfVN0Or10JhIuj9X+JaPZyI7ydqTDFaKNdUcDP69o/+Q=="
+		},
+		"reakit-warning": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.1.tgz",
+			"integrity": "sha512-poFUV0EyxB+CcV9uTNBAFmcgsnR2DzAbOTkld4Ul+QOKSeEHZB3b3+MoZQgcYHmbvG19Na1uWaM7ES+/Eyr8tQ==",
+			"requires": {
+				"reakit-utils": "^0.15.1"
 			}
 		},
 		"realpath-native": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 	"dependencies": {
 		"js-cookie": "^2.2.1",
 		"react-transition-group": "^4.4.1",
+		"reakit": "^1.3.8",
 		"seedrandom": "^3.0.5",
 		"uuid": "^8.2.0"
 	},


### PR DESCRIPTION
This patch adds a vertically centered position for the feedback block.  
When this position is selected the button appears vertically and is positioned against the edge of the page and the popover should appear to the side of it.

As an additional improvement, I implemented our version of `<BlockAlignmentControl />` component which can be configured with any matrix size/configuration and can now be also navigated using the keyboard.

<img width="1154" alt="Screen Shot 2021-05-13 at 2 17 48 PM" src="https://user-images.githubusercontent.com/8056203/118124754-54257600-b3f6-11eb-8173-c9a5aa331956.png">

# Testing

You'll need to run `npm install` after you apply the patch.
Test that the new positions work in both the editor as well as the published page.