### PR TITLE
GH build action for named releases

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -11,7 +11,7 @@ on:
         required: true
         default: master
       releaseName:
-        description: Named release
+        description: Named release (no spaces/weird chars, will become the filename)
         required: true
         default: nightly_build
 
@@ -44,7 +44,7 @@ jobs:
           ref: ${{ github.event.inputs.buildBranch }}
 
       - name: Fork
-        run: git checkout -b nightly_build
+        run: git checkout -b ${{ github.event.inputs.releaseName }}
 
       - name: NPM install
         run: npm install

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -10,7 +10,6 @@ on:
         description: Branch to build
         required: true
         default: master
-    inputs:
       releaseName:
         description: Named release
         required: true

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -10,6 +10,11 @@ on:
         description: Branch to build
         required: true
         default: master
+    inputs:
+      releaseName:
+        description: Named release
+        required: true
+        default: nightly_build
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -62,7 +67,7 @@ jobs:
         uses: marvinpinto/action-automatic-releases@latest
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          automatic_release_tag: nightly_build
+          automatic_release_tag: ${{ github.event.inputs.releaseName }}
           prerelease: true
           title: Development Build
-          files: release/crowdsignal-forms.nightly_build.zip
+          files: release/crowdsignal-forms.${{ github.event.inputs.releaseName }}.zip


### PR DESCRIPTION
This PR updates the GH action to allow named releases. This is a tool for testing.

There is now a second input box when running the action that will allow some specific naming of the build. This improves our current flow where we usually could build only `nightly_build` pre-release builds. `nightly_build` is still the default but, if at some point you're going to be building some beta test to be deployed, you can name your build so it's distinguishable and it doesn't get overwritten:
<img width="345" alt="image" src="https://user-images.githubusercontent.com/157240/180875188-c2dc306c-f7c7-490e-8791-e45fbdfbedee.png">
