### PR TITLE
Add filter to control transform behavior

### DIFF
--- a/client/blocks/feedback/index.js
+++ b/client/blocks/feedback/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -44,3 +45,15 @@ export default {
 		},
 	},
 };
+
+// Prevent transforming this block to anything
+addFilter(
+	'blocks.registerBlockType',
+	'crowdsignal-forms/feedback',
+	( settings ) => {
+		return {
+			...settings,
+			transforms: null,
+		};
+	}
+);

--- a/client/editor.js
+++ b/client/editor.js
@@ -35,3 +35,13 @@ addFilter(
 	'crowdsignal-forms/with-fixed-position-control',
 	withFixedPositionControl
 );
+addFilter(
+	'blocks.registerBlockType',
+	'crowdsignal-forms/feedback',
+	( settings ) => {
+		return {
+			...settings,
+			transforms: null,
+		};
+	}
+);

--- a/client/editor.js
+++ b/client/editor.js
@@ -35,13 +35,3 @@ addFilter(
 	'crowdsignal-forms/with-fixed-position-control',
 	withFixedPositionControl
 );
-addFilter(
-	'blocks.registerBlockType',
-	'crowdsignal-forms/feedback',
-	( settings ) => {
-		return {
-			...settings,
-			transforms: null,
-		};
-	}
-);


### PR DESCRIPTION
This PR is another PoC in the attempt to prevent Feedback block to be transformed into other blocks that don't make sense. In particular, this adds a filter preventing any transformation of the block. However, Jetpack's "Premium Content" still can't be prevented.

With the filter in place, Column and Group are no longer available as a "Transform to" option, which is a good start I guess. Feedback block just doesn't make sense inside a column (its layout won't respect the column restrictions) and Group might have some valid use case, but none so far demonstrating to be useful.

Shall we consider this a successful change, it should also be applied to NPS block. 

## Test instructions
Checkout and `make client`. Insert a Feedback block and try to use the leftmost toolbar button to transform it into some other block, it shouldn't even display a list.
On Jetpack enabled sites, the list will only show "Premium Content"