### PR TITLE
Test: make button style default

### DIFF
--- a/client/blocks/poll/index.js
+++ b/client/blocks/poll/index.js
@@ -59,8 +59,8 @@ export default {
 	},
 	styles: [
 		{
-			name: 'default',
-			label: __( 'Default', 'crowdsignal-forms' ),
+			name: 'buttons',
+			label: __( 'Buttons', 'crowdsignal-forms' ),
 			isDefault: true,
 		},
 	],

--- a/client/blocks/poll/util.js
+++ b/client/blocks/poll/util.js
@@ -183,12 +183,12 @@ export const getAnswerStyle = ( attributes, className ) => {
 
 	if (
 		! isEmpty( className ) &&
-		className.indexOf( 'is-style-buttons' ) > -1
+		className.indexOf( 'is-style-default' ) > -1
 	) {
-		return AnswerStyle.BUTTON;
+		return AnswerStyle.RADIO;
 	}
 
-	return AnswerStyle.RADIO;
+	return AnswerStyle.BUTTON;
 };
 
 /**

--- a/client/blocks/poll/util.js
+++ b/client/blocks/poll/util.js
@@ -197,12 +197,23 @@ export const getAnswerStyle = ( attributes, className ) => {
  * @param {boolean} enable True if button style should be available, false if not.
  */
 export const toggleButtonStyleAvailability = ( enable ) => {
+	unregisterBlockStyle( 'crowdsignal-forms/poll', 'default' );
+	unregisterBlockStyle( 'crowdsignal-forms/poll', 'buttons' );
 	if ( enable ) {
+		registerBlockStyle( 'crowdsignal-forms/poll', {
+			name: 'default',
+			label: __( 'Default', 'crowdsignal-forms' ),
+		} );
 		registerBlockStyle( 'crowdsignal-forms/poll', {
 			name: 'buttons',
 			label: __( 'Buttons', 'crowdsignal-forms' ),
+			isDefault: true,
 		} );
 	} else {
-		unregisterBlockStyle( 'crowdsignal-forms/poll', 'buttons' );
+		registerBlockStyle( 'crowdsignal-forms/poll', {
+			name: 'default',
+			label: __( 'Default', 'crowdsignal-forms' ),
+			isDefault: true,
+		} );
 	}
 };


### PR DESCRIPTION
This PR explores the idea of making Buttons style the default style.

## Challenges

Both styles have to be [dynamically added and removed](https://github.com/Automattic/crowdsignal-forms/commit/a6b9eecbe6886ebdbf065f44779ab4f934e05e4d) upon availability (Buttons style should only be available when NOT in multiple choice option)

Otherwise, when switching to Multiple Choice mode a "double default style" can be seen, not sure why.

This other challenge I couldn't figure out without making a huge change: for the style to be properly applied by default the CSS class detection has to be inverted and applied by default. This causes ALL existing polls that have been published with the default style (Radio buttons) to now show as Buttons.

I'm quite sure there must be a simpler workaround for the latter, this is just a quick exploration PR.

## Test instructions
Checkout and `make client`. Adding a poll on a post should show the Buttons style selected and applied by default.
Check polls that are created without selecting any style, those should render with Buttons style. This might raise problems.
