### PR TITLE
Default to site URL on source_link prop when no permalink is returned

### DIFF
--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -408,10 +408,20 @@ const EditFeedbackBlock = ( props ) => {
 };
 
 export default compose( [
-	withSelect( ( select ) => ( {
-		activeSidebar: select( 'core/edit-post' ).getActiveGeneralSidebarName(),
-		editorFeatures: select( 'core/edit-post' ).getPreference( 'features' ),
-		sourceLink: select( 'core/editor' ).getPermalink(),
-	} ) ),
+	withSelect( ( select ) => {
+		let url = select( 'core/editor' ).getPermalink();
+		if ( ! url ) {
+			url = select( 'core' ).getSite() && select( 'core' ).getSite().url;
+		}
+		return {
+			activeSidebar: select(
+				'core/edit-post'
+			).getActiveGeneralSidebarName(),
+			editorFeatures: select( 'core/edit-post' ).getPreference(
+				'features'
+			),
+			sourceLink: url,
+		};
+	} ),
 	withFallbackStyles,
 ] )( EditFeedbackBlock );

--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -310,8 +310,14 @@ const EditNpsBlock = ( props ) => {
 };
 
 export default compose( [
-	withSelect( ( select ) => ( {
-		sourceLink: select( 'core/editor' ).getPermalink(),
-	} ) ),
+	withSelect( ( select ) => {
+		let url = select( 'core/editor' ).getPermalink();
+		if ( ! url ) {
+			url = select( 'core' ).getSite() && select( 'core' ).getSite().url;
+		}
+		return {
+			sourceLink: url,
+		};
+	} ),
 	withFallbackStyles,
 ] )( EditNpsBlock );

--- a/includes/models/class-poll.php
+++ b/includes/models/class-poll.php
@@ -134,6 +134,8 @@ class Poll {
 			// $source_link = trim( admin_url( 'post.php?post=' . $data['post_id'] . '&action=edit' ) );
 			// $poll->set_source_link( $source_link );.
 			$poll->set_source_link( \get_permalink( $data['post_id'] ) );
+		} else {
+			$poll->set_source_link( \get_site_url() );
 		}
 
 		return $poll;


### PR DESCRIPTION
This PR addresses an issue when Feedback Button block is used on FSE: the permalink is empty.

Depends on #154 and D64087-code

## Test instructions
Checkout and `make client`. Use a FSE enabled site and create a Feedback Button as a widget. Visit your dashboard and check that the created block shows the URL where it was created.