### PR TITLE
Fix toolbar/feedback overlay interactions

### DIFF
--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -46,8 +46,8 @@ const EditFeedbackBlock = ( props ) => {
 
 	const {
 		attributes,
-		activeSidebar,
 		isFullscreen,
+		isSidebarActive,
 		fallbackStyles,
 		isSelected,
 		setAttributes,
@@ -68,6 +68,7 @@ const EditFeedbackBlock = ( props ) => {
 	} = attributes;
 
 	const [ margin, setMargin ] = useState( {} );
+	const [ sidebarChanged, setSidebarChanged ] = useState( false );
 
 	const widgetEditor = useMemo( isWidgetEditor, [] );
 
@@ -128,6 +129,15 @@ const EditFeedbackBlock = ( props ) => {
 		setView( views.QUESTION );
 	}, [ isSelected ] );
 
+	useEffect( () => {
+		// The sidebar itself is rendered off the same setting
+		// hence the need to wait until it's re-rendered
+		// so we can measure it properly.
+		window.requestAnimationFrame( () =>
+			setSidebarChanged( isSidebarActive )
+		);
+	}, [ isSidebarActive ] );
+
 	useLayoutEffect( () => {
 		if ( isExample || ! triggerButton.current || widgetEditor ) {
 			return;
@@ -181,7 +191,7 @@ const EditFeedbackBlock = ( props ) => {
 					: 0,
 		} );
 	}, [
-		activeSidebar,
+		sidebarChanged,
 		isFullscreen,
 		isSelected,
 		setPosition,
@@ -227,7 +237,7 @@ const EditFeedbackBlock = ( props ) => {
 			right: window.innerWidth - ( contentBox.left + contentBox.width ),
 			top: contentBox.top,
 		} );
-	}, [ activeSidebar, isFullscreen, isSelected, triggerButton.current ] );
+	}, [ sidebarChanged, isFullscreen, isSelected, triggerButton.current ] );
 
 	const toggleBlock = () => {
 		dispatch( 'core/block-editor' ).clearSelectedBlock();
@@ -486,10 +496,8 @@ export default compose( [
 				? editPost.isFeatureActive( 'fullscreenMode' )
 				: editPost.getPreference( 'fullscreenMode' );
 		return {
-			activeSidebar: select(
-				'core/edit-post'
-			).getActiveGeneralSidebarName(),
 			isFullscreen,
+			isSidebarActive: editPost.isEditorSidebarOpened(),
 			sourceLink: url,
 		};
 	} ),

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -54,7 +54,6 @@ const EditFeedbackBlock = ( props ) => {
 		clientId,
 		sourceLink,
 		setPosition,
-		isFixedToolbar,
 	} = props;
 
 	const {
@@ -195,29 +194,6 @@ const EditFeedbackBlock = ( props ) => {
 	] );
 
 	useLayoutEffect( () => {
-		// hack: this effect changes the zIndex of the block's toolbar.
-		// As soon as the block is rendered the Toolbar "waits" for mouse movement
-		// to actually render. So, the first time this will fail (toolbarContainer = null)
-		// yet selecting the block again will make the effect go through.
-		// TODO: find a better way to do this!
-		const contentWrapper = document.getElementsByClassName(
-			'interface-interface-skeleton__content'
-		)[ 0 ];
-
-		if ( contentWrapper ) {
-			const toolbarContainer = contentWrapper.querySelector(
-				isFixedToolbar
-					? '.components-accessible-toolbar.block-editor-block-contextual-toolbar.is-fixed'
-					: '.components-popover.block-editor-block-list__block-popover'
-			);
-
-			if ( toolbarContainer ) {
-				toolbarContainer.style.zIndex = 101;
-			}
-		}
-	}, [ isSelected, isFixedToolbar ] );
-
-	useLayoutEffect( () => {
 		if ( ! popover.current ) {
 			return;
 		}
@@ -243,7 +219,6 @@ const EditFeedbackBlock = ( props ) => {
 		const contentWrapper = document.getElementsByClassName(
 			'interface-interface-skeleton__content'
 		)[ 0 ];
-
 		const contentBox = contentWrapper.getBoundingClientRect();
 
 		setOverlayPosition( {
@@ -510,17 +485,12 @@ export default compose( [
 			'isFeatureActive' in editPost
 				? editPost.isFeatureActive( 'fullscreenMode' )
 				: editPost.getPreference( 'fullscreenMode' );
-		const isFixedToolbar =
-			'isFeatureActive' in editPost
-				? editPost.isFeatureActive( 'fixedToolbar' )
-				: editPost.getPreference( 'fixedToolbar' );
 		return {
 			activeSidebar: select(
 				'core/edit-post'
 			).getActiveGeneralSidebarName(),
 			isFullscreen,
 			sourceLink: url,
-			isFixedToolbar,
 		};
 	} ),
 	withFallbackStyles,

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -47,6 +47,8 @@ const EditFeedbackBlock = ( props ) => {
 	const {
 		attributes,
 		isFullscreen,
+		isInserterActive,
+		isListViewActive,
 		isSidebarActive,
 		fallbackStyles,
 		isSelected,
@@ -134,9 +136,9 @@ const EditFeedbackBlock = ( props ) => {
 		// hence the need to wait until it's re-rendered
 		// so we can measure it properly.
 		window.requestAnimationFrame( () =>
-			setSidebarChanged( isSidebarActive )
+			setSidebarChanged( ! sidebarChanged )
 		);
-	}, [ isSidebarActive ] );
+	}, [ isInserterActive, isListViewActive, isSidebarActive ] );
 
 	useLayoutEffect( () => {
 		if ( isExample || ! triggerButton.current || widgetEditor ) {
@@ -495,8 +497,11 @@ export default compose( [
 			'isFeatureActive' in editPost
 				? editPost.isFeatureActive( 'fullscreenMode' )
 				: editPost.getPreference( 'fullscreenMode' );
+
 		return {
 			isFullscreen,
+			isInserterActive: editPost.isInserterOpened(),
+			isListViewActive: editPost.isListViewOpened(),
 			isSidebarActive: editPost.isEditorSidebarOpened(),
 			sourceLink: url,
 		};

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -55,7 +55,7 @@
 
 	.wp-block[data-type="crowdsignal-forms/feedback"] {
 		width: auto;
-		z-index: 100;
+		z-index: 1;
 
 		&::after {
 			display: none;


### PR DESCRIPTION
This patch reverts Automattic/crowdsignal-forms#170 in favor of a more concise fix for the block toolbar being overlapped by the feedback button's overlay.

The root issue was the z-index property on the block wrapper, which I believe dates back to the days when the overlay would span the entire window and be overlapped by the UI.  
As we later implemented proper logic for sizing the overlay so it only ever covers the content part of the editor, I don't think this value need to be so high. Setting it to `1` makes our block appear in front of other _normal_ blocks while not covering up the toolbar.

While at it, I added an additional fix for the overlay not being resized correctly whenever the sidebar is toggled.

# Testing

- Add a feedback block to your page.
- Trigger the feedback block, the toolbar should still appear in front of the overlay and the overlay should cover the content.
- Add some more regular blocks to the page and test if the overlay covers them when the feedback button is active.
- Try toggling the sidebar and validate that the feedback button and overlay are resized/repositioned correctly.
