### PR TITLE
Fix Feedback Button block on Block Widget editor.

### DIFF
--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -214,6 +214,10 @@ const EditFeedbackBlock = ( props ) => {
 	}, [ attributes.header, popover.current, isSelected ] );
 
 	useLayoutEffect( () => {
+		if ( isWidgetEditor ) {
+			return;
+		}
+
 		if (
 			triggerButton.current &&
 			triggerButton.current.ownerDocument !== document

--- a/client/blocks/feedback/edit.scss
+++ b/client/blocks/feedback/edit.scss
@@ -51,7 +51,8 @@
 	}
 }
 
-.editor-styles-wrapper {
+.editor-styles-wrapper,
+.wp-customizer {
 
 	.wp-block[data-type="crowdsignal-forms/feedback"] {
 		width: auto;
@@ -117,6 +118,10 @@
 			border: 1px solid #e0e0e0;
 			padding: 10px;
 			margin-bottom: 15px !important;
+
+			.crowdsignal-forms-feedback__popover {
+				width: 100%;
+			}
 
 			&.is-vertical {
 				padding-left: 0;

--- a/client/blocks/feedback/util.js
+++ b/client/blocks/feedback/util.js
@@ -20,5 +20,4 @@ export const getStyleVars = ( attributes, fallbackStyles ) =>
 		( _, key ) => `--crowdsignal-forms-${ kebabCase( key ) }`
 	);
 
-export const isWidgetEditor = () =>
-	!! window.wp.widgets;
+export const isWidgetEditor = () => !! window.wp.widgets;

--- a/client/blocks/feedback/util.js
+++ b/client/blocks/feedback/util.js
@@ -21,4 +21,4 @@ export const getStyleVars = ( attributes, fallbackStyles ) =>
 	);
 
 export const isWidgetEditor = () =>
-	!! document.getElementById( 'widgets-editor' );
+	!! window.wp.widgets;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"watch:poll": "calypso-build --env.WP --output-path='./build' poll=./client/poll.js --watch",
 		"watch:applause": "calypso-build --env.WP --output-path='./build' applause=./client/applause.js --watch",
 		"watch:nps": "calypso-build --env.WP --output-path='./build' nps=./client/nps.js --watch",
+		"watch:feedback": "calypso-build --env.WP --output-path=./build feedback=./client/feedback.js --watch",
 		"format:js": "wp-scripts format-js ./client",
 		"lint:js": "wp-scripts lint-js ./client",
 		"lint:styles": "wp-scripts lint-style ./assets/stylesheets ./client/**/*.scss",


### PR DESCRIPTION
## Description

Fixes the `isWidgetEditor` checking.

## Test Instructions

1. Go to Customize > Widgets.
2. Add "Feedback Button" block.
3. It should not show the error 'This block has encountered an error and cannot be previewed.' and cannot be previewed'.

Fixes https://github.com/Automattic/wp-calypso/issues/55808