### PR TITLE
Add api.polldaddy.com as extra host 

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -42,6 +42,7 @@ services:
     extra_hosts:
       - "api.crowdsignal.com:${CS_SANDBOX_IP:-192.0.123.248}"
       - "app.crowdsignal.com:${CS_SANDBOX_IP:-192.0.123.248}"
+      - "api.polldaddy.com:${CS_SANDBOX_IP:-192.0.123.248}"
     env_file:
       - default.env
       - .env


### PR DESCRIPTION
This way, we can map the url to our sandbox so we get legacy calls to the sandbox as well