### PR TITLE
Fix POT compilation on the local environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ client:
 	npm run build:feedback
 
 # Package for release
+release: export NODE_ENV=production
 release: clean-release install-node client pot
 	./scripts/package-for-release.sh
 
@@ -33,7 +34,6 @@ clean:
 	rm -rf build
 
 clean-release: clean
-	NODE_ENV=production
 	rm -rf release
 
 docker_build:


### PR DESCRIPTION
Makefile sets the `NODE_ENV` variable incorrectly for the `make release` step. Webpack compilation uses the "development" mode when the variable is not set. Then "eval" devtool is used and produced `.js` code doesn't match the format expected by `wp i18n make-pot`.

PR fixes it by moving `NODE_ENV `as an export to the "release" target.

### Testing steps

1. Run `make release`
2. Check `.js` files from `build/` directory and ensure that translatable phrases are wrapped as follows:
```
(d.__)("Server error. Please try again.","crowdsignal-forms")
```
3. Check if `languages/crowdsignal-forms.pot` doesn't miss any phrases from `build/` directory.