### PR TITLE
Fix visibility for top bar tabs when Hello Dolly is active

### DIFF
--- a/includes/admin/admin-styles.css
+++ b/includes/admin/admin-styles.css
@@ -82,21 +82,6 @@
   color: #888;
 }
 
-.wp-admin #dolly {
-	float: none;
-	position: relative;
-	right: 0;
-	left: 0;
-	top: 0;
-	padding: .625rem;
-	text-align: right;
-	background: #fff;
-	font-size: .75rem;
-	font-style: italic;
-	color: #87a6bc;
-	border-bottom: 1px #e9eff3 solid;
-}
-
 .crowdsignal-setup__header {
 	background-color: #fff;
 	text-align: center;


### PR DESCRIPTION
The styling for Hello Dolly plugin content introduced in the Crowdsignal Forms plugin breaks the top menu navigation in WP when both Crowdsignal forms and Hello Dolly plugins are installed - it hides tabs that are part of the top bar:

![Screen Shot 2022-05-31 at 15 40 05](https://user-images.githubusercontent.com/727413/171226483-16fbc35e-5d26-4ec2-829e-da00205a633d.png)

This PR fixes https://github.com/Automattic/wp-calypso/issues/60361

## Test instructions

1. Log in to the test site's WP Admin 
2. Ensure that the Hello Dolly plugin is installed and active
3. Ensure that the Crowdsignal Forms plugin is installed and active
4. Navigate to "Plugins" page

The expected behavior is to have top bar tabs visible like shown on the screenshot:

![Screen Shot 2022-05-31 at 15 39 53](https://user-images.githubusercontent.com/727413/171226641-94cc188b-7c15-4322-af4b-d3bed4035f7c.png)
