### PR TITLE
Unset border-style on crowdsignal-forms-vote class

### DIFF
--- a/client/components/vote/style.scss
+++ b/client/components/vote/style.scss
@@ -15,6 +15,7 @@
 	align-items: center;
 	display: inline-flex;
 	flex-direction: column;
+	border-style: unset;
 
 	&.crowdsignal-forms-vote__example {
 		align-items: center;


### PR DESCRIPTION
Since the appearance of the pseudo class `html :where([style*=border-width])` forcing `border-style` to `solid`, Vote blocks have been showing an unexpected border.

This PR unsets the border-style on class `crowdsignal-forms-vote` to disable the pseudo selector.

## Test instructions
Checkout and run `make client`, vist a post with a Vote block in it. It shouldn't change from our usual styling and the container block should not show a border