### PR TITLE
Attempt to track failed connections

### DIFF
--- a/client/components/connect-to-crowdsignal/index.js
+++ b/client/components/connect-to-crowdsignal/index.js
@@ -3,11 +3,14 @@
  */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useCallback } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { useAccountInfo } from 'data/hooks';
+import { trackFailedConnection } from 'lib/tracks';
 
 const ConnectToCrowdsignal = ( props ) => {
 	const { blockIcon, blockName, children } = props;
@@ -15,6 +18,18 @@ const ConnectToCrowdsignal = ( props ) => {
 	const { accountInfo, reloadAccountInfo } = useAccountInfo();
 	const isConnected = accountInfo && accountInfo.id !== 0;
 	const isAccountVerified = !! accountInfo.is_verified;
+	const { authorId, site } = useSelect( ( select ) => {
+		console.log( select( 'core' ) );
+		console.log( select( 'core/editor' ) );
+		window.cc = select( 'core' );
+		window.ce = select( 'core/editor' );
+		return {
+			authorId: select( 'core/editor' ).getEditedPostAttribute(
+				'author'
+			),
+			site: select( 'core' ).getSite(),
+		};
+	} );
 
 	const handleConnectClick = async () => {
 		const initialConnectedState = isConnected;
@@ -40,6 +55,8 @@ const ConnectToCrowdsignal = ( props ) => {
 
 	const showConnectionMessage = ! isConnected;
 	const showVerificationMessage = isConnected && ! isAccountVerified;
+
+	trackFailedConnection( authorId, site, blockName );
 
 	return (
 		<div className="crowdsignal-forms__connect-to-crowdsignal">

--- a/client/components/connect-to-crowdsignal/index.js
+++ b/client/components/connect-to-crowdsignal/index.js
@@ -19,10 +19,6 @@ const ConnectToCrowdsignal = ( props ) => {
 	const isConnected = accountInfo && accountInfo.id !== 0;
 	const isAccountVerified = !! accountInfo.is_verified;
 	const { authorId, site } = useSelect( ( select ) => {
-		console.log( select( 'core' ) );
-		console.log( select( 'core/editor' ) );
-		window.cc = select( 'core' );
-		window.ce = select( 'core/editor' );
 		return {
 			authorId: select( 'core/editor' ).getEditedPostAttribute(
 				'author'

--- a/client/components/connect-to-crowdsignal/index.js
+++ b/client/components/connect-to-crowdsignal/index.js
@@ -3,7 +3,6 @@
  */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -18,14 +17,9 @@ const ConnectToCrowdsignal = ( props ) => {
 	const { accountInfo, reloadAccountInfo } = useAccountInfo();
 	const isConnected = accountInfo && accountInfo.id !== 0;
 	const isAccountVerified = !! accountInfo.is_verified;
-	const { authorId, site } = useSelect( ( select ) => {
-		return {
-			authorId: select( 'core/editor' ).getEditedPostAttribute(
-				'author'
-			),
-			site: select( 'core' ).getSite(),
-		};
-	} );
+	const authorId = useSelect( ( select ) =>
+		select( 'core/editor' ).getEditedPostAttribute( 'author' )
+	);
 
 	const handleConnectClick = async () => {
 		const initialConnectedState = isConnected;
@@ -52,7 +46,7 @@ const ConnectToCrowdsignal = ( props ) => {
 	const showConnectionMessage = ! isConnected;
 	const showVerificationMessage = isConnected && ! isAccountVerified;
 
-	trackFailedConnection( authorId, site, blockName );
+	trackFailedConnection( authorId, blockName );
 
 	return (
 		<div className="crowdsignal-forms__connect-to-crowdsignal">

--- a/client/lib/tracks.js
+++ b/client/lib/tracks.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { debounce } from 'lodash';
+
+export const trackFailedConnection = debounce(
+	( authorId, site, blockName ) => {
+		window._tkq = window._tkq || [];
+		window._tkq.push( [
+			'recordEvent',
+			'crowdsignal_connection_failed',
+			{
+				author_id: authorId,
+				site,
+				block_name: blockName,
+			},
+		] );
+	},
+	5000
+);

--- a/client/lib/tracks.js
+++ b/client/lib/tracks.js
@@ -3,18 +3,14 @@
  */
 import { debounce } from 'lodash';
 
-export const trackFailedConnection = debounce(
-	( authorId, site, blockName ) => {
-		window._tkq = window._tkq || [];
-		window._tkq.push( [
-			'recordEvent',
-			'crowdsignal_connection_failed',
-			{
-				author_id: authorId,
-				site,
-				block_name: blockName,
-			},
-		] );
-	},
-	5000
-);
+export const trackFailedConnection = debounce( ( authorId, blockName ) => {
+	window._tkq = window._tkq || [];
+	window._tkq.push( [
+		'recordEvent',
+		'crowdsignal_connection_failed',
+		{
+			author_id: authorId,
+			block_name: blockName,
+		},
+	] );
+}, 5000 );


### PR DESCRIPTION
This PR adds a call to our track events to try and solve the disconnection issue happening on isolated cases.

When the connection fails and the notice is shown, try and enqueue a call to the event system.

## Test instructions

Checkout and run `make client`. Force a disconnection by un-setting your Crowdsignal API KEY from the settings.
Create a post and insert a Poll block.
- on self-hosted sites there should be no errors, but no tracking either
- on a sandboxed site you'll need to force the disconnection by deleting the API KEY manually, then try and insert a Poll block on a post

After a couple of minutes you should be able to see the logged event: `crowdsignal_connection_failed`