### PR TITLE
Fix feedback form rendering issues on mobile screens

### DIFF
--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -3,7 +3,7 @@
 .crowdsignal-forms-feedback {
 	display: flex;
 	position: fixed;
-	z-index: 1000;
+	z-index: 9999999;
 
 	> div:last-child:not(.crowdsignal-forms-feedback__trigger) {
 		border-bottom-left-radius: 10px;
@@ -82,13 +82,25 @@
 	border-top: 10px solid var(--crowdsignal-forms-button-color);
 	box-shadow: 1px 1px 7px rgba(0, 0, 0, 0.3);
 	color: var(--crowdsignal-forms-text-color);
+	max-height: 480px;
 	outline: 0;
+	overflow-y: scroll;
 	padding: 24px;
-	width: 380px;
+	width: 240px;
 	text-align: left;
 	z-index: 100;
 	display: flex;
 	flex-direction: column;
+
+	@media screen and (min-width: 360px) {
+		max-height: 640px;
+		width: 300px;
+	}
+
+	@media screen and (min-width: 480px) {
+		max-height: auto;
+		width: 380px;
+	}
 }
 
 .crowdsignal-forms-feedback__header {


### PR DESCRIPTION
This small patch fixes some of the rendering issues we were dealing with on mobile, namely:

- The block should no longer be _shaking vigorously_ when triggered on a narrow screen.  
This was caused by the form actually being wider than the screen itself and constantly trying to reposition itself to fit. I added rules to limit its maximum width for screens between `320px` and `480px` wide.

- In case of a `320px` wide screen, there's a high probability the form also wouldn't fit vertically so I added an additional rule to make it scrollable for those. Not an ideal solution but not much else we can do without totally changing the interaction and making things inconsistent.

- I noticed that depending on where the popover is positioned, it'd sometimes get overlapped by WPs masterbar so I bumped our `z-index` property accordingly.

# Testing

Verify the block appears correctly on mobile screens.