### PR TITLE
Let the dashboard plugin take care of menus.

### DIFF
--- a/includes/admin/class-crowdsignal-forms-admin.php
+++ b/includes/admin/class-crowdsignal-forms-admin.php
@@ -66,11 +66,18 @@ class Crowdsignal_Forms_Admin {
 	 * Adds pages to admin menu.
 	 */
 	public function admin_menu() {
-		$icon_encoded = 'PHN2ZyBpZD0iY29udGVudCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMjg4IDIyMCI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNGRkZGRkY7fTwvc3R5bGU+PC9kZWZzPjx0aXRsZT5pY29uLWJsdWU8L3RpdGxlPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTI2Mi40MSw4MC4xYy04LjQ3LTIyLjU1LTE5LjA1LTQyLjgzLTI5Ljc5LTU3LjFDMjIwLjc0LDcuMjQsMjEwLC41NywyMDEuNDcsMy43OWExMi4zMiwxMi4zMiwwLDAsMC0zLjcyLDIuM2wtLjA1LS4xNUwxNiwxNzMuOTRsOC4yLDE5LjEyLDMwLjU2LTEuOTJ2MTMuMDVhMTIuNTcsMTIuNTcsMCwwLDAsMTIuNTgsMTIuNTZjLjMzLDAsLjY3LDAsMSwwbDU4Ljg1LTQuNzdhMTIuNjUsMTIuNjUsMCwwLDAsMTEuNTYtMTIuNTNWMTg1Ljg2bDEyMS40NS03LjY0YTEzLjg4LDEzLjg4LDAsMCwwLDIuMDkuMjYsMTIuMywxMi4zLDAsMCwwLDQuNDEtLjhDMjg1LjMzLDE3MC43LDI3OC42MywxMjMuMzEsMjYyLjQxLDgwLjFabS0yLjI2LDg5Ljc3Yy0xMC40OC0zLjI1LTMwLjQ0LTI4LjE1LTQ2LjY4LTcxLjM5LTE1LjcyLTQxLjktMTcuNS03My4yMS0xMi4zNC04My41NGE2LjUyLDYuNTIsMCwwLDEsMy4yMi0zLjQ4LDMuODIsMy44MiwwLDAsMSwxLjQxLS4yNGMzLjg1LDAsMTAuOTQsNC4yNiwyMC4zMSwxNi43MUMyMzYuMzYsNDEuNTksMjQ2LjU0LDYxLjE1LDI1NC43NCw4M2MxOC40NCw0OS4xMiwxNy43NCw4My43OSw5LjEzLDg3QTUuOTMsNS45MywwLDAsMSwyNjAuMTUsMTY5Ljg3Wk0xMzAuNiwxOTkuNDFhNC40LDQuNCwwLDAsMS00LDQuMzdsLTU4Ljg1LDQuNzdBNC4zOSw0LjM5LDAsMCwxLDYzLDIwNC4xOVYxOTAuNjJsNjcuNjEtNC4yNVoiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik02LDE4NS4yNmExMC4yNSwxMC4yNSwwLDAsMCwxMC4yNSwxMC4yNSwxMC4wNSwxMC4wNSwwLDAsMCw0LjM0LTFsLTcuOTQtMTguNzNBMTAuMiwxMC4yLDAsMCwwLDYsMTg1LjI2WiIvPjwvc3ZnPgo=';
-		add_menu_page( __( 'Crowdsignal', 'crowdsignal-forms' ), __( 'Crowdsignal', 'crowdsignal-forms' ), 'manage_options', 'crowdsignal-forms', array( $this->settings_page, 'output' ), 'data:image/svg+xml;base64,' . $icon_encoded );
-		add_submenu_page( 'crowdsignal-forms', __( 'Settings', 'crowdsignal-forms' ), __( 'Settings', 'crowdsignal-forms' ), 'manage_options', 'crowdsignal-forms-settings', array( $this->settings_page, 'output' ) );
-		add_submenu_page( 'crowdsignal-forms', __( 'Getting Started', 'crowdsignal-forms' ), __( 'Getting Started', 'crowdsignal-forms' ), 'manage_options', 'crowdsignal-forms-setup', array( $this->setup_page, 'setup_page' ) );
-		remove_submenu_page( 'crowdsignal-forms', 'crowdsignal-forms' );
+		if (
+			isset( $_GET['page'] )
+			&& ( 'crowdsignal-forms-settings' === $_GET['page'] || 'crowdsignal-forms-setup' === $_GET['page'] )
+		) {
+			wp_safe_redirect( admin_url( 'options-general.php?page=crowdsignal-settings' ) );
+			die();
+		}
+
+		if ( ! is_plugin_active( 'polldaddy/polldaddy.php' ) ) {
+			// Add settings pages.
+			add_options_page( 'Crowdsignal', 'Crowdsignal', 'manage_options', 'crowdsignal-settings', array( $this->settings_page, 'output' ) );
+		}
 	}
 
 	/**
@@ -82,8 +89,7 @@ class Crowdsignal_Forms_Admin {
 	public function plugin_action_links( $links ) {
 		return array_merge(
 			array(
-				sprintf( '<a href="%s">' . __( 'Getting Started', 'crowdsignal-forms' ) . '</a>', admin_url( 'admin.php?page=crowdsignal-forms-setup' ) ),
-				sprintf( '<a href="%s">' . __( 'Settings', 'crowdsignal-forms' ) . '</a>', admin_url( 'admin.php?page=crowdsignal-forms-settings' ) ),
+				sprintf( '<a href="%s">' . __( 'Settings', 'crowdsignal-forms' ) . '</a>', admin_url( 'options-general.php?page=crowdsignal-settings' ) ),
 			),
 			$links
 		);

--- a/includes/admin/class-crowdsignal-forms-settings.php
+++ b/includes/admin/class-crowdsignal-forms-settings.php
@@ -102,7 +102,7 @@ class Crowdsignal_Forms_Settings {
 	 * Disconnect from Crowdsignal if required.
 	 */
 	public function update_settings() {
-		if ( ! isset( $_GET['page'] ) || 'crowdsignal-forms-settings' !== $_GET['page'] ) {
+		if ( ! isset( $_GET['page'] ) || 'crowdsignal-settings' !== $_GET['page'] ) {
 			return;
 		}
 
@@ -121,20 +121,20 @@ class Crowdsignal_Forms_Settings {
 					$api_key = sanitize_key( wp_unslash( $_POST['crowdsignal_api_key'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- got_api_key
 					if ( ! empty( $api_key ) && $api_auth_provider->get_user_code_for_key( $api_key ) ) {
 						$api_auth_provider->set_api_key( $api_key );
-						wp_safe_redirect( admin_url( 'admin.php?page=crowdsignal-forms-settings&msg=api-key-added' ) );
+						wp_safe_redirect( admin_url( 'options-general.php?page=crowdsignal-settings&msg=api-key-added' ) );
 					} else {
-						wp_safe_redirect( admin_url( 'admin.php?page=crowdsignal-forms-settings&msg=api-key-not-added' ) );
+						wp_safe_redirect( admin_url( 'options-general.php?page=crowdsignal-settings&msg=api-key-not-added' ) );
 					}
 				} else {
-					wp_safe_redirect( admin_url( 'admin.php?page=crowdsignal-forms-settings&msg=bad-nonce' ) );
+					wp_safe_redirect( admin_url( 'options-general.php?page=crowdsignal-settings&msg=bad-nonce' ) );
 				}
 			} elseif ( 'disconnect' === $_POST['action'] ) {
 				if ( ! wp_verify_nonce( sanitize_key( $_POST['_wpnonce'] ), 'disconnect-api-key' ) ) {
-					wp_safe_redirect( admin_url( 'admin.php?page=crowdsignal-forms-settings&msg=disconnect-failed' ) );
+					wp_safe_redirect( admin_url( 'options-general.php?page=crowdsignal-settings&msg=disconnect-failed' ) );
 				} else {
 					$api_auth_provider->delete_api_key();
 					$api_auth_provider->delete_user_code();
-					wp_safe_redirect( admin_url( 'admin.php?page=crowdsignal-forms-settings&msg=disconnected' ) );
+					wp_safe_redirect( admin_url( 'options-general.php?page=crowdsignal-settings&msg=disconnected' ) );
 				}
 			}
 		}
@@ -173,7 +173,7 @@ class Crowdsignal_Forms_Settings {
 							<?php esc_html_e( 'You can do this by entering an API key below:', 'crowdsignal-forms' ); ?>
 						</div>
 
-						<form class="crowdsignal-options" method="post" action="<?php echo esc_url( admin_url( 'admin.php?page=crowdsignal-forms-settings' ) ); ?>">
+						<form class="crowdsignal-options" method="post" action="<?php echo esc_url( admin_url( 'options-general.php?page=crowdsignal-settings' ) ); ?>">
 							<?php
 							// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Used for basic flow.
 							if ( ! empty( $_GET['settings-updated'] ) ) {


### PR DESCRIPTION
If the other Crowdsignal plugin is installed then it will take care of
connecting/disconnecting from Crowdsignal.
This patch also removes the Getting Started page so it should be merged
*after* https://github.com/Automattic/crowdsignal-forms/pull/179 is
merged.

Test
1. Install the Crowdsignal Plugin from https://github.com/Automattic/crowdsignal-plugin
2. Install this plugin with the add/menu_refresh branch.
3. Enable the Crowdsignal plugin. You should see Settings->Crowdsignal at options-general.php?page=crowdsignal-settings
4. Enable the CS Forms plugin. It shouldn't create a new Crowdsignal menu.