### PR TITLE
Update/survey help landing page

### DIFF
--- a/client/blocks/cs-embed/attributes.js
+++ b/client/blocks/cs-embed/attributes.js
@@ -35,7 +35,8 @@ export default {
 	},
 	createLink: {
 		type: 'string',
-		default: 'https://crowdsignal.com/support/create-a-survey/',
+		default:
+			'https://crowdsignal.com/support/add-a-multipage-survey-to-any-wordpress-page-or-post/?ref=surveyembedblock',
 	},
 	createText: {
 		type: 'string',

--- a/client/blocks/cs-embed/attributes.js
+++ b/client/blocks/cs-embed/attributes.js
@@ -57,7 +57,7 @@ export default {
 				a: (
 					// eslint-disable-next-line jsx-a11y/anchor-has-content
 					<a
-						href="https://app.crowdsignal.com"
+						href="https://app.crowdsignal.com?ref=surveymbedblock"
 						target="_blank"
 						rel="external noreferrer noopener"
 					/>


### PR DESCRIPTION
Changing the link in the embed form to point to the newly created getting started doc and added the survey embed referral string where it was missing in one of the links.

Test:

Apply patch and check the links.