### PR TITLE
Fix transient and empty user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.cache
 .idea
 *.code-workspace
 vendor

--- a/includes/admin/class-crowdsignal-forms-settings.php
+++ b/includes/admin/class-crowdsignal-forms-settings.php
@@ -60,7 +60,7 @@ class Crowdsignal_Forms_Settings {
 		wp_enqueue_style( 'jetpack-styles2', 'https://c0.wp.com/c/5.8.1/wp-admin/css/common.min.css', array(), '1.5.7' );
 		wp_enqueue_style( 'jetpack-styles3', 'https://c0.wp.com/p/jetpack/10.0/_inc/build/admin.css', array(), '1.5.7' );
 		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.5.12' );
-		wp_enqueue_script( 'videopress', 'https://videopress.com/videopress-iframe.js', array(), '1.0', false );		
+		wp_enqueue_script( 'videopress', 'https://videopress.com/videopress-iframe.js', array(), '1.0', false );
 	}
 
 	/**

--- a/includes/admin/class-crowdsignal-forms-settings.php
+++ b/includes/admin/class-crowdsignal-forms-settings.php
@@ -53,6 +53,16 @@ class Crowdsignal_Forms_Settings {
 	}
 
 	/**
+	 * Filter admin notice if the plugin has just finished step 3 successfully.
+	 *
+	 * @param bool $show to show the notice or not.
+	 */
+	public function show_setup_success( $show ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- readonly, boolean check
+		return isset( $_GET['msg'] ) && 'connect' === $_GET['msg'];
+	}
+
+	/**
 	 * Enqueues scripts for setup page.
 	 */
 	public function admin_enqueue_scripts() {

--- a/includes/admin/class-crowdsignal-forms-setup.php
+++ b/includes/admin/class-crowdsignal-forms-setup.php
@@ -117,7 +117,6 @@ class Crowdsignal_Forms_Setup {
 			}
 		}
 
-
 		// we're all done, remove the notice.
 		if ( 1 !== $this->step ) {
 			Crowdsignal_Forms_Admin_Notices::remove_notice( Crowdsignal_Forms_Admin_Notices::NOTICE_CORE_SETUP );

--- a/includes/gateways/class-api-gateway.php
+++ b/includes/gateways/class-api-gateway.php
@@ -530,15 +530,6 @@ class Api_Gateway implements Api_Gateway_Interface {
 	 */
 	public function get_account_info() {
 		try {
-			if ( ! get_current_user_id() ) {
-				throw new \Exception( 'Invalid user ID: ' . get_current_user_id() );
-			}
-			$transient_key          = 'cs-forms-account-info-' . get_current_user_id();
-			$transient_account_info = get_current_user_id() ? get_transient( $transient_key ) : false;
-			if ( $transient_account_info ) {
-				return $transient_account_info;
-			}
-
 			$response = $this->perform_request( 'GET', '/account/info' );
 
 			// let it be handled by the catch.
@@ -553,14 +544,6 @@ class Api_Gateway implements Api_Gateway_Interface {
 			if ( ! is_array( $response_data ) || isset( $response_data['error'] ) ) {
 				throw new \Exception( 'Could not get account info' );
 			}
-
-			// cache for 1 minute.
-			set_transient(
-				$transient_key,
-				$response_data,
-				MINUTE_IN_SECONDS
-			);
-
 		} catch ( \Exception $ex ) {
 			// ignore error, we'll get the updated value next time.
 			// Provide dummy response with safe defaults.


### PR DESCRIPTION
This PR changes where we cache for requests and removes the restriction for non logged in users.

* Allow user ID `0`/`null` to perform the request, credentials should be stored on the blog options
* Remove transient on get_account_info, we can't validate a unique-ish key there
* Place transient on auth headers filter, salt it with API KEY
* Fix an issue with a filter handler (dupe method from setup to settings class)