### PR TITLE
Build Tools: Add `allow-plugins` to `composer.json` for v2-compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,5 +10,11 @@
 		"wp-coding-standards/wpcs": "2.2.1",
 		"wp-cli/wp-cli-bundle": "2.4.0",
 		"psy/psysh": "^0.10.7"
+	},
+	"config": {
+		"allow-plugins": {
+			"cweagans/composer-patches": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }


### PR DESCRIPTION
See https://getcomposer.org/doc/06-config.md#allow-plugins

The change is for `composer` v2 compatibility. `composer v1` won't be impacted by this change.