### PR TITLE
Fix TwentyTwentyTwo styling issues

### DIFF
--- a/client/blocks/vote-item/edit.scss
+++ b/client/blocks/vote-item/edit.scss
@@ -1,1 +1,13 @@
 /* editor styles */
+
+[data-type="crowdsignal-forms/vote-item"] {
+
+	/* Gutenberg 9 fix for vertically overridden margins in a horizontal
+	orientation block. */
+	margin-top: 28px !important;
+	margin-bottom: 0 !important;
+
+	&:not(:last-child) {
+		margin-inline-end: 8px;
+	}
+}

--- a/client/components/feedback/style.scss
+++ b/client/components/feedback/style.scss
@@ -43,6 +43,7 @@
 	line-height: 1.5 !important;
 	padding: 10px 16px !important;
 	white-space: nowrap !important;
+	border: none;
 
 	> svg {
 		fill: currentColor;
@@ -142,4 +143,5 @@
 .crowdsignal-forms-feedback__feedback-button {
 	background-color: var(--crowdsignal-forms-button-color) !important;
 	color: var(--crowdsignal-forms-button-text-color) !important;
+	border: none;
 }

--- a/client/components/poll/style.scss
+++ b/client/components/poll/style.scss
@@ -180,6 +180,11 @@
 	}
 }
 
+.crowdsignal-forms-poll__submit-button {
+	border: none;
+	line-height: normal;
+}
+
 input[type="checkbox"].crowdsignal-forms-poll__input,
 input[type="radio"].crowdsignal-forms-poll__input {
 	height: 0;

--- a/client/components/vote/style.scss
+++ b/client/components/vote/style.scss
@@ -21,14 +21,6 @@
 	}
 }
 
-[data-type="crowdsignal-forms/vote-item"] {
-
-	/* Gutenberg 9 fix for vertically overridden margins in a horizontal
-	orientation block. */
-	margin-top: 28px !important;
-	margin-bottom: 0 !important;
-}
-
 .crowdsignal-forms-vote__items {
 	display: flex;
 	flex-direction: row;


### PR DESCRIPTION
## Summary

This PR fixes a few styling issues on CS Blocks noticed when using the theme `TwentyTwentyTwo`.
Details in the card below.

Ref: c/MIBzgZEl-tr

## Test Instructions
* Checkout this branch and run `make client`
* Open a post with most of the CS Blocks
* Check if the issues reported in the referenced card were solved