### PR TITLE
Fix isPollBlock to prevent crashes when getBlocks() returns null

### DIFF
--- a/client/blocks/poll/subscriptions.js
+++ b/client/blocks/poll/subscriptions.js
@@ -12,10 +12,15 @@ import apiFetch from '@wordpress/api-fetch';
 
 import { map, filter } from 'lodash';
 
-const isPollBlock = ( block ) =>
-	block.name === 'crowdsignal-forms/poll' ||
-	block.name === 'crowdsignal-forms/applause' ||
-	block.name === 'crowdsignal-forms/vote';
+const isPollBlock = ( block ) => {
+	if ( ! block ) {
+		return false;
+	}
+
+	return block.name === 'crowdsignal-forms/poll' ||
+		block.name === 'crowdsignal-forms/applause' ||
+		block.name === 'crowdsignal-forms/vote';
+};
 
 let subsStarted = false;
 let pollingStarted = false;


### PR DESCRIPTION
As reported in [Automattic/wp-calypso#56455](https://github.com/Automattic/wp-calypso/issues/56455), there seems to have been a change to `getBlocks()` selector implementation causing it to return `null` on occasion, which in turn causes our plugin to crash.

While it's not necessarily the core issue, we can make our code a little more resilient by verifying if a `block` is not `null` before attempting to access its properties.

# Testing

See [Automattic/wp-calypso#56455](https://github.com/Automattic/wp-calypso/issues/56455).