### PR TITLE
Use poll.fm for the nonce check

### DIFF
--- a/client/data/poll/index.js
+++ b/client/data/poll/index.js
@@ -46,7 +46,7 @@ export const requestVoteNonce = async ( pollId ) => {
 	const hash = '5430eeac3911395001d731d9702fc38b'; // hash not used when format=json is passed
 	const timestamp = new Date().getTime();
 	const respNonce = await window.fetch(
-		`https://polldaddy.com/n/${ hash }/${ pollId }?${ timestamp }&format=json`
+		`https://poll.fm/n/${ hash }/${ pollId }?${ timestamp }&format=json`
 	);
 	if ( ! respNonce.ok ) {
 		throw new CrowdsignalFormsServerError();


### PR DESCRIPTION
This PR attempts to address an issue regarding Firefox having polldaddy.com domain in a block list.

We've attempted to remove the domain from the list with no success so far, we don't collect any tracking data other than the, willingly, provided vote data for a poll.

## Test instructions
Checkout and `make client`. Visit a post with a poll, upon voting, check the network requests and verify the first request is sent to poll.fm/n/...