### PR TITLE
Remove the register filter

### DIFF
--- a/client/blocks/feedback/index.js
+++ b/client/blocks/feedback/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -45,15 +44,3 @@ export default {
 		},
 	},
 };
-
-// Prevent transforming this block to anything
-addFilter(
-	'blocks.registerBlockType',
-	'crowdsignal-forms/feedback',
-	( settings ) => {
-		return {
-			...settings,
-			transforms: null,
-		};
-	}
-);


### PR DESCRIPTION
This PR removes the filter put in place to avoid the block being transformed as it either turns problematic or doesn't solve the issue at all.

## Test instructions
Checkout and `make client`. The blocks functionality shouldn't have changed and they should be transformable to the default options from the editor (mostly Group and Column)