### PR TITLE
fix/don't add (optional) to email field placeholder in front end

### DIFF
--- a/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
@@ -143,7 +143,7 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 			),
 			'emailPlaceholder'       => array(
 				'type'    => 'string',
-				'default' => __( 'Your Email (optional)', 'crowdsignal-forms' ),
+				'default' => __( 'Your Email', 'crowdsignal-forms' ),
 			),
 			'emailRequired'          => array(
 				'type'    => 'boolean',

--- a/languages/crowdsignal-forms.pot
+++ b/languages/crowdsignal-forms.pot
@@ -228,7 +228,7 @@ msgid "Crowdsignal"
 msgstr ""
 
 #: includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php:146
-msgid "Your Email (optional)"
+msgid "Your Email"
 msgstr ""
 
 #: includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php:154


### PR DESCRIPTION
This is a fix for https://github.com/Automattic/crowdsignal-forms/issues/99

The default placeholder on the feedback form front end for email says "your email (optional)" even if the email field is required.  This only happens when the default placeholder is left in place, any changes to the place holder in the editor overrides the default (optional) text.

It looks like at some point the attributes.js for the block was corrected to remove that (which is why it doesn't show in the editor).  However, this block also pulls attributes from a .php file for the front end, which still had the optional wording.  

I've corrected the wording in the PHP file as well as the translation file (crowdsignal-forms.pot)

Testing:

build this plugin on a test site, and then create a new post/page and add the feedback block.  Preview the post and click the feedback button.  Verify that Optional doesn't show up.