### PR TITLE
Add a widget-editor compatible interface for the feedback block

### DIFF
--- a/client/blocks/feedback/attributes.js
+++ b/client/blocks/feedback/attributes.js
@@ -108,4 +108,8 @@ export default {
 		type: 'boolean',
 		default: false,
 	},
+	isWidget: {
+		type: 'boolean',
+		default: false,
+	},
 };

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -1,7 +1,13 @@
 /**
  * External dependencies
  */
-import React, { useLayoutEffect, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+	useLayoutEffect,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import classnames from 'classnames';
 import { get, max } from 'lodash';
 
@@ -242,9 +248,14 @@ const EditFeedbackBlock = ( props ) => {
 	// Widget editor uses CSS `display: none;` to hide sections making it impossible to measure any elements
 	// until they're show. As such, we cannot detect when they actually become visible either.
 	// Hence the need to just repeat this on every render until we get a value.
-	const buttonHeight = ( widgetEditor && triggerButton.current && triggerButton.current.offsetHeight )
-		? `${ triggerButton.current && triggerButton.current.offsetHeight }px`
-		: null;
+	const buttonHeight =
+		widgetEditor &&
+		triggerButton.current &&
+		triggerButton.current.offsetHeight
+			? `${
+					triggerButton.current && triggerButton.current.offsetHeight
+			  }px`
+			: null;
 
 	const styles = {
 		...getStyleVars( attributes, fallbackStyles ),
@@ -335,9 +346,9 @@ const EditFeedbackBlock = ( props ) => {
 								</>
 							) }
 
-							{ ! isExample && ! widgetEditor && signalWarning && (
-								<SignalWarning />
-							) }
+							{ ! isExample &&
+								! widgetEditor &&
+								signalWarning && <SignalWarning /> }
 							{ ! isExample && ! widgetEditor && saveError && (
 								<RetryNotice retryHandler={ saveBlock } />
 							) }

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -108,12 +108,16 @@ const EditFeedbackBlock = ( props ) => {
 	);
 
 	// Force a save to Crowdsignal.com as soon as a new block is created
+	// Also make sure isWidget flag is set correctly
 	useEffect( () => {
 		if ( isExample || attributes.surveyId ) {
 			return;
 		}
 
 		saveBlock();
+		setAttributes( {
+			isWidget: widgetEditor,
+		} );
 	}, [] );
 
 	useEffect( () => {

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -87,6 +87,7 @@
 
 		&.is-active .crowdsignal-forms-feedback__trigger {
 			cursor: text !important;
+			white-space: pre-wrap !important;
 		}
 
 		&.is-vertical {

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -137,7 +137,7 @@
 				}
 			}
 
-			& .crowdsignal-forms-feedback__trigger {
+			.crowdsignal-forms-feedback__trigger {
 				margin: 0;
 			}
 		}

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -28,6 +28,11 @@
 		margin-left: 20px;
 		margin-right: 0;
 	}
+
+	.crowdsignal-forms-feedback.is-vertical.is-widget & {
+		position: relative;
+		width: var(--crowdsignal-forms-trigger-height);
+	}
 }
 
 .crowdsignal-forms-feedback__popover-preview {
@@ -91,6 +96,10 @@
 				transform-origin: top right;
 				transform: rotateZ(270deg) translateY(-100%);
 			}
+
+			.crowdsignal-forms-feedback__trigger {
+				margin: 0;
+			}
 		}
 
 		&.is-vertical.align-right {
@@ -103,9 +112,33 @@
 		}
 
 		.crowdsignal-forms__editor-notice {
-			// this width must match the width of
-			// .crowdsignal-forms-feedback__popover on components/feedback/style.scss
 			width: 380px;
+		}
+
+		&.is-widget {
+			border: 1px solid #e0e0e0;
+			padding: 10px;
+			margin-bottom: 15px !important;
+
+			&.is-vertical {
+				padding-left: 0;
+				padding-right: 0;
+				justify-content: flex-start;
+				overflow: hidden;
+				position: relative;
+
+				.crowdsignal-forms-feedback__trigger-wrapper {
+					position: absolute;
+					top: 50%;
+					left: 50%;
+					transform-origin: top left;
+					transform: rotateZ(270deg) translateX(-50%) translateY(-50%);
+				}
+			}
+
+			& .crowdsignal-forms-feedback__trigger {
+				margin: 0;
+			}
 		}
 	}
 

--- a/client/blocks/feedback/util.js
+++ b/client/blocks/feedback/util.js
@@ -19,3 +19,6 @@ export const getStyleVars = ( attributes, fallbackStyles ) =>
 		},
 		( _, key ) => `--crowdsignal-forms-${ kebabCase( key ) }`
 	);
+
+export const isWidgetEditor = () =>
+	!! document.getElementById( 'widgets-editor' );

--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -57,16 +57,6 @@
 	.crowdsignal-forms-feedback.no-shadow & {
 		box-shadow: none;
 	}
-
-	.crowdsignal-forms-feedback.is-vertical.align-left & {
-		border-top-left-radius: 0 !important;
-		border-top-right-radius: 0 !important;
-	}
-
-	.crowdsignal-forms-feedback.is-vertical.align-right & {
-		border-bottom-left-radius: 0 !important;
-		border-bottom-right-radius: 0 !important;
-	}
 }
 
 .crowdsignal-forms-feedback__popover-wrapper.components-popover .components-popover__content {

--- a/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
@@ -94,8 +94,13 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 	 * @return bool
 	 */
 	private function should_hide_block( $attributes = array() ) {
-		if ( ! $this->is_cs_connected() || ! is_singular() ) {
-			return true;
+		if (
+			! $attributes['isWidget'] && (
+				! $this->is_cs_connected() ||
+				! is_singular()
+			)
+		) {
+				return true;
 		}
 
 		if ( isset( $attributes['status'] ) ) {


### PR DESCRIPTION
This patch will make the feedback block render inline whenever used inside the widget editor.  
Unfortunately we can't have it rendering 'anywhere' as then it's impossible for anyone to tell what area it's actually in. This way it'd also theoretically be possible to have more than one in different areas. I did add a banner on top of the block explaining how it works as well as a subtle border to better imitate where it will be placed on the page.

![Screen Shot 2021-07-12 at 11 52 39 PM](https://user-images.githubusercontent.com/8056203/125361459-9f63f280-e36d-11eb-896f-4b55d623b9a5.png)

As I was fiddling with the styling for the buttons a lot to get this done, I also fixed two other issues involving 'overkill borders' on vertically centered buttons and appending spaces to the button text in Firefox.

Solves c/8P2J5FRq, c/IOYbOdca and c/P6GMxhA7.

# Testing

You'll need to setup a test site with the widget editor enabled in order to test it.

- Make sure the block displays correctly inside the widget editor and its functionality is preserved.
- Make sure the tweaks haven't affected the regular _post_ version of the block.