### PR TITLE
Remove editor dependencies

### DIFF
--- a/client/components/feedback/form.js
+++ b/client/components/feedback/form.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
+import { RawHTML } from '@wordpress/element';
 import { TextControl, TextareaControl } from '@wordpress/components';
 
 /**
@@ -55,11 +55,9 @@ const FeedbackForm = ( { attributes, onSubmit } ) => {
 
 	return (
 		<form onSubmit={ handleSubmit }>
-			<RichText.Content
-				tagName="h3"
-				className="crowdsignal-forms-feedback__header"
-				value={ attributes.header }
-			/>
+			<h3 className="crowdsignal-forms-feedback__header">
+				<RawHTML>{ attributes.header }</RawHTML>
+			</h3>
 
 			<TextareaControl
 				className={ feedbackClasses }

--- a/client/components/feedback/submit.js
+++ b/client/components/feedback/submit.js
@@ -6,14 +6,12 @@ import React from 'react';
 /**
  * Wordpress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
+import { RawHTML } from '@wordpress/element';
 
 const FeedbackSubmit = ( { attributes } ) => (
-	<RichText.Content
-		tagName="h3"
-		className="crowdsignal-forms-feedback__header"
-		value={ attributes.submitText }
-	/>
+	<h3 className="crowdsignal-forms-feedback__header">
+		<RawHTML>{ attributes.submitText }</RawHTML>
+	</h3>
 );
 
 export default FeedbackSubmit;

--- a/client/components/feedback/toggle.js
+++ b/client/components/feedback/toggle.js
@@ -13,7 +13,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { RichText } from '@wordpress/block-editor';
+import { RawHTML } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -61,10 +61,9 @@ const FeedbackToggle = (
 					onClick={ onClick }
 					onMouseEnter={ handleHover }
 				>
-					<RichText.Content
-						className="crowdsignal-forms-feedback__trigger-text"
-						value={ attributes.triggerLabel }
-					/>
+					<div className="crowdsignal-forms-feedback__trigger-text">
+						<RawHTML>{ attributes.triggerLabel }</RawHTML>
+					</div>
 				</button>
 			) }
 			{ isOpen && (

--- a/client/components/nps/index.js
+++ b/client/components/nps/index.js
@@ -9,7 +9,7 @@ import { get } from 'lodash';
  */
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { RichText } from '@wordpress/block-editor';
+import { RawHTML } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -55,11 +55,9 @@ const Nps = ( {
 	return (
 		<>
 			<div className="crowdsignal-forms-nps" style={ style }>
-				<RichText.Content
-					tagName="h3"
-					className="crowdsignal-forms-nps__question"
-					value={ questionText }
-				/>
+				<h3 className="crowdsignal-forms-nps__question">
+					<RawHTML>{ questionText }</RawHTML>
+				</h3>
 
 				<button
 					className="crowdsignal-forms-nps__close-button"

--- a/client/components/poll/index.js
+++ b/client/components/poll/index.js
@@ -11,7 +11,8 @@ import classNames from 'classnames';
  */
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
-import { RichText } from '@wordpress/block-editor';
+// import { RichText } from '@wordpress/block-editor';
+import { RawHTML } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -157,18 +158,14 @@ const Poll = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 			{ errorMessage && <ErrorBanner>{ errorMessage }</ErrorBanner> }
 
 			<div className={ contentClasses }>
-				<RichText.Content
-					tagName="h3"
-					value={ decodeEntities( attributes.question ) }
-					className="crowdsignal-forms-poll__question"
-				/>
+				<h3 className="crowdsignal-forms-poll__question">
+					<RawHTML>{ decodeEntities( attributes.question ) }</RawHTML>
+				</h3>
 
 				{ attributes.note && (
-					<RichText.Content
-						className="crowdsignal-forms-poll__note"
-						tagName="div"
-						value={ decodeEntities( attributes.note ) }
-					/>
+					<div className="crowdsignal-forms-poll__note">
+						<RawHTML>{ decodeEntities( attributes.note ) }</RawHTML>
+					</div>
 				) }
 
 				{ ! showResults && (

--- a/includes/frontend/class-crowdsignal-forms-blocks-assets.php
+++ b/includes/frontend/class-crowdsignal-forms-blocks-assets.php
@@ -74,7 +74,8 @@ class Crowdsignal_Forms_Blocks_Assets {
 			wp_register_script(
 				$id,
 				$this->url_path( $paths['script'] ),
-				array_merge( array( 'wp-url', 'wp-editor' ), $config['dependencies'] ), // fix for apiFetch dependency in some environments.
+				$config['dependencies'], // fix for apiFetch dependency in some environments.
+				// array_merge( array( 'wp-url', 'wp-editor' ), $config['dependencies'] ), // fix for apiFetch dependency in some environments.
 				$config['version'],
 				true
 			);


### PR DESCRIPTION
This PR is a test in progress. It removes the dependency on `block-editor` on public frontend builds.

A build is being proposed on WPCOM D75292-code

NOT FOR MERGE (yet), see the Diff instructions