### PR TITLE
Update feedback button block condition for triggering the widget mode

### DIFF
--- a/client/blocks/feedback/util.js
+++ b/client/blocks/feedback/util.js
@@ -20,4 +20,4 @@ export const getStyleVars = ( attributes, fallbackStyles ) =>
 		( _, key ) => `--crowdsignal-forms-${ kebabCase( key ) }`
 	);
 
-export const isWidgetEditor = () => !! window.wp.widgets;
+export const isWidgetEditor = () => !! window.wp.customizeWidgets;


### PR DESCRIPTION
This patch updates the condition responsible for triggering the inline version of our feedback button block editor interface, which is to be used inside the widgets editor in the Customizer.  

It seems this isn't actually an issue for WordPress core - it still works as expected - but WordPress.com started loading `wp.widgets` even inside the regular post editor. `window.wp.customizeWidgets` seems to only be loaded inside the customizer making it a good candidate to use until we figure out a perhaps more reliable way of determining whether we're in the widgets editor or not.

# Testing

- Verify the feedback block is always using its fixed-position version inside the post/page- and full site editors.
- When you go to Theme -> Customizer -> Widgets, the feedback block should use the inline editor version. This is the only place where you should see it.