### PR TITLE
Fix answer inputs

### DIFF
--- a/client/blocks/poll/edit-answer.js
+++ b/client/blocks/poll/edit-answer.js
@@ -43,7 +43,7 @@ const EditAnswer = ( {
 
 	const renderRadioAnswers = () => (
 		<>
-			<span className="crowdsignal-forms-poll__check" />
+			<div className="crowdsignal-forms-poll__check" />
 
 			<div className="crowdsignal-forms-poll__answer-label-wrapper">
 				{ ! disabled ? (
@@ -62,13 +62,14 @@ const EditAnswer = ( {
 						value={ answer.text }
 						allowedFormats={ [] }
 						withoutInteractiveFormatting
+						keepplaceholderonfocus="true"
 					/>
 				) : (
-					<span className="crowdsignal-forms-poll__answer-label">
+					<div className="crowdsignal-forms-poll__answer-label">
 						{ answer.text
 							? decodeEntities( answer.text )
 							: __( 'Enter an answer', 'crowdsignal-forms' ) }
-					</span>
+					</div>
 				) }
 			</div>
 		</>
@@ -89,7 +90,7 @@ const EditAnswer = ( {
 					value={ answer.text }
 					allowedFormats={ [] }
 					withoutInteractiveFormatting
-					keepPlaceholderOnFocus={ true }
+					keepplaceholderonfocus="true"
 				/>
 			) : (
 				<div className="wp-block-button__link crowdsignal-forms-poll__submit-button">

--- a/client/blocks/poll/edit-answer.js
+++ b/client/blocks/poll/edit-answer.js
@@ -49,7 +49,6 @@ const EditAnswer = ( {
 				{ ! disabled ? (
 					<RichText
 						className="crowdsignal-forms-poll__answer-label"
-						tagName="span"
 						placeholder={ __(
 							'Enter an answer',
 							'crowdsignal-forms'

--- a/client/blocks/poll/edit-answer.js
+++ b/client/blocks/poll/edit-answer.js
@@ -62,7 +62,6 @@ const EditAnswer = ( {
 						value={ answer.text }
 						allowedFormats={ [] }
 						withoutInteractiveFormatting
-						keepplaceholderonfocus="true"
 					/>
 				) : (
 					<div className="crowdsignal-forms-poll__answer-label">
@@ -90,7 +89,6 @@ const EditAnswer = ( {
 					value={ answer.text }
 					allowedFormats={ [] }
 					withoutInteractiveFormatting
-					keepplaceholderonfocus="true"
 				/>
 			) : (
 				<div className="wp-block-button__link crowdsignal-forms-poll__submit-button">

--- a/client/blocks/poll/edit.scss
+++ b/client/blocks/poll/edit.scss
@@ -39,6 +39,10 @@
 			}
 		}
 	}
+
+	.crowdsignal-forms-poll__answer-label-wrapper {
+		margin-top: 2px;
+	}
 }
 
 .crowdsignal-forms-poll__resize-wrapper {

--- a/client/components/poll/answer.js
+++ b/client/components/poll/answer.js
@@ -64,12 +64,12 @@ const PollAnswer = ( {
 				onFocus={ handleFocus }
 			/>
 
-			<span className="crowdsignal-forms-poll__check" />
+			<div className="crowdsignal-forms-poll__check" />
 
 			<div className="crowdsignal-forms-poll__answer-label-wrapper">
-				<span className="crowdsignal-forms-poll__answer-label">
+				<div className="crowdsignal-forms-poll__answer-label">
 					{ decodeEntities( text ) }
-				</span>
+				</div>
 			</div>
 		</label>
 	);

--- a/client/components/poll/style.scss
+++ b/client/components/poll/style.scss
@@ -188,11 +188,8 @@ input[type="radio"].crowdsignal-forms-poll__input {
 }
 
 .crowdsignal-forms-poll__check {
-	display: inline-block;
-	height: 1em;
-	margin: 0 10px 0 0;
+	margin: 6px 10px 0 0;
 	position: relative;
-	width: 1em;
 
 	&::before {
 		background-color: transparent;
@@ -226,11 +223,11 @@ input[type="radio"].crowdsignal-forms-poll__input {
 		box-sizing: border-box;
 		content: "";
 		display: block;
-		height: 100%;
+		height: 1em;
 		position: absolute;
 		left: 0;
 		top: 0;
-		width: 100%;
+		width: 1em;
 	}
 
 	.crowdsignal-forms-poll__answer.is-selected.is-multiple-choice &::after {
@@ -251,19 +248,9 @@ input[type="radio"].crowdsignal-forms-poll__input {
 }
 
 /* stylelint-disable-next-line no-descending-specificity */
-div.crowdsignal-forms-poll__answer-label-wrapper {
+.crowdsignal-forms-poll__answer-label-wrapper {
 	flex: 1;
 	word-break: break-word;
-
-	span.crowdsignal-forms-poll__answer-label {
-		line-height: 1;
-		vertical-align: top;
-
-		/* the placeholder text */
-		span::after {
-			vertical-align: top;
-		}
-	}
 }
 
 .crowdsignal-forms-poll__button {

--- a/client/components/poll/style.scss
+++ b/client/components/poll/style.scss
@@ -201,9 +201,9 @@ input[type="radio"].crowdsignal-forms-poll__input {
 		box-sizing: border-box;
 		content: "";
 		display: block;
-		height: 100%;
+		height: 1em;
 		transition: background-color 0.3s, border-color 0.3s;
-		width: 100%;
+		width: 1em;
 	}
 
 	.crowdsignal-forms-poll__answer.is-multiple-choice &::before {

--- a/client/components/poll/style.scss
+++ b/client/components/poll/style.scss
@@ -153,8 +153,9 @@
 
 		.crowdsignal-forms-poll__submit-button {
 			overflow: hidden;
-			text-overflow: ellipsis;
-			white-space: nowrap;
+			white-space: break-spaces !important;
+			word-break: break-word;
+			word-wrap: break-word;
 		}
 	}
 


### PR DESCRIPTION
This PR addresses an issue on Safari where answers become not editable in the editor.

A couple of culprits down the line: RichText component not handling very well the `keepplaceholderonfocus` property, RichText component doing funny stuff with `tagName` property, our own `::before` solution for custom radio buttons, themes implementing different line-heights in combination with font-size, block elements displaying inline.

So far, this is the most _fit all_ solution I could find, yet some cases (Seedlet, TwentySeventeen, maybe others) still struggle to center the radio button at the baseline of the adjacent element (answer label/text).

## Test instructions
Checkout and run `make client`. Use Safari browser to confirm.
Add/edit a poll block. See that the answers are editable.
Confirm radio buttons are (somewhat) well aligned with the text, both while editing and on the public view.
