### PR TITLE
Update docker to build with PHP 8.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,8 +46,6 @@ RUN \
 		sudo \
 		vim \
 	&& rm -rf /var/lib/apt/lists/*
-# libapache2-mod-php8.1
-# php8.1 php8.1-common php8.1-mysql php8.1-xml php8.1-xmlrpc php8.1-curl php8.1-gd php8.1-imagick php8.1-cli php8.1-dev php8.1-imap php8.1-mbstring php8.1-opcache php8.1-soap php8.1-zip php8.1-intl
 
 # Enable mod_rewrite in Apache
 RUN a2enmod rewrite
@@ -96,8 +94,5 @@ RUN chmod +x /usr/local/bin/run
 
 # Set the working directory for the next commands
 WORKDIR /var/www/html
-
-# remove php 8.1 as it brings issues with WP install process
-# RUN apt-get remove -y php8.1
 
 CMD ["/usr/local/bin/run"]


### PR DESCRIPTION
This PR updates the Dockerfile to install PHP 8.1 and its libs

## Test instructions
Stop and remove previous docker:

- run `docker ps -a`, from the list (if any) remove the dockers using the docker name (last column), usually `cs_forms_wordpress` and `cs_forms_mysql`
```
docker rm cs_forms_wordpress
docker rm cs_forms mysql
```

- remove any underlying images, run `docker image ls -a`. This time you need to use the `IMAGE_ID`. Repeat for as many images, related to Crowdsignal Forms, you find (you can check on the first column the name of the container who originated it)
```
docker image rm [IMAGE_ID]
```

Make a fresh build:
- run `make docker_build`, verify it finishes without issues
- run `make docker_up`, verify it runs without issues
- open another terminal (docker will continue to run after `docker_up`) and run `make docker_sh`
- once inside the docker, run `php -v`, you should see PHP 8.1
- visit your docker at localhost:8000 and its admin area

Closes 419-gh-Automattic/crowdsignal