### PR TITLE
Make transform filter match the blockname

### DIFF
--- a/client/blocks/feedback/index.js
+++ b/client/blocks/feedback/index.js
@@ -47,13 +47,13 @@ export default {
 };
 
 // Prevent transforming this block to anything
-addFilter(
-	'blocks.registerBlockType',
-	'crowdsignal-forms/feedback',
-	( settings ) => {
-		return {
-			...settings,
-			transforms: null,
-		};
-	}
-);
+// addFilter(
+// 	'blocks.registerBlockType',
+// 	'crowdsignal-forms/feedback',
+// 	( settings ) => {
+// 		return {
+// 			...settings,
+// 			transforms: null,
+// 		};
+// 	}
+// );

--- a/client/blocks/feedback/index.js
+++ b/client/blocks/feedback/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -47,13 +52,16 @@ export default {
 };
 
 // Prevent transforming this block to anything
-// addFilter(
-// 	'blocks.registerBlockType',
-// 	'crowdsignal-forms/feedback',
-// 	( settings ) => {
-// 		return {
-// 			...settings,
-// 			transforms: null,
-// 		};
-// 	}
-// );
+addFilter(
+	'blocks.registerBlockType',
+	'crowdsignal-forms/feedback',
+	( settings ) => {
+		if ( includes( [ 'crowdsignal-forms/feedback' ], settings.name ) ) {
+			return {
+				...settings,
+				transforms: null,
+			};
+		}
+		return settings;
+	}
+);


### PR DESCRIPTION
The filter is affecting ALL blocks and needs to be more specific.

This PR adds a condition before applying the filter.

## Test instructions

Checkout and `make client`. The block selector should show normally for any other block and empty for the Feedback Button block.