### PR TITLE
Rework code

### DIFF
--- a/includes/admin/class-crowdsignal-forms-setup.php
+++ b/includes/admin/class-crowdsignal-forms-setup.php
@@ -43,8 +43,8 @@ class Crowdsignal_Forms_Setup {
 	 * @param bool $show to show the notice or not.
 	 */
 	public function show_setup_notice( $show ) {
-		$api_auth_provider = Crowdsignal_Forms::instance()->get_api_authenticator();
-		if ( $api_auth_provider->get_user_code() ) {
+		$api_authenticator = Crowdsignal_Forms::instance()->get_api_authenticator();
+		if ( $api_authenticator->get_user_code() ) {
 			return false;
 		} else {
 			return true;
@@ -74,15 +74,15 @@ class Crowdsignal_Forms_Setup {
 	 */
 	public function setup_page() {
 
-		$api_auth_provider = Crowdsignal_Forms::instance()->get_api_authenticator();
+		$api_authenticator = Crowdsignal_Forms::instance()->get_api_authenticator();
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- got_api_key check later
 		$step = ! empty( $_GET['step'] ) ? absint( $_GET['step'] ) : 1;
 		if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] ) {
 			if ( 2 === $step && isset( $_POST['got_api_key'] ) && isset( $_POST['api_key'] ) && get_option( 'crowdsignal_api_key_secret' ) === $_POST['got_api_key'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- got_api_key
 				$api_key = sanitize_key( wp_unslash( $_POST['api_key'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- got_api_key
-				$api_auth_provider->set_api_key( $api_key );
-				$api_auth_provider->get_user_code_for_key( $api_key );
+				$api_authenticator->set_api_key( $api_key );
+				$api_authenticator->get_user_code_for_key( $api_key );
 				delete_option( 'crowdsignal_api_key_secret' );
 			} else {
 				$step = 1; // repeat the setup.
@@ -90,18 +90,18 @@ class Crowdsignal_Forms_Setup {
 		} elseif ( 1 === $step ) {
 			update_option( 'crowdsignal_api_key_secret', md5( time() . wp_rand() ) );
 
-			$existing_api_key = $api_auth_provider->get_api_key();
+			$existing_api_key = $api_authenticator->get_api_key();
 			if ( ! $existing_api_key ) {
 				$existing_api_key = get_option( 'polldaddy_api_key' );
-				$api_auth_provider->set_api_key( $existing_api_key );
+				$api_authenticator->set_api_key( $existing_api_key );
 			}
 
 			if ( $existing_api_key ) {
-				$existing_user_code = $api_auth_provider->get_user_code_for_key( $existing_api_key );
+				$existing_user_code = $api_authenticator->get_user_code_for_key( $existing_api_key );
 
 				if ( $existing_user_code ) {
-					if ( $api_auth_provider->get_user_code() !== $existing_user_code ) {
-						$api_auth_provider->set_user_code( $existing_user_code );
+					if ( $api_authenticator->get_user_code() !== $existing_user_code ) {
+						$api_authenticator->set_user_code( $existing_user_code );
 					}
 					delete_option( 'crowdsignal_api_key_secret' );
 					$step = 3;
@@ -110,7 +110,7 @@ class Crowdsignal_Forms_Setup {
 					 * Cached API key may have been deleted on the server.
 					 * Force reconnection.
 					 */
-					$api_auth_provider->delete_api_key();
+					$api_authenticator->delete_api_key();
 				}
 			}
 		}

--- a/includes/class-crowdsignal-forms.php
+++ b/includes/class-crowdsignal-forms.php
@@ -240,7 +240,7 @@ final class Crowdsignal_Forms {
 		add_action( 'init', array( $this->blocks, 'register' ) );
 		add_action( 'rest_api_init', array( $this, 'register_rest_api_routes' ) );
 
-		add_filter( 'block_categories', array( $this, 'add_block_category' ), 10, 2 );
+		add_filter( 'block_categories_all', array( $this, 'add_block_category' ), 10, 2 );
 		add_filter( 'crowdsignal_forms_api_request_headers', array( $this, 'add_auth_request_headers' ) );
 
 		$this->admin_hooks->hook();

--- a/includes/frontend/class-crowdsignal-forms-block.php
+++ b/includes/frontend/class-crowdsignal-forms-block.php
@@ -92,7 +92,7 @@ abstract class Crowdsignal_Forms_Block {
 		}
 
 		$api_auth_provider     = Crowdsignal_Forms::instance()->get_api_authenticator();
-		self::$is_cs_connected = false !== $api_auth_provider->get_user_code();
+		self::$is_cs_connected = ! empty( $api_auth_provider->get_user_code() );
 
 		// purposely not doing the account is_verified check to avoid making a slow query on every page load.
 

--- a/includes/synchronization/class-post-sync-entity.php
+++ b/includes/synchronization/class-post-sync-entity.php
@@ -68,7 +68,7 @@ class Post_Sync_Entity implements Synchronizable_Entity {
 	 * @return bool
 	 */
 	public function can_be_saved() {
-		if ( wp_is_post_autosave( $this->post_id ) || wp_is_post_revision( $this->post_id ) || 'trash' === $this->post->post_status ) {
+		if ( wp_is_post_autosave( $this->post_id ) || wp_is_post_revision( $this->post_id ) || 'trash' === $this->post->post_status || 'auto-draft' === $this->post->post_status ) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
This PR fixes some small issues with the code and variable naming

* 996cbd1 get_user_code never returns strict false, mostly empty strings
* 19d865c auto-draft is the post status upon creation. Skip any synchronization on this status, it's triggering a useless request on EVERY POST CREATION
* fb8a60d Var rename: api_authenticator is the abstraction for auth_provider, less confusing this way
* 0085fa2 A deprecation notice is taking place on filter usage `block_categories` in favor of `block_categories_all`