### PR TITLE
Fix typo on setup screen

### DIFF
--- a/includes/admin/views/html-admin-setup-step-1.php
+++ b/includes/admin/views/html-admin-setup-step-1.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<div class="crowdsignal-setup__content">
 		<div class="crowdsignal-setup__description">
 				<h1><?php esc_html_e( 'Welcome to Crowdsignal Forms', 'crowdsignal-forms' ); ?></h1>
-				<p><?php echo wp_kses_post( 'To collect and manage respones you need to connect the plugin to <a href="https://crowdsignal.com">Crowdsignal</a>. <br />It will take less than a minute and it’s free.', 'crowdsignal-forms' ); ?></p>
+				<p><?php echo wp_kses_post( 'To collect and manage responses you need to connect the plugin to <a href="https://crowdsignal.com">Crowdsignal</a>. <br />It will take less than a minute and it’s free.', 'crowdsignal-forms' ); ?></p>
 		</div>
 
 		<div class="wrap crowdsignal-settings-wrap">


### PR DESCRIPTION
This PR addresses a typo (respones -> responses) on first setup screen

Not much to test, checkout and just verify the setup screen reads "responses" now.