### PR TITLE
Bump version to 1.5.12

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -4,7 +4,7 @@ Tags: polls, forms, surveys, gutenberg, block
 Requires at least: 5.0
 Requires PHP: 5.6.20
 Tested up to: 5.6
-Stable tag: 1.5.11
+Stable tag: 1.5.12
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,11 @@ Compare our [simple and affordable plans](https://crowdsignal.com/pricing/) or t
 4. Use the poll block inside of other blocks
 
 == Changelog ==
+
+= 1.5.12 =
+* Improve broken connection handling (#193)
+* Fix multiple choice poll check position (#192)
+* Rework backend code (#191)
 
 = 1.5.11 =
 * Default polls to "Button" style (#189)
@@ -144,8 +149,8 @@ Compare our [simple and affordable plans](https://crowdsignal.com/pricing/) or t
 
 == Upgrade Notice ==
 
-= 1.5.7 =
-Bugfixes and typos. v1.5.7 addresses an issue with newer version of Gutenberg preventing Feedback Button to render properly on the editor.
+= 1.5.12 =
+Improve broken connection handling, fix multiple choice poll check styling. Bugs and fixes on backend code.
 
 = 0.9 =
 Initial release

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+= 1.5.12 =
+* Improve broken connection handling (#193)
+* Fix multiple choice poll check position (#192)
+* Rework backend code (#191)
+
 = 1.5.11 =
 * Default polls to "Button" style (#189)
 

--- a/crowdsignal-forms.php
+++ b/crowdsignal-forms.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Crowdsignal Forms
  * Plugin URI:        https://crowdsignal.com/crowdsignal-forms/
  * Description:       Crowdsignal Form Blocks
- * Version:           1.5.11
+ * Version:           1.5.12
  * Author:            Automattic
  * Author URI:        https://automattic.com/
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die;
 }
 
-define( 'CROWDSIGNAL_FORMS_VERSION', '1.5.11' );
+define( 'CROWDSIGNAL_FORMS_VERSION', '1.5.12' );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_FILE', __FILE__ );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 

--- a/includes/admin/class-crowdsignal-forms-settings.php
+++ b/includes/admin/class-crowdsignal-forms-settings.php
@@ -42,7 +42,7 @@ class Crowdsignal_Forms_Settings {
 	 * Enqueues scripts for setup page.
 	 */
 	public function admin_enqueue_scripts() {
-		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.5.11' );
+		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.5.12' );
 	}
 
 	/**

--- a/includes/admin/class-crowdsignal-forms-setup.php
+++ b/includes/admin/class-crowdsignal-forms-setup.php
@@ -65,7 +65,7 @@ class Crowdsignal_Forms_Setup {
 	 * Enqueues scripts for setup page.
 	 */
 	public function admin_enqueue_scripts() {
-		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.5.11' );
+		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.5.12' );
 		wp_enqueue_script( 'videopress', 'https://videopress.com/videopress-iframe.js', array(), '1.0', false );
 	}
 

--- a/languages/crowdsignal-forms.pot
+++ b/languages/crowdsignal-forms.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Crowdsignal Forms 1.5.10\n"
+"Project-Id-Version: Crowdsignal Forms 1.5.12\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/crowdsignal-forms\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2021-11-01T16:30:20+00:00\n"
+"POT-Creation-Date: 2021-11-22T17:51:43+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.4.0\n"
 "X-Domain: crowdsignal-forms\n"
@@ -625,10 +625,6 @@ msgstr ""
 
 #: build/editor.js:13
 msgid "Email"
-msgstr ""
-
-#: build/editor.js:13
-msgid "Default"
 msgstr ""
 
 #: build/editor.js:13

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/crowdsignal-forms",
-	"version": "1.5.11",
+	"version": "1.5.12",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/crowdsignal-forms",
-	"version": "1.5.11",
+	"version": "1.5.12",
 	"description": "Crowdsignal powered forms for WordPress",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
This is the bump release PR for 1.5.12

From the changelog:

* Improve broken connection handling (#193)
* Fix multiple choice poll check position (#192)
* Rework backend code (#191)

## Test instructions
Go through the changelog entries, verify the fixes and changes are there. Keep in mind some of the changes are not to be tested on self-hosted sites (will have no effect), but the action call should be in place