### PR TITLE
Remove PHP 8.1 on docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -96,4 +96,7 @@ RUN chmod +x /usr/local/bin/run
 # Set the working directory for the next commands
 WORKDIR /var/www/html
 
+# remove php 8.1 as it brings issues with WP install process
+RUN apt-get remove -y php8.1
+
 CMD ["/usr/local/bin/run"]


### PR DESCRIPTION
This PR adds a last minute run to remove php8.1 to avoid compatiblity issues between WP, PHP and php-mysql libs.

## Test instructions
Clean up all docker containers and images, run `make docker_build`. Once it finishes, run the container `make docker_up`

Open another terminal and get into the container with `make docker_sh`. Once inside the the container, check PHP version with `php -v`. It should read 7.4