### PR TITLE
Use new filter for block category registration

### DIFF
--- a/includes/class-crowdsignal-forms.php
+++ b/includes/class-crowdsignal-forms.php
@@ -240,7 +240,7 @@ final class Crowdsignal_Forms {
 		add_action( 'init', array( $this->blocks, 'register' ) );
 		add_action( 'rest_api_init', array( $this, 'register_rest_api_routes' ) );
 
-		add_filter( 'block_categories', array( $this, 'add_block_category' ), 10, 2 );
+		add_filter( 'block_categories_all', array( $this, 'add_block_category' ), 10, 2 );
 		add_filter( 'crowdsignal_forms_api_request_headers', array( $this, 'add_auth_request_headers' ) );
 
 		$this->admin_hooks->hook();


### PR DESCRIPTION
This PR addresses an issue brought up by @simison regarding Crowdsignal Forms blocks not being registered correctly (https://github.com/Automattic/wp-calypso/issues/63081)

This happened due to filters being deprecated for some screens (ref: https://core.trac.wordpress.org/ticket/52920)

## Test instructions
On a FSE enabled site, edit the site and watch for console messages regarding `crowdsignal-forms` being an invalid category (refer to mentioned issue above).
Checkout this PR and reload the FSE, the messages should be gone and the block inserter should show the correct (Crowdsignal) category for our blocks
