### PR TITLE
Fix warnings and skips

### DIFF
--- a/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
@@ -95,7 +95,7 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 	 */
 	private function should_hide_block( $attributes = array() ) {
 		if (
-			! $attributes['isWidget'] && (
+			! empty( $attributes['isWidget'] ) && (
 				! $this->is_cs_connected() ||
 				! is_singular()
 			)

--- a/includes/synchronization/class-poll-block-synchronizer.php
+++ b/includes/synchronization/class-poll-block-synchronizer.php
@@ -148,6 +148,10 @@ class Poll_Block_Synchronizer {
 
 			foreach ( $blocks_to_process as $block ) {
 				if ( in_array( $block['blockName'], array( 'crowdsignal-forms/poll', 'crowdsignal-forms/vote', 'crowdsignal-forms/applause' ), true ) ) {
+					if ( empty( $block['attrs']['pollId'] ) ) {
+						// this means somehow a newly created poll still not saved, let it there to maybe sync next time.
+						continue;
+					}
 					$poll_blocks[] = $block;
 					continue;
 				}


### PR DESCRIPTION
This PR changes some data validation with more reliable checks:

- use `empty` instead of trying to access array index directly
- skip block processing if there's no poll ID present (poll ID should be acquired while editing and available at the time of saving)

## Test instructions
These are mere code improvements, this PR should not pose significant changes unless something is broken on the frontend