### PR TITLE
Manually set the priority of withFixedPosition hook on BlockListBlock to 1

### DIFF
--- a/client/editor.js
+++ b/client/editor.js
@@ -28,7 +28,8 @@ registerBlockType( 'crowdsignal-forms/feedback', feedbackBlock );
 addFilter(
 	'editor.BlockListBlock',
 	'crowdsignal-forms/with-fixed-position',
-	withFixedPosition
+	withFixedPosition,
+	1
 );
 addFilter(
 	'editor.BlockEdit',


### PR DESCRIPTION
As discussed in C01CSBEN0QZ/p1632774353453800-slack-acme-signal-co, it seems we're dealing with issues where other plugins with editor filters using the default priority can override the styles generated by `withFixedPosition` for `BlockListBlock`.  

While ultimately this isn't necessarily an issue on our end, since our filter is fairly well behaved, doesn't apply itself onto other blocks and doesn't strip any existing properties, I believe we can safely increase the priority so it's not affected as much by this issue and we're not relying on 3rd parties to implement fixes.

# Testing

Test if the feedback block is being positioned correctly within the post editor.