### PR TITLE
Default polls to "Button" style

### DIFF
--- a/client/blocks/poll/index.js
+++ b/client/blocks/poll/index.js
@@ -63,5 +63,18 @@ export default {
 			label: __( 'Default', 'crowdsignal-forms' ),
 			isDefault: true,
 		},
+		{
+			name: 'buttons',
+			label: __( 'Buttons', 'crowdsignal-forms' ),
+		},
+	],
+	variations: [
+		{
+			isDefault: true,
+			attributes: {
+				// Force the correct className onto the block by default
+				className: 'is-style-buttons',
+			},
+		},
 	],
 };

--- a/client/blocks/poll/index.js
+++ b/client/blocks/poll/index.js
@@ -60,7 +60,7 @@ export default {
 	styles: [
 		{
 			name: 'default',
-			label: __( 'Default', 'crowdsignal-forms' ),
+			label: __( 'List', 'crowdsignal-forms' ),
 			isDefault: true,
 		},
 		{


### PR DESCRIPTION
This PR registers a variation and makes it default with the button style class.

Thanks @ice9js for the tip on this one

## Test instructions
Checkout and run `make client`. Create a post and insert a Poll block. The Poll should be on its "button style" by default.
Check older Poll blocks either on the same post or other posts, those should remain as they were.