### PR TITLE
Remove templateLock

### DIFF
--- a/client/blocks/vote/edit.js
+++ b/client/blocks/vote/edit.js
@@ -88,7 +88,6 @@ const EditVoteBlock = ( props ) => {
 							[ 'crowdsignal-forms/vote-item', { type: 'down' } ],
 						] }
 						templateInsertUpdatesSelection={ false }
-						templateLock="insert"
 						allowedBlocks={ [ 'crowdsignal-forms/vote-item' ] }
 						orientation="horizontal"
 						__experimentalMoverDirection="horizontal" // required for pre WP 5.5, post 5.5 only requires `orientation` to be set


### PR DESCRIPTION
This PR removes the `templateLock` restriction on Vote block innerBlocks. The directive not only prevents insertions, but also removals. This goes against what we state on the docs about "removing the thumbs down vote is easy".

If we're not happy with this change, we can always put up a new "Thumbs Up" block, somewhat similar to the Applause block.

## Test instructions
Checkout and run `make client`. Edit a post on your docker and insert a Vote block. You should be able to remove the votes individually.
