### PR TITLE
Add trigger for crowdsignal_forms_get_account_info

### DIFF
--- a/includes/gateways/class-api-gateway.php
+++ b/includes/gateways/class-api-gateway.php
@@ -544,6 +544,8 @@ class Api_Gateway implements Api_Gateway_Interface {
 			if ( ! is_array( $response_data ) || isset( $response_data['error'] ) ) {
 				throw new \Exception( 'Could not get account info' );
 			}
+
+			do_action( 'crowdsignal_forms_get_account_info', $response_data );
 		} catch ( \Exception $ex ) {
 			// ignore error, we'll get the updated value next time.
 			// Provide dummy response with safe defaults.


### PR DESCRIPTION
This PR adds a trigger for `crowdsignal_forms_get_account_info` called upon API gateway's `get_account_info`

It's a cherry pick from #202 latest commit