### PR TITLE
Release bump and notes for 1.5.8

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -70,7 +70,6 @@ Compare our [simple and affordable plans](https://crowdsignal.com/pricing/) or t
 = 1.5.8 =
 * Fix Feedback Button block on Block Widget editor. (#173)
 * Fix isPollBlock to prevent crashes when getBlocks() returns null (#175)
-* Move menu items into Settings menu. (#174)
 * Fix toolbar/feedback overlay interactions (#172)
 
 = 1.5.7 =

--- a/README.TXT
+++ b/README.TXT
@@ -4,7 +4,7 @@ Tags: polls, forms, surveys, gutenberg, block
 Requires at least: 5.0
 Requires PHP: 5.6.20
 Tested up to: 5.6
-Stable tag: 1.5.7
+Stable tag: 1.5.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,12 @@ Compare our [simple and affordable plans](https://crowdsignal.com/pricing/) or t
 4. Use the poll block inside of other blocks
 
 == Changelog ==
+
+= 1.5.8 =
+* Fix Feedback Button block on Block Widget editor. (#173)
+* Fix isPollBlock to prevent crashes when getBlocks() returns null (#175)
+* Move menu items into Settings menu. (#174)
+* Fix toolbar/feedback overlay interactions (#172)
 
 = 1.5.7 =
 * Fix toolbar remaining behind the feedback overlay (#170)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,10 @@
+= 1.5.8 =
+* Fix Feedback Button block on Block Widget editor. (#173)
+* Fix isPollBlock to prevent crashes when getBlocks() returns null (#175)
+* Move menu items into Settings menu. (#174)
+* Fix toolbar/feedback overlay interactions (#172)
+* Release v1.5.7 bump (#171)
+
 = 1.5.7 =
 * Fix toolbar remaining behind the feedback overlay (#170)
 * Make video iframe dimension-less, add CSS rules for it (#169)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,6 @@
 = 1.5.8 =
 * Fix Feedback Button block on Block Widget editor. (#173)
 * Fix isPollBlock to prevent crashes when getBlocks() returns null (#175)
-* Move menu items into Settings menu. (#174)
 * Fix toolbar/feedback overlay interactions (#172)
 * Release v1.5.7 bump (#171)
 

--- a/crowdsignal-forms.php
+++ b/crowdsignal-forms.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Crowdsignal Forms
  * Plugin URI:        https://crowdsignal.com/crowdsignal-forms/
  * Description:       Crowdsignal Form Blocks
- * Version:           1.5.7
+ * Version:           1.5.8
  * Author:            Automattic
  * Author URI:        https://automattic.com/
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die;
 }
 
-define( 'CROWDSIGNAL_FORMS_VERSION', '1.5.7' );
+define( 'CROWDSIGNAL_FORMS_VERSION', '1.5.8' );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_FILE', __FILE__ );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 

--- a/includes/admin/class-crowdsignal-forms-settings.php
+++ b/includes/admin/class-crowdsignal-forms-settings.php
@@ -42,7 +42,7 @@ class Crowdsignal_Forms_Settings {
 	 * Enqueues scripts for setup page.
 	 */
 	public function admin_enqueue_scripts() {
-		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.5.7' );
+		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.5.8' );
 	}
 
 	/**

--- a/includes/admin/class-crowdsignal-forms-setup.php
+++ b/includes/admin/class-crowdsignal-forms-setup.php
@@ -65,7 +65,7 @@ class Crowdsignal_Forms_Setup {
 	 * Enqueues scripts for setup page.
 	 */
 	public function admin_enqueue_scripts() {
-		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.5.7' );
+		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.5.8' );
 		wp_enqueue_script( 'videopress', 'https://videopress.com/videopress-iframe.js', array(), '1.0', false );
 	}
 

--- a/languages/crowdsignal-forms.pot
+++ b/languages/crowdsignal-forms.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2021-09-23T19:58:51+00:00\n"
+"POT-Creation-Date: 2021-09-27T14:24:26+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.4.0\n"
 "X-Domain: crowdsignal-forms\n"
@@ -42,13 +42,20 @@ msgstr ""
 msgid "You don&#8217;t have permission to do this."
 msgstr ""
 
-#: includes/admin/class-crowdsignal-forms-admin.php:87
-msgid "Getting Started"
+#: includes/admin/class-crowdsignal-forms-admin.php:70
+#: includes/class-crowdsignal-forms.php:439
+msgid "Crowdsignal"
 msgstr ""
 
-#: includes/admin/class-crowdsignal-forms-admin.php:88
+#: includes/admin/class-crowdsignal-forms-admin.php:71
+#: includes/admin/class-crowdsignal-forms-admin.php:86
 #: build/editor.js:13
 msgid "Settings"
+msgstr ""
+
+#: includes/admin/class-crowdsignal-forms-admin.php:72
+#: includes/admin/class-crowdsignal-forms-admin.php:85
+msgid "Getting Started"
 msgstr ""
 
 #: includes/admin/class-crowdsignal-forms-settings.php:71
@@ -173,10 +180,6 @@ msgstr ""
 #. translators: Argument is a link to Crowdsignal's support page.
 #: includes/admin/views/html-admin-setup-step-3.php:52
 msgid "<a href=\"%1s\" target=\"_blank\">Read more about us here.</a>"
-msgstr ""
-
-#: includes/class-crowdsignal-forms.php:439
-msgid "Crowdsignal"
 msgstr ""
 
 #: includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php:146

--- a/languages/crowdsignal-forms.pot
+++ b/languages/crowdsignal-forms.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Crowdsignal Forms 1.5.7\n"
+"Project-Id-Version: Crowdsignal Forms 1.5.8\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/crowdsignal-forms\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2021-09-01T20:27:22+00:00\n"
+"POT-Creation-Date: 2021-09-23T19:58:51+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.4.0\n"
 "X-Domain: crowdsignal-forms\n"
@@ -42,20 +42,13 @@ msgstr ""
 msgid "You don&#8217;t have permission to do this."
 msgstr ""
 
-#: includes/admin/class-crowdsignal-forms-admin.php:70
-#: includes/class-crowdsignal-forms.php:439
-msgid "Crowdsignal"
+#: includes/admin/class-crowdsignal-forms-admin.php:87
+msgid "Getting Started"
 msgstr ""
 
-#: includes/admin/class-crowdsignal-forms-admin.php:71
-#: includes/admin/class-crowdsignal-forms-admin.php:86
+#: includes/admin/class-crowdsignal-forms-admin.php:88
 #: build/editor.js:13
 msgid "Settings"
-msgstr ""
-
-#: includes/admin/class-crowdsignal-forms-admin.php:72
-#: includes/admin/class-crowdsignal-forms-admin.php:85
-msgid "Getting Started"
 msgstr ""
 
 #: includes/admin/class-crowdsignal-forms-settings.php:71
@@ -180,6 +173,10 @@ msgstr ""
 #. translators: Argument is a link to Crowdsignal's support page.
 #: includes/admin/views/html-admin-setup-step-3.php:52
 msgid "<a href=\"%1s\" target=\"_blank\">Read more about us here.</a>"
+msgstr ""
+
+#: includes/class-crowdsignal-forms.php:439
+msgid "Crowdsignal"
 msgstr ""
 
 #: includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php:146

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/crowdsignal-forms",
-	"version": "1.5.7",
+	"version": "1.5.8",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/crowdsignal-forms",
-	"version": "1.5.7",
+	"version": "1.5.8",
 	"description": "Crowdsignal powered forms for WordPress",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
This is a release PR for 1.5.8

## Test instructions

Verify all blocks, confirm the included changes from the changelog:

* Fix Feedback Button block on Block Widget editor. (#173)
* Fix isPollBlock to prevent crashes when getBlocks() returns null (#175)
* ~~Move menu items into Settings menu. (#174)~~ (reverted)
* Fix toolbar/feedback overlay interactions (#172)