### PR TITLE
Bump CS Forms version v1.6.4

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -4,7 +4,7 @@ Tags: polls, forms, surveys, gutenberg, block
 Requires at least: 5.0
 Requires PHP: 5.6.20
 Tested up to: 5.8.3
-Stable tag: 1.6.3
+Stable tag: 1.6.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,12 @@ Compare our [simple and affordable plans](https://crowdsignal.com/pricing/) or t
 4. Use the poll block inside of other blocks
 
 == Changelog ==
+
+= 1.6.4 =
+* Update/survey help landing page (#231)
+* add/quiz variation to CS Embed block (#230)
+* add/crowdsignal-embed block (#222)
+* Fix POT compilation on the local environment (#226)
 
 = 1.6.3 =
 * remove php8.1 from docker, PHP and php-mysql libs (#221)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+= 1.6.4 =
+* Update/survey help landing page (#231)
+* add/quiz variation to CS Embed block (#230)
+* add/crowdsignal-embed block (#222)
+* Fix POT compilation on the local environment (#226)
+
 = 1.6.3 =
 * remove php8.1 when all is said and done to avoid compatiblity issues between WP, PHP and php-mysql libs (#221)
 * Update filter name due to deprecation (block_categories) (#220)

--- a/crowdsignal-forms.php
+++ b/crowdsignal-forms.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Crowdsignal Forms
  * Plugin URI:        https://crowdsignal.com/crowdsignal-forms/
  * Description:       Crowdsignal Form Blocks
- * Version:           1.6.3
+ * Version:           1.6.4
  * Author:            Automattic
  * Author URI:        https://automattic.com/
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die;
 }
 
-define( 'CROWDSIGNAL_FORMS_VERSION', '1.6.3' );
+define( 'CROWDSIGNAL_FORMS_VERSION', '1.6.4' );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_FILE', __FILE__ );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 

--- a/includes/admin/class-crowdsignal-forms-settings.php
+++ b/includes/admin/class-crowdsignal-forms-settings.php
@@ -66,7 +66,7 @@ class Crowdsignal_Forms_Settings {
 	 * Enqueues scripts for setup page.
 	 */
 	public function admin_enqueue_scripts() {
-		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.6.3' );
+		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.6.4' );
 		wp_enqueue_script( 'videopress', 'https://videopress.com/videopress-iframe.js', array(), '1.0', false );
 	}
 

--- a/includes/admin/class-crowdsignal-forms-setup.php
+++ b/includes/admin/class-crowdsignal-forms-setup.php
@@ -67,7 +67,7 @@ class Crowdsignal_Forms_Setup {
 	 * Enqueues scripts for setup page.
 	 */
 	public function admin_enqueue_scripts() {
-		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.6.3' );
+		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.6.4' );
 		wp_enqueue_script( 'videopress', 'https://videopress.com/videopress-iframe.js', array(), '1.0', false );
 	}
 

--- a/languages/crowdsignal-forms.pot
+++ b/languages/crowdsignal-forms.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Crowdsignal Forms 1.6.3\n"
+"Project-Id-Version: Crowdsignal Forms 1.6.4\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/crowdsignal-forms\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2022-06-07T17:59:32+00:00\n"
+"POT-Creation-Date: 2022-07-07T15:14:59+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.4.0\n"
 "X-Domain: crowdsignal-forms\n"
@@ -43,7 +43,7 @@ msgid "You don&#8217;t have permission to do this."
 msgstr ""
 
 #: includes/admin/class-crowdsignal-forms-admin.php:92
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Settings"
 msgstr ""
 
@@ -169,6 +169,7 @@ msgid "Privacy"
 msgstr ""
 
 #: includes/admin/views/html-admin-setup-header.php:15
+#: build/editor.js:18
 msgid "Crowdsignal Settings"
 msgstr ""
 
@@ -231,54 +232,54 @@ msgid "Your Email (optional)"
 msgstr ""
 
 #: includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php:154
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Please let us know how we can do better…"
 msgstr ""
 
 #: includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php:158
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "👋 Hey there!"
 msgstr ""
 
 #: includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php:170
 #: includes/frontend/blocks/class-crowdsignal-forms-nps-block.php:154
 #: includes/frontend/blocks/class-crowdsignal-forms-poll-block.php:155
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Submit"
 msgstr ""
 
 #: includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php:174
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Thanks for letting us know!"
 msgstr ""
 
 #: includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php:189
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Feedback"
 msgstr ""
 
 #: includes/frontend/blocks/class-crowdsignal-forms-nps-block.php:121
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Please help us understand your rating"
 msgstr ""
 
 #: includes/frontend/blocks/class-crowdsignal-forms-nps-block.php:128
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Thanks so much for your response! How could we do better?"
 msgstr ""
 
 #: includes/frontend/blocks/class-crowdsignal-forms-nps-block.php:139
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Extremely likely"
 msgstr ""
 
 #: includes/frontend/blocks/class-crowdsignal-forms-nps-block.php:143
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Not likely at all"
 msgstr ""
 
 #: includes/frontend/blocks/class-crowdsignal-forms-nps-block.php:147
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "How likely is it that you would recommend this project to a friend or colleague?"
 msgstr ""
 
@@ -306,801 +307,873 @@ msgid "Resource not found"
 msgstr ""
 
 #: build/applause.js:13
-#: build/editor.js:13
+#: build/editor.js:18
 #: build/poll.js:13
 #: build/vote.js:13
 msgid "Server error. Please try again."
 msgstr ""
 
 #: build/applause.js:13
-#: build/editor.js:13
+#: build/editor.js:18
 #: build/vote.js:13
 msgid "Powered by Crowdsignal"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 #: build/poll.js:13
 msgid "This Poll is Hidden"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 #: build/poll.js:13
 msgid "This Poll is Closed"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 #: build/poll.js:13
 msgid "Thanks For Voting!"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 #: build/poll.js:13
 msgid "%s vote"
 msgid_plural "%s votes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 #: build/feedback.js:6
 #: build/nps.js:6
 #: build/poll.js:13
 msgid "Create your own poll with Crowdsignal"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 #: build/feedback.js:6
 #: build/nps.js:6
 #: build/poll.js:13
 msgid "Hide"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 #: build/poll.js:13
 msgid "Unfortunately, we're having some trouble retrieving the results for this poll at this time."
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 #: build/poll.js:13
 msgid "%s total vote"
 msgid_plural "%s total votes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Enter an answer"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Buttons"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Upgrade"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Your free Crowdsignal account has "
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "reached the signals limit."
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Hide Crowdsignal branding and get "
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "unlimited signals"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Results"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Manage results on "
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Publish this post to enable results on "
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "View results"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Title of the poll block"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Confirmation message"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "On submission"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Show results"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Show \"Thank You\" message"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Show a custom text message"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Message text"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 #: build/poll.js:13
 msgid "Thanks for voting!"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Redirect address"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Status"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Open"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Closed after"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Closed"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Close poll on"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "When poll is closed"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Show poll with \"Closed\" banner"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Hide poll"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Block styling"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Text color"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Background color"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Border color"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Choose font"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Default theme font"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Width (%)"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Reset"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Border thickness"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Corner radius"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Drop shadow"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Button styling"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Alignment"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "List"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Inline"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Answer settings"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "One response per computer"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Randomize answer order"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Choose one answer"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Choose multiple answers"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Warning! This poll is published. Deleting or reordering answers may cause the loss of existing responses."
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Edit"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "You need to connect to a Crowdsignal account to collect and manage your results."
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Please verify your WordPress.com email address in order to publish your poll."
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Connect to Crowdsignal"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Verify or Change your Email Address"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Please upgrade"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "exceeded 2500 signals."
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Crowdsignal Poll"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Enter your question"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Add a note (optional)"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Poll"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Create polls and get your audience’s opinion — powered by Crowdsignal."
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "ask"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "feedback"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "form"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "opinion"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "poll"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "pop"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "question"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "quiz"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "research"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "survey"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "vote"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "How did you hear about us?"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Search"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Friend"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Email"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Small"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Medium"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Large"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Title of the vote block"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Close vote block on"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Show vote counters"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Hide vote counters"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Change block size"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Untitled Vote"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Crowdsignal Vote"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Vote"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Allow your audience to rate your work or express their opinion — powered by Crowdsignal."
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "ballot"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "button"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "count"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "deciding"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "decision"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "elect"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "election"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "like"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "nero"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "polling"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "rate"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "rating"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "thumb down"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "thumb up"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "thumbs"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "voting"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Styling"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Vote Item"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Title of the applause block"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Close applause block on"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Untitled Applause"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Crowdsignal Applause"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Applause"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Let your audience cheer with a big round of applause — powered by Crowdsignal."
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "applause"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "cheer"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "cheering"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "clap"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "kudos"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "praise"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "upvote"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "upvoting"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "votes"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Save the block to track results on "
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Title (optional)"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Button color"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Button text color"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Close on"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Current view"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Rating"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Set view threshold"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Show this block after __ visits:"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Retry"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Unfortunately, the block couldn't be saved to Crowdsignal.com."
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Crowdsignal NPS"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Preview"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "This block will appear as a popup window to people who have visited this page at least %d time."
 msgid_plural "This block will appear as a popup window to people who have visited this page at least %d times."
 msgstr[0] ""
 msgstr[1] ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Enter your rating question"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Not likely"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Very likely"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 #: build/feedback.js:6
 #: build/nps.js:6
 msgid "Collect your own feedback with Crowdsignal"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Enter your feedback question"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Measure NPS"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Calculate your Net Promoter Score! Collect feedback and track customer satisfaction over time. — powered by Crowdsignal."
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "CSAT"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "customer experience"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "customer satisfaction"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "loyalty"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "net promoter score"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "nps"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "promoter"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "review"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "score"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "How satisfied are you with the content of the site?"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Any advise on how we could improve your experience?"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Not satisfied"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Very satisfied"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Your Email"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Send me responses via email"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Responses will be sent to %s"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Feedback Button"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Hide Shadow"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Show feedback form on:"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Click"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Hover"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Page load"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Require email address"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Top"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Bottom"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Left"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Right"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Center"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Change block position"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Question"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Change button position"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "This widget will appear in a fixed position as selected, in a corner or at an edge."
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "This Feedback Form is Closed"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "Add an always visible button that allows your audience to share feedback anytime."
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "floating"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "contact"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "call to action"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "cta"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "subscribe"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "email"
 msgstr ""
 
-#: build/editor.js:13
+#: build/editor.js:18
 msgid "message"
+msgstr ""
+
+#: build/editor.js:18
+msgid "View results on <a>crowdsignal.com</a>"
+msgstr ""
+
+#: build/editor.js:18
+msgid "View Results"
+msgstr ""
+
+#: build/editor.js:18
+msgid "Edit URL"
+msgstr ""
+
+#: build/editor.js:18
+msgid "Unable to embed, please check the URL and try again."
+msgstr ""
+
+#: build/editor.js:18
+msgid "Embed"
+msgstr ""
+
+#: build/editor.js:18
+msgid "Create a new Survey"
+msgstr ""
+
+#: build/editor.js:18
+msgid "Edit your surveys on <a>crowdsignal.com</a>"
+msgstr ""
+
+#: build/editor.js:18
+msgid "Paste a link to the survey you want to display on your site"
+msgstr ""
+
+#: build/editor.js:18
+msgid "Survey Embed"
+msgstr ""
+
+#: build/editor.js:18
+msgid "Quiz"
+msgstr ""
+
+#: build/editor.js:18
+msgid "Create a multipage quiz on crowdsignal.com and embed it."
+msgstr ""
+
+#: build/editor.js:18
+msgid "Create a new Quiz"
+msgstr ""
+
+#: build/editor.js:18
+msgid "Quiz Embed"
+msgstr ""
+
+#: build/editor.js:18
+msgid "Edit your quizzes on <a>crowdsignal.com</a>"
+msgstr ""
+
+#: build/editor.js:18
+msgid "Paste a link to the quiz you want to display on your site"
+msgstr ""
+
+#: build/editor.js:18
+msgid "quizzes"
+msgstr ""
+
+#: build/editor.js:18
+msgid "Survey"
+msgstr ""
+
+#: build/editor.js:18
+msgid "Create a multipage survey on crowdsignal.com and embed it."
 msgstr ""
 
 #: build/feedback.js:6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/crowdsignal-forms",
-	"version": "1.6.3",
+	"version": "1.6.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/crowdsignal-forms",
-	"version": "1.6.3",
+	"version": "1.6.4",
 	"description": "Crowdsignal powered forms for WordPress",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
This PR bumps the plugin version to 1.6.4

## Test instructions
Verify the changelog

* Update/survey help landing page (#231)
* add/quiz variation to CS Embed block (#230)
* add/crowdsignal-embed block (#222)
* Fix POT compilation on the local environment (#226)