### PR TITLE
Some fixes along the way

### DIFF
--- a/client/components/connect-to-crowdsignal/index.js
+++ b/client/components/connect-to-crowdsignal/index.js
@@ -17,8 +17,8 @@ const ConnectToCrowdsignal = ( props ) => {
 	const { accountInfo, reloadAccountInfo } = useAccountInfo();
 	const isConnected = accountInfo && accountInfo.id !== 0;
 	const isAccountVerified = !! accountInfo.is_verified;
-	const authorId = useSelect( ( select ) =>
-		select( 'core/editor' ).getEditedPostAttribute( 'author' )
+	const currentUser = useSelect( ( select ) =>
+		select( 'core' ).getCurrentUser()
 	);
 
 	const handleConnectClick = async () => {
@@ -46,7 +46,10 @@ const ConnectToCrowdsignal = ( props ) => {
 	const showConnectionMessage = ! isConnected;
 	const showVerificationMessage = isConnected && ! isAccountVerified;
 
-	trackFailedConnection( authorId, blockName );
+	trackFailedConnection(
+		currentUser && currentUser.id ? currentUser.id : 0,
+		blockName
+	);
 
 	return (
 		<div className="crowdsignal-forms__connect-to-crowdsignal">

--- a/includes/class-crowdsignal-forms.php
+++ b/includes/class-crowdsignal-forms.php
@@ -240,7 +240,7 @@ final class Crowdsignal_Forms {
 		add_action( 'init', array( $this->blocks, 'register' ) );
 		add_action( 'rest_api_init', array( $this, 'register_rest_api_routes' ) );
 
-		add_filter( 'block_categories_all', array( $this, 'add_block_category' ), 10, 2 );
+		add_filter( 'block_categories', array( $this, 'add_block_category' ), 10, 2 );
 		add_filter( 'crowdsignal_forms_api_request_headers', array( $this, 'add_auth_request_headers' ) );
 
 		$this->admin_hooks->hook();

--- a/includes/gateways/class-api-gateway.php
+++ b/includes/gateways/class-api-gateway.php
@@ -566,7 +566,7 @@ class Api_Gateway implements Api_Gateway_Interface {
 				'capabilities' => array( 'hide-branding' ),
 			);
 
-			do_action( 'crowdsignal_forms_failed_connection' );
+			do_action( 'crowdsignal_forms_failed_connection', $ex->getMessage() ? $ex->getMessage() : 'Unknown error' );
 		}
 
 		return $response_data;

--- a/includes/gateways/class-api-gateway.php
+++ b/includes/gateways/class-api-gateway.php
@@ -529,13 +529,16 @@ class Api_Gateway implements Api_Gateway_Interface {
 	 * @throws \Exception   The exception is handled inside the try/catch.
 	 */
 	public function get_account_info() {
-		$transient_key          = 'cs-forms-account-info-' . get_current_user_id();
-		$transient_account_info = get_transient( $transient_key );
-		if ( $transient_account_info ) {
-			return $transient_account_info;
-		}
-
 		try {
+			if ( ! get_current_user_id() ) {
+				throw new \Exception( 'Invalid user ID: ' . get_current_user_id() );
+			}
+			$transient_key          = 'cs-forms-account-info-' . get_current_user_id();
+			$transient_account_info = get_current_user_id() ? get_transient( $transient_key ) : false;
+			if ( $transient_account_info ) {
+				return $transient_account_info;
+			}
+
 			$response = $this->perform_request( 'GET', '/account/info' );
 
 			// let it be handled by the catch.


### PR DESCRIPTION
This PR is part of the issue tracking regarding our connection problems.

* Rollback usage of `block_categories_all` as it's bringing problems with our builds. Deprecation warning will have to wait
* Use `core` store to get the user ID
* Pass error message as argument when invoking failed connection action
* Abort process if user ID is `0` and, most importantly, DO NOT SET THE TRANSIENT if that is the case

## Test instructions
This all is mostly backend fixes, not much to test but a usage of all the blocks and an eye on error logs / console would help.