### PR TITLE
Move menus into Settings

### DIFF
--- a/client/components/connect-to-crowdsignal/index.js
+++ b/client/components/connect-to-crowdsignal/index.js
@@ -24,7 +24,7 @@ const ConnectToCrowdsignal = ( props ) => {
 		const isNowVerified = !! newAccountInfo.is_verified;
 
 		if ( ! isNowConnected ) {
-			window.open( '/wp-admin/admin.php?page=crowdsignal-forms-setup' );
+			window.open( '/wp-admin/options-general.php?page=crowdsignal-forms-settings' );
 		}
 
 		// Don't pop open the email window if the connection state just changed.

--- a/includes/admin/class-crowdsignal-forms-admin.php
+++ b/includes/admin/class-crowdsignal-forms-admin.php
@@ -66,11 +66,14 @@ class Crowdsignal_Forms_Admin {
 	 * Adds pages to admin menu.
 	 */
 	public function admin_menu() {
-		$icon_encoded = 'PHN2ZyBpZD0iY29udGVudCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMjg4IDIyMCI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNGRkZGRkY7fTwvc3R5bGU+PC9kZWZzPjx0aXRsZT5pY29uLWJsdWU8L3RpdGxlPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTI2Mi40MSw4MC4xYy04LjQ3LTIyLjU1LTE5LjA1LTQyLjgzLTI5Ljc5LTU3LjFDMjIwLjc0LDcuMjQsMjEwLC41NywyMDEuNDcsMy43OWExMi4zMiwxMi4zMiwwLDAsMC0zLjcyLDIuM2wtLjA1LS4xNUwxNiwxNzMuOTRsOC4yLDE5LjEyLDMwLjU2LTEuOTJ2MTMuMDVhMTIuNTcsMTIuNTcsMCwwLDAsMTIuNTgsMTIuNTZjLjMzLDAsLjY3LDAsMSwwbDU4Ljg1LTQuNzdhMTIuNjUsMTIuNjUsMCwwLDAsMTEuNTYtMTIuNTNWMTg1Ljg2bDEyMS40NS03LjY0YTEzLjg4LDEzLjg4LDAsMCwwLDIuMDkuMjYsMTIuMywxMi4zLDAsMCwwLDQuNDEtLjhDMjg1LjMzLDE3MC43LDI3OC42MywxMjMuMzEsMjYyLjQxLDgwLjFabS0yLjI2LDg5Ljc3Yy0xMC40OC0zLjI1LTMwLjQ0LTI4LjE1LTQ2LjY4LTcxLjM5LTE1LjcyLTQxLjktMTcuNS03My4yMS0xMi4zNC04My41NGE2LjUyLDYuNTIsMCwwLDEsMy4yMi0zLjQ4LDMuODIsMy44MiwwLDAsMSwxLjQxLS4yNGMzLjg1LDAsMTAuOTQsNC4yNiwyMC4zMSwxNi43MUMyMzYuMzYsNDEuNTksMjQ2LjU0LDYxLjE1LDI1NC43NCw4M2MxOC40NCw0OS4xMiwxNy43NCw4My43OSw5LjEzLDg3QTUuOTMsNS45MywwLDAsMSwyNjAuMTUsMTY5Ljg3Wk0xMzAuNiwxOTkuNDFhNC40LDQuNCwwLDAsMS00LDQuMzdsLTU4Ljg1LDQuNzdBNC4zOSw0LjM5LDAsMCwxLDYzLDIwNC4xOVYxOTAuNjJsNjcuNjEtNC4yNVoiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik02LDE4NS4yNmExMC4yNSwxMC4yNSwwLDAsMCwxMC4yNSwxMC4yNSwxMC4wNSwxMC4wNSwwLDAsMCw0LjM0LTFsLTcuOTQtMTguNzNBMTAuMiwxMC4yLDAsMCwwLDYsMTg1LjI2WiIvPjwvc3ZnPgo=';
-		add_menu_page( __( 'Crowdsignal', 'crowdsignal-forms' ), __( 'Crowdsignal', 'crowdsignal-forms' ), 'manage_options', 'crowdsignal-forms', array( $this->settings_page, 'output' ), 'data:image/svg+xml;base64,' . $icon_encoded );
-		add_submenu_page( 'crowdsignal-forms', __( 'Settings', 'crowdsignal-forms' ), __( 'Settings', 'crowdsignal-forms' ), 'manage_options', 'crowdsignal-forms-settings', array( $this->settings_page, 'output' ) );
-		add_submenu_page( 'crowdsignal-forms', __( 'Getting Started', 'crowdsignal-forms' ), __( 'Getting Started', 'crowdsignal-forms' ), 'manage_options', 'crowdsignal-forms-setup', array( $this->setup_page, 'setup_page' ) );
-		remove_submenu_page( 'crowdsignal-forms', 'crowdsignal-forms' );
+		$settings_page_title = 'Crowdsignal';
+		$hook = add_options_page( $settings_page_title, $settings_page_title, 'manage_options', 'crowdsignal-forms-settings', array( $this->settings_page, 'output' ) );
+		add_action( "load-$hook", array( $this->settings_page, 'update_settings' ) );
+
+		$settings_page_title = 'Get Started with Crowdsignal';
+		$hook = add_options_page( $settings_page_title, $settings_page_title, 'manage_options', 'crowdsignal-forms-setup', array( $this->setup_page, 'output' ) );
+		add_action( "load-$hook", array( $this->setup_page, 'setup_page' ) );
+
 	}
 
 	/**

--- a/includes/admin/class-crowdsignal-forms-settings.php
+++ b/includes/admin/class-crowdsignal-forms-settings.php
@@ -121,20 +121,20 @@ class Crowdsignal_Forms_Settings {
 					$api_key = sanitize_key( wp_unslash( $_POST['crowdsignal_api_key'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- got_api_key
 					if ( ! empty( $api_key ) && $api_auth_provider->get_user_code_for_key( $api_key ) ) {
 						$api_auth_provider->set_api_key( $api_key );
-						wp_safe_redirect( admin_url( 'admin.php?page=crowdsignal-forms-settings&msg=api-key-added' ) );
+						wp_safe_redirect( admin_url( 'options-general.php?page=crowdsignal-forms-settings&msg=api-key-added' ) );
 					} else {
-						wp_safe_redirect( admin_url( 'admin.php?page=crowdsignal-forms-settings&msg=api-key-not-added' ) );
+						wp_safe_redirect( admin_url( 'options-general.php?page=crowdsignal-forms-settings&msg=api-key-not-added' ) );
 					}
 				} else {
-					wp_safe_redirect( admin_url( 'admin.php?page=crowdsignal-forms-settings&msg=bad-nonce' ) );
+					wp_safe_redirect( admin_url( 'options-general.php?page=crowdsignal-forms-settings&msg=bad-nonce' ) );
 				}
 			} elseif ( 'disconnect' === $_POST['action'] ) {
 				if ( ! wp_verify_nonce( sanitize_key( $_POST['_wpnonce'] ), 'disconnect-api-key' ) ) {
-					wp_safe_redirect( admin_url( 'admin.php?page=crowdsignal-forms-settings&msg=disconnect-failed' ) );
+					wp_safe_redirect( admin_url( 'options-general.php?page=crowdsignal-forms-settings&msg=disconnect-failed' ) );
 				} else {
 					$api_auth_provider->delete_api_key();
 					$api_auth_provider->delete_user_code();
-					wp_safe_redirect( admin_url( 'admin.php?page=crowdsignal-forms-settings&msg=disconnected' ) );
+					wp_safe_redirect( admin_url( 'options-general.php?page=crowdsignal-forms-settings&msg=disconnected' ) );
 				}
 			}
 		}
@@ -165,7 +165,7 @@ class Crowdsignal_Forms_Settings {
 									sprintf(
 										/* translators: %s is a link to the Crowdsignal connection page. */
 										__( 'To collect responses and data with Crowdsignal Forms you need to <a href="%s" target="_blank">connect the plugin with a Crowdsignal account.</a>', 'crowdsignal-forms' ),
-										'/wp-admin/admin.php?page=crowdsignal-forms-setup'
+										'/wp-admin/options-general.php?page=crowdsignal-forms-setup'
 									)
 								);
 							?>
@@ -173,7 +173,7 @@ class Crowdsignal_Forms_Settings {
 							<?php esc_html_e( 'You can do this by entering an API key below:', 'crowdsignal-forms' ); ?>
 						</div>
 
-						<form class="crowdsignal-options" method="post" action="<?php echo esc_url( admin_url( 'admin.php?page=crowdsignal-forms-settings' ) ); ?>">
+						<form class="crowdsignal-options" method="post" action="<?php echo esc_url( admin_url( 'options-general.php?page=crowdsignal-forms-settings' ) ); ?>">
 							<?php
 							// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Used for basic flow.
 							if ( ! empty( $_GET['settings-updated'] ) ) {
@@ -223,7 +223,7 @@ class Crowdsignal_Forms_Settings {
 								<?php
 								if ( ! get_option( Crowdsignal_Forms_Api_Authenticator::API_KEY_NAME ) ) {
 									esc_html_e( "If you don't have an API key we can help you here: ", 'crowdsignal-forms' );
-									echo '<a class="button" rel="noopener noreferrer" href="/wp-admin/admin.php?page=crowdsignal-forms-setup">Get an API Key</a>';
+									echo '<a class="button" rel="noopener noreferrer" href="/wp-admin/options-general.php?page=crowdsignal-forms-setup">Get an API Key</a>';
 								}
 								?>
 

--- a/includes/admin/class-crowdsignal-forms-setup.php
+++ b/includes/admin/class-crowdsignal-forms-setup.php
@@ -24,6 +24,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Crowdsignal_Forms_Setup {
 
 	/**
+	 * The step in the setup process.
+	 *
+	 * @var int
+	 */
+	private $step = false;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -77,17 +84,17 @@ class Crowdsignal_Forms_Setup {
 		$api_auth_provider = Crowdsignal_Forms::instance()->get_api_authenticator();
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- got_api_key check later
-		$step = ! empty( $_GET['step'] ) ? absint( $_GET['step'] ) : 1;
+		$this->step = ! empty( $_GET['step'] ) ? absint( $_GET['step'] ) : 1;
 		if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] ) {
-			if ( 2 === $step && isset( $_POST['got_api_key'] ) && isset( $_POST['api_key'] ) && get_option( 'crowdsignal_api_key_secret' ) === $_POST['got_api_key'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- got_api_key
+			if ( 2 === $this->step && isset( $_POST['got_api_key'] ) && isset( $_POST['api_key'] ) && get_option( 'crowdsignal_api_key_secret' ) === $_POST['got_api_key'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- got_api_key
 				$api_key = sanitize_key( wp_unslash( $_POST['api_key'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- got_api_key
 				$api_auth_provider->set_api_key( $api_key );
 				$api_auth_provider->get_user_code_for_key( $api_key );
 				delete_option( 'crowdsignal_api_key_secret' );
 			} else {
-				$step = 1; // repeat the setup.
+				$this->step = 1; // repeat the setup.
 			}
-		} elseif ( 1 === $step ) {
+		} elseif ( 1 === $this->step ) {
 			update_option( 'crowdsignal_api_key_secret', md5( time() . wp_rand() ) );
 
 			$existing_api_key = $api_auth_provider->get_api_key();
@@ -104,7 +111,7 @@ class Crowdsignal_Forms_Setup {
 						$api_auth_provider->set_user_code( $existing_user_code );
 					}
 					delete_option( 'crowdsignal_api_key_secret' );
-					$step = 3;
+					$this->step = 3;
 				} else {
 					/**
 					 * Cached API key may have been deleted on the server.
@@ -116,11 +123,9 @@ class Crowdsignal_Forms_Setup {
 		}
 
 		// we're all done, remove the notice.
-		if ( 1 !== $step ) {
+		if ( 1 !== $this->step ) {
 			Crowdsignal_Forms_Admin_Notices::remove_notice( Crowdsignal_Forms_Admin_Notices::NOTICE_CORE_SETUP );
 		}
-
-		$this->output( $step );
 	}
 
 	/**
@@ -141,16 +146,14 @@ class Crowdsignal_Forms_Setup {
 
 	/**
 	 * Displays setup page.
-	 *
-	 * @param int $step the step shown to the user.
 	 */
-	public function output( $step ) {
+	public function output() {
 		include dirname( __FILE__ ) . '/views/html-admin-setup-header.php';
-		if ( 1 === $step ) {
+		if ( 1 === $this->step ) {
 			include dirname( __FILE__ ) . '/views/html-admin-setup-step-1.php';
-		} elseif ( 2 === $step ) {
+		} elseif ( 2 === $this->step ) {
 			include dirname( __FILE__ ) . '/views/html-admin-setup-step-2.php';
-		} elseif ( 3 === $step ) {
+		} elseif ( 3 === $this->step ) {
 			include dirname( __FILE__ ) . '/views/html-admin-setup-step-3.php';
 		}
 		include dirname( __FILE__ ) . '/views/html-admin-setup-footer.php';

--- a/includes/admin/views/html-admin-setup-step-1.php
+++ b/includes/admin/views/html-admin-setup-step-1.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="wrap crowdsignal-settings-wrap">
 			<form id="cs-connect-form" class="crowdsignal-options" method="post" action="https://app.crowdsignal.com/get-api-key/" target="CSCONNECT">
 			<input type="hidden" name="get_api_key" value="<?php echo esc_attr( get_option( 'crowdsignal_api_key_secret' ) ); ?>" />
-			<input type="hidden" name="ref" value="<?php echo esc_attr( admin_url( 'admin.php?page=crowdsignal-forms-setup' ) ); ?>" />
+			<input type="hidden" name="ref" value="<?php echo esc_attr( admin_url( 'options-general.php?page=crowdsignal-forms-setup' ) ); ?>" />
 			<input type="submit" value="<?php esc_html_e( 'Let’s get started', 'crowdsignal-forms' ); ?>" class="crowdsignal-setup__button" />
 			</form>
 		</div>


### PR DESCRIPTION
This is a dupe of #174 which was reverted.

The "Getting Started with Crowdsignal" menu is a temporary menu until we move it into the main settings page.