### PR TITLE
Update Dockerfile to pull latest stable Ubuntu. Small update to .yml file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:groovy
+FROM ubuntu:focal
 
 VOLUME ["/var/www/html"]
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,7 @@ volumes:
 
 services:
   db:
+    platform: linux/x86_64
     image: mysql:5.7
     container_name: cs_forms_mysql
     volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,7 +19,9 @@ services:
     container_name: cs_forms_wordpress
     depends_on:
       - db
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: cs_forms_wordpress:localbuild
     volumes:
       - ..:/var/www/html/wp-content/plugins/crowdsignal-forms
@@ -37,8 +39,8 @@ services:
       - "${PORT_CS_WORDPRESS:-8000}:80"
     restart: always
     extra_hosts:
-      - "api.crowdsignal.com:${CS_SANDBOX_IP:-192.0.123.248}"
-      - "app.crowdsignal.com:${CS_SANDBOX_IP:-192.0.123.248}"
+      - "api.crowdsignal.com:${CS_SANDBOX_IP:-192.0.123.178}"
+      - "app.crowdsignal.com:${CS_SANDBOX_IP:-192.0.123.178}"
     env_file:
       - default.env
       - .env

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,8 +40,8 @@ services:
       - "${PORT_CS_WORDPRESS:-8000}:80"
     restart: always
     extra_hosts:
-      - "api.crowdsignal.com:${CS_SANDBOX_IP:-192.0.123.178}"
-      - "app.crowdsignal.com:${CS_SANDBOX_IP:-192.0.123.178}"
+      - "api.crowdsignal.com:${CS_SANDBOX_IP:-192.0.123.248}"
+      - "app.crowdsignal.com:${CS_SANDBOX_IP:-192.0.123.248}"
     env_file:
       - default.env
       - .env


### PR DESCRIPTION
When attempting to run `make docker_build` following readme.md, the build process was crashing due to the Dockerfile attempting to install Ubuntu Groovy, which has been [retired](https://fridge.ubuntu.com/2021/07/25/ubuntu-20-10-groovy-gorilla-end-of-life-reached-on-july-22-2021/)

Updated the release docker installs to the current stable release (Focal).

Also made a slight update to the YML file to use the new syntax for build context and file.

Testing instructions:

Follow the readme.md file and build a new docker instance of Crowdsignal, verify that there are no 404 errors.