### PR TITLE
Fix video size on setup page

### DIFF
--- a/includes/admin/admin-styles.css
+++ b/includes/admin/admin-styles.css
@@ -199,6 +199,11 @@
 	background-color: #e2e2e2;
 }
 
+.crowdsignal-setup__video iframe {
+	width: 100%;
+	height: 100%;
+}
+
 
 .wrap div.crowdsignal-message {
 	margin: 24px auto 8px auto;

--- a/includes/admin/views/html-admin-setup-step-3.php
+++ b/includes/admin/views/html-admin-setup-step-3.php
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			<div class="crowdsignal-setup__video-container">
 				<div class="crowdsignal-setup__video">
-					<iframe width="100%" height="100%" src="https://videopress.com/v/jWTs90Dg" frameborder="0" allowfullscreen></iframe>
+					<iframe src="https://videopress.com/v/jWTs90Dg" frameborder="0" allowfullscreen></iframe>
 				</div>
 			</div>
 


### PR DESCRIPTION
This PR makes video iframe dimension-less and adds CSS rules for it to fill `100%` its container.

## Test instructions
Checkout and visithttp://localhost:8000/wp-admin/admin.php?page=crowdsignal-forms-setup

The video should now be big to fill the wrapped content