### PR TITLE
Version release bump 1.6.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install: install-node install-php
 
 # Install Node dependencies
 install-node:
-	npm ci
+	npm install
 
 # Install PHP dependencies
 install-php:

--- a/README.TXT
+++ b/README.TXT
@@ -4,7 +4,7 @@ Tags: polls, forms, surveys, gutenberg, block
 Requires at least: 5.0
 Requires PHP: 5.6.20
 Tested up to: 5.8.3
-Stable tag: 1.6.4
+Stable tag: 1.6.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,18 @@ Compare our [simple and affordable plans](https://crowdsignal.com/pricing/) or t
 4. Use the poll block inside of other blocks
 
 == Changelog ==
+
+= 1.6.5 =
+* fix the (optional) text that shows up on the front end for email (#243)
+* GH build action for named releases (#242)
+* Back to PHP 7.4 for builds (#241)
+* Create store (#234)
+* Update docker to build with PHP 8.1 (#237)
+* update build action to use php 8.1 (#240)
+* Update development environment (#236)
+* Update feedback button block condition for triggering the widget mode (#235)
+* Build Tools: Add `allow-plugins` to `composer.json` for v2-compat (#227)
+* fix/add missing ref links to quiz variation (#233)
 
 = 1.6.4 =
 * Update/survey help landing page (#231)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,17 @@
+= 1.6.5 =
+* rollback to npm install
+* update package-lock
+* fix the (optional) text that shows up on the front end for email (#243)
+* GH build action for named releases (#242)
+* Back to PHP 7.4 for builds (#241)
+* Create store (#234)
+* Update docker to build with PHP 8.1 (#237)
+* update build action to use php 8.1 (#240)
+* Update development environment (#236)
+* Update feedback button block condition for triggering the widget mode (#235)
+* Build Tools: Add `allow-plugins` to `composer.json` for v2-compat (#227)
+* fix/add missing ref links to quiz variation (#233)
+
 = 1.6.4 =
 * Update/survey help landing page (#231)
 * add/quiz variation to CS Embed block (#230)

--- a/crowdsignal-forms.php
+++ b/crowdsignal-forms.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Crowdsignal Forms
  * Plugin URI:        https://crowdsignal.com/crowdsignal-forms/
  * Description:       Crowdsignal Form Blocks
- * Version:           1.6.4
+ * Version:           1.6.5
  * Author:            Automattic
  * Author URI:        https://automattic.com/
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die;
 }
 
-define( 'CROWDSIGNAL_FORMS_VERSION', '1.6.4' );
+define( 'CROWDSIGNAL_FORMS_VERSION', '1.6.5' );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_FILE', __FILE__ );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 

--- a/includes/admin/class-crowdsignal-forms-settings.php
+++ b/includes/admin/class-crowdsignal-forms-settings.php
@@ -66,7 +66,7 @@ class Crowdsignal_Forms_Settings {
 	 * Enqueues scripts for setup page.
 	 */
 	public function admin_enqueue_scripts() {
-		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.6.4' );
+		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.6.5' );
 		wp_enqueue_script( 'videopress', 'https://videopress.com/videopress-iframe.js', array(), '1.0', false );
 	}
 

--- a/includes/admin/class-crowdsignal-forms-setup.php
+++ b/includes/admin/class-crowdsignal-forms-setup.php
@@ -67,7 +67,7 @@ class Crowdsignal_Forms_Setup {
 	 * Enqueues scripts for setup page.
 	 */
 	public function admin_enqueue_scripts() {
-		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.6.4' );
+		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.6.5' );
 		wp_enqueue_script( 'videopress', 'https://videopress.com/videopress-iframe.js', array(), '1.0', false );
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17629,9 +17629,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "npm:wp-prettier@2.0.5",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
-			"integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
+			"version": "npm:wp-prettier@2.6.2",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.6.2.tgz",
+			"integrity": "sha512-AV33EzqiFJ3fj+mPlKABN59YFPReLkDxQnj067Z3uEOeRQf3g05WprL0RDuqM7UBhSRo9W1rMSC2KvZmjE5UOA==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/crowdsignal-forms",
-	"version": "1.6.4",
+	"version": "1.6.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -15799,19 +15799,19 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
 					"dev": true
 				},
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
 					"dev": true
 				},
 				"chalk": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^2.2.1",
@@ -15824,7 +15824,7 @@
 				"cross-spawn": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-					"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+					"integrity": "sha512-eZ+m1WNhSZutOa/uRblAc9Ut5MQfukFrFMtPSm3bZCA888NmMd5AWXWdgRZ80zd+pTk1P2JrGjg9pUPTvl2PWQ==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^4.0.1",
@@ -15844,7 +15844,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
@@ -15853,13 +15853,13 @@
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
 					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+					"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
 					"dev": true
 				}
 			}
@@ -17626,12 +17626,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
 			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-			"dev": true
-		},
-		"prettier": {
-			"version": "npm:wp-prettier@2.6.2",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.6.2.tgz",
-			"integrity": "sha512-AV33EzqiFJ3fj+mPlKABN59YFPReLkDxQnj067Z3uEOeRQf3g05WprL0RDuqM7UBhSRo9W1rMSC2KvZmjE5UOA==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/crowdsignal-forms",
-	"version": "1.6.4",
+	"version": "1.6.5",
 	"description": "Crowdsignal powered forms for WordPress",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
This PR is a release PR for version 1.6.5

## Test instructions

Verify changelog entries are there as well as new features/functionalities/fixes

* fix the (optional) text that shows up on the front end for email (#243)
* GH build action for named releases (#242)
* Back to PHP 7.4 for builds (#241)
* Create store (#234)
* Update docker to build with PHP 8.1 (#237)
* update build action to use php 8.1 (#240)
* Update development environment (#236)
* Update feedback button block condition for triggering the widget mode (#235)
* Build Tools: Add `allow-plugins` to `composer.json` for v2-compat (#227)
* fix/add missing ref links to quiz variation (#233)
