### PR TITLE
Fix toolbar remaining behind the feedback overlay

### DIFF
--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -219,6 +219,18 @@ const EditFeedbackBlock = ( props ) => {
 		const contentWrapper = document.getElementsByClassName(
 			'interface-interface-skeleton__content'
 		)[ 0 ];
+
+		if ( isSelected ) {
+			// hack: make the toolbar play nice with our overlay
+			const toolbarContainer = contentWrapper.querySelector(
+				'.components-popover.block-editor-block-list__block-popover'
+			);
+
+			if ( toolbarContainer ) {
+				toolbarContainer.style.zIndex = 101;
+			}
+		}
+
 		const contentBox = contentWrapper.getBoundingClientRect();
 
 		setOverlayPosition( {

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -54,6 +54,7 @@ const EditFeedbackBlock = ( props ) => {
 		clientId,
 		sourceLink,
 		setPosition,
+		isFixedToolbar,
 	} = props;
 
 	const {
@@ -205,14 +206,16 @@ const EditFeedbackBlock = ( props ) => {
 
 		if ( contentWrapper ) {
 			const toolbarContainer = contentWrapper.querySelector(
-				'.components-popover.block-editor-block-list__block-popover'
+				isFixedToolbar
+					? '.components-accessible-toolbar.block-editor-block-contextual-toolbar.is-fixed'
+					: '.components-popover.block-editor-block-list__block-popover'
 			);
 
 			if ( toolbarContainer ) {
 				toolbarContainer.style.zIndex = 101;
 			}
 		}
-	}, [ isSelected ] );
+	}, [ isSelected, isFixedToolbar ] );
 
 	useLayoutEffect( () => {
 		if ( ! popover.current ) {
@@ -507,12 +510,17 @@ export default compose( [
 			'isFeatureActive' in editPost
 				? editPost.isFeatureActive( 'fullscreenMode' )
 				: editPost.getPreference( 'fullscreenMode' );
+		const isFixedToolbar =
+			'isFeatureActive' in editPost
+				? editPost.isFeatureActive( 'fixedToolbar' )
+				: editPost.getPreference( 'fixedToolbar' );
 		return {
 			activeSidebar: select(
 				'core/edit-post'
 			).getActiveGeneralSidebarName(),
 			isFullscreen,
 			sourceLink: url,
+			isFixedToolbar,
 		};
 	} ),
 	withFallbackStyles,

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -194,6 +194,27 @@ const EditFeedbackBlock = ( props ) => {
 	] );
 
 	useLayoutEffect( () => {
+		// hack: this effect changes the zIndex of the block's toolbar.
+		// As soon as the block is rendered the Toolbar "waits" for mouse movement
+		// to actually render. So, the first time this will fail (toolbarContainer = null)
+		// yet selecting the block again will make the effect go through.
+		// TODO: find a better way to do this!
+		const contentWrapper = document.getElementsByClassName(
+			'interface-interface-skeleton__content'
+		)[ 0 ];
+
+		if ( contentWrapper ) {
+			const toolbarContainer = contentWrapper.querySelector(
+				'.components-popover.block-editor-block-list__block-popover'
+			);
+
+			if ( toolbarContainer ) {
+				toolbarContainer.style.zIndex = 101;
+			}
+		}
+	}, [ isSelected ] );
+
+	useLayoutEffect( () => {
 		if ( ! popover.current ) {
 			return;
 		}
@@ -219,17 +240,6 @@ const EditFeedbackBlock = ( props ) => {
 		const contentWrapper = document.getElementsByClassName(
 			'interface-interface-skeleton__content'
 		)[ 0 ];
-
-		if ( isSelected ) {
-			// hack: make the toolbar play nice with our overlay
-			const toolbarContainer = contentWrapper.querySelector(
-				'.components-popover.block-editor-block-list__block-popover'
-			);
-
-			if ( toolbarContainer ) {
-				toolbarContainer.style.zIndex = 101;
-			}
-		}
 
 		const contentBox = contentWrapper.getBoundingClientRect();
 


### PR DESCRIPTION
This PR changes the interface skeleton popover z-index: force 101 to not be occluded by our overlay

## Test instructions
Checkout and `make client`. Insert a Feedback Button on a post.

**The first time the toolbar is rendered, it will remain behind the overlay. So far, this is unavoidable due to the mechanics behind the toolbar rendering process.**

De-select the block and select it again: See that the Toolbar is now functional and not behind the overlay