### PR TITLE
Fix new interface package compatibility

### DIFF
--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -47,7 +47,7 @@ const EditFeedbackBlock = ( props ) => {
 	const {
 		attributes,
 		activeSidebar,
-		editorFeatures,
+		isFullscreen,
 		fallbackStyles,
 		isSelected,
 		setAttributes,
@@ -182,7 +182,7 @@ const EditFeedbackBlock = ( props ) => {
 		} );
 	}, [
 		activeSidebar,
-		editorFeatures.fullscreenMode,
+		isFullscreen,
 		isSelected,
 		setPosition,
 		attributes.x,
@@ -227,12 +227,7 @@ const EditFeedbackBlock = ( props ) => {
 			right: window.innerWidth - ( contentBox.left + contentBox.width ),
 			top: contentBox.top,
 		} );
-	}, [
-		activeSidebar,
-		editorFeatures.fullscreenMode,
-		isSelected,
-		triggerButton.current,
-	] );
+	}, [ activeSidebar, isFullscreen, isSelected, triggerButton.current ] );
 
 	const toggleBlock = () => {
 		dispatch( 'core/block-editor' ).clearSelectedBlock();
@@ -485,13 +480,16 @@ export default compose( [
 		if ( ! url ) {
 			url = select( 'core' ).getSite() && select( 'core' ).getSite().url;
 		}
+		const editPost = select( 'core/edit-post' );
+		const isFullscreen =
+			'isFeatureActive' in editPost
+				? editPost.isFeatureActive( 'fullscreenMode' )
+				: editPost.getPreference( 'fullscreenMode' );
 		return {
 			activeSidebar: select(
 				'core/edit-post'
 			).getActiveGeneralSidebarName(),
-			editorFeatures: select( 'core/edit-post' ).getPreference(
-				'features'
-			),
+			isFullscreen,
 			sourceLink: url,
 		};
 	} ),

--- a/client/components/block-alignment-control/icon.js
+++ b/client/components/block-alignment-control/icon.js
@@ -6,10 +6,15 @@ import classnames from 'classnames';
 import { map } from 'lodash';
 
 const BlockAlignmentControlIcon = ( { rows, columns, value } ) => {
+	let spanKeyNum = 0;
+	let divKeyNum = 0;
 	return (
 		<div className="crowdsignal-forms__block-alignment-control-icon">
 			{ map( rows, ( row ) => (
-				<div className="crowdsignal-forms__block-alignment-control-icon-row">
+				<div
+					key={ divKeyNum++ }
+					className="crowdsignal-forms__block-alignment-control-icon-row"
+				>
 					{ map( columns, ( column ) => {
 						const isActive =
 							row.value === value.row &&
@@ -22,7 +27,9 @@ const BlockAlignmentControlIcon = ( { rows, columns, value } ) => {
 							}
 						);
 
-						return <span className={ classes } />;
+						return (
+							<span key={ spanKeyNum++ } className={ classes } />
+						);
 					} ) }
 				</div>
 			) ) }


### PR DESCRIPTION
This PR adds a simple check to see if `isFeatureActive` is available and prioritize its use over `getPreference( 'features' )`.

Our use of `getPreference( 'features' )` aimed to keep a watch on `fullscreenMode` but since https://github.com/WordPress/gutenberg/pull/34154 this seems not available anymore.

## Test instructions
Checkout and `make client`. Open the developer console and insert a Feedback Button on a post. There should be no errors regarding the block insertion.