### PR TITLE
Update dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,10 @@
-FROM ubuntu:xenial
+FROM ubuntu:groovy
 
 VOLUME ["/var/www/html"]
 
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install required Ubuntu packages for having Apache PHP as a module
 # as well a bunch of other packages

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - ./logs/apache2/:/var/log/apache2
       - ./logs/php:/var/log/php
       - ./bin:/var/scripts
+      - ../../crowdsignal-plugin:/var/www/html/wp-content/plugins/polldaddy
     ports:
       - "${PORT_CS_WORDPRESS:-8000}:80"
     restart: always


### PR DESCRIPTION
This PR updates the Dockerfile setup as xenial is not able to pull all the needed packages anymore.

## Test instructions
Checkout and make sure you clean up the old build/images:
```bash
make docker_down
```
List your docker instances to make sure it's not running.

```
docker ps -a
```

If any of the involved instances is running, stop it with `docker stop [container ID]`, then remove them with `docker rm [container ID]`

Remove images:
```
docker image prune
```

The mysql image can be left alone, the rest should be removed via `docker image rm [image ID]`. Some `rm` commands might fail due to dependant/child images. Try different removal order to address this.

Finally, create the docker again:
```
make docker_build
```
and run it with `make docker_up`

You local instance should be running and accessible at http://localhost:8080

