### PR TITLE
Fix feedback block editor overlay on the full site editor

### DIFF
--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -202,6 +202,20 @@ const EditFeedbackBlock = ( props ) => {
 	}, [ attributes.header, popover.current, isSelected ] );
 
 	useLayoutEffect( () => {
+		if (
+			triggerButton.current &&
+			triggerButton.current.ownerDocument !== document
+		) {
+			setOverlayPosition( {
+				bottom: 0,
+				left: 0,
+				right: 0,
+				top: 0,
+			} );
+
+			return;
+		}
+
 		const contentWrapper = document.getElementsByClassName(
 			'interface-interface-skeleton__content'
 		)[ 0 ];
@@ -213,7 +227,12 @@ const EditFeedbackBlock = ( props ) => {
 			right: window.innerWidth - ( contentBox.left + contentBox.width ),
 			top: contentBox.top,
 		} );
-	}, [ activeSidebar, editorFeatures.fullscreenMode, isSelected ] );
+	}, [
+		activeSidebar,
+		editorFeatures.fullscreenMode,
+		isSelected,
+		triggerButton.current,
+	] );
 
 	const toggleBlock = () => {
 		dispatch( 'core/block-editor' ).clearSelectedBlock();
@@ -337,7 +356,7 @@ const EditFeedbackBlock = ( props ) => {
 				<div className="crowdsignal-forms-feedback__popover-preview">
 					{ ( isExample || isSelected || widgetEditor ) && (
 						<>
-							{ ! isWidgetEditor && (
+							{ ! widgetEditor && (
 								<>
 									{ /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */ }
 									<div

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -55,10 +55,7 @@
 
 	.wp-block[data-type="crowdsignal-forms/feedback"] {
 		width: auto;
-		// This number is was carefully chosen so the block and its overlay
-		// don't block any editor UI elements but appear in front of regular
-		// content
-		z-index: 10;
+		z-index: 100;
 
 		&::after {
 			display: none;


### PR DESCRIPTION
This patch fixes the issue with the feedback block editor overlay being offset incorrectly inside the full site editor by checking if the block is rendered inside an iframe.

Before:

![Screen Shot 2021-07-17 at 12 41 40 AM](https://user-images.githubusercontent.com/8056203/126015244-3d4eea5c-1172-45a8-b75f-e2a68c0fa293.png)

After:

![Screen Shot 2021-07-17 at 12 42 03 AM](https://user-images.githubusercontent.com/8056203/126015240-36f4043c-ad25-431c-bf56-cae06d971865.png)

# Testing

Make sure you're testing on WP `trunk` and select a theme which has FSE support.
Verify that when adding the feedback block in side of the full site editor, the overlay is rendered correctly when the block is selected.
Similarly, verify that the overlay still displays correctly on the regular poll editor which doesn't have the iframe.