### PR TITLE
Bump version for 1.6.5 release

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -4,7 +4,7 @@ Tags: polls, forms, surveys, gutenberg, block
 Requires at least: 5.0
 Requires PHP: 5.6.20
 Tested up to: 5.8.3
-Stable tag: 1.6.4
+Stable tag: 1.6.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,19 @@ Compare our [simple and affordable plans](https://crowdsignal.com/pricing/) or t
 4. Use the poll block inside of other blocks
 
 == Changelog ==
+
+= 1.6.5 =
+* Fix makefile and dependencies (#245)
+* Fix the (optional) text that shows up on the front end for email (#243)
+* GH build action for named releases (#242)
+* Back to PHP 7.4 for builds (#241)
+* Create store (#234)
+* Update docker to build with PHP 8.1 (#237)
+* update build action to use php 8.1 (#240)
+* Update development environment (#236)
+* Update feedback button block condition for triggering the widget mode (#235)
+* Build Tools: Add `allow-plugins` to `composer.json` for v2-compat (#227)
+* fix/add missing ref links to quiz variation (#233)
 
 = 1.6.4 =
 * Update/survey help landing page (#231)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,16 @@
+= 1.6.5 =
+* Fix makefile and dependencies (#245)
+* fix the (optional) text that shows up on the front end for email (#243)
+* GH build action for named releases (#242)
+* Back to PHP 7.4 for builds (#241)
+* Create store (#234)
+* Update docker to build with PHP 8.1 (#237)
+* update build action to use php 8.1 (#240)
+* Update development environment (#236)
+* Update feedback button block condition for triggering the widget mode (#235)
+* Build Tools: Add `allow-plugins` to `composer.json` for v2-compat (#227)
+* fix/add missing ref links to quiz variation (#233)
+
 = 1.6.4 =
 * Update/survey help landing page (#231)
 * add/quiz variation to CS Embed block (#230)

--- a/crowdsignal-forms.php
+++ b/crowdsignal-forms.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Crowdsignal Forms
  * Plugin URI:        https://crowdsignal.com/crowdsignal-forms/
  * Description:       Crowdsignal Form Blocks
- * Version:           1.6.4
+ * Version:           1.6.5
  * Author:            Automattic
  * Author URI:        https://automattic.com/
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die;
 }
 
-define( 'CROWDSIGNAL_FORMS_VERSION', '1.6.4' );
+define( 'CROWDSIGNAL_FORMS_VERSION', '1.6.5' );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_FILE', __FILE__ );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 

--- a/includes/admin/class-crowdsignal-forms-settings.php
+++ b/includes/admin/class-crowdsignal-forms-settings.php
@@ -66,7 +66,7 @@ class Crowdsignal_Forms_Settings {
 	 * Enqueues scripts for setup page.
 	 */
 	public function admin_enqueue_scripts() {
-		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.6.4' );
+		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.6.5' );
 		wp_enqueue_script( 'videopress', 'https://videopress.com/videopress-iframe.js', array(), '1.0', false );
 	}
 

--- a/includes/admin/class-crowdsignal-forms-setup.php
+++ b/includes/admin/class-crowdsignal-forms-setup.php
@@ -67,7 +67,7 @@ class Crowdsignal_Forms_Setup {
 	 * Enqueues scripts for setup page.
 	 */
 	public function admin_enqueue_scripts() {
-		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.6.4' );
+		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.6.5' );
 		wp_enqueue_script( 'videopress', 'https://videopress.com/videopress-iframe.js', array(), '1.0', false );
 	}
 

--- a/languages/crowdsignal-forms.pot
+++ b/languages/crowdsignal-forms.pot
@@ -2,16 +2,16 @@
 # This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Crowdsignal Forms 1.6.4\n"
+"Project-Id-Version: Crowdsignal Forms 1.6.5\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/crowdsignal-forms\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2022-07-07T15:14:59+00:00\n"
+"POT-Creation-Date: 2022-08-19T14:13:29+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.4.0\n"
+"X-Generator: WP-CLI 2.6.0\n"
 "X-Domain: crowdsignal-forms\n"
 
 #. Plugin Name of the plugin
@@ -228,6 +228,7 @@ msgid "Crowdsignal"
 msgstr ""
 
 #: includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php:146
+#: build/editor.js:18
 msgid "Your Email"
 msgstr ""
 
@@ -990,10 +991,6 @@ msgstr ""
 
 #: build/editor.js:18
 msgid "Very satisfied"
-msgstr ""
-
-#: build/editor.js:18
-msgid "Your Email"
 msgstr ""
 
 #: build/editor.js:18

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/crowdsignal-forms",
-	"version": "1.6.4",
+	"version": "1.6.5",
 	"description": "Crowdsignal powered forms for WordPress",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
This PR is the version bump on all places for 1.6.5

## Test instructions

Verify the changelog entries, see that it works

* Fix makefile and dependencies (#245)
* fix the (optional) text that shows up on the front end for email (#243)
* GH build action for named releases (#242)
* Back to PHP 7.4 for builds (#241)
* Create store (#234)
* Update docker to build with PHP 8.1 (#237)
* update build action to use php 8.1 (#240)
* Update development environment (#236)
* Update feedback button block condition for triggering the widget mode (#235)
* Build Tools: Add `allow-plugins` to `composer.json` for v2-compat (#227)
* fix/add missing ref links to quiz variation (#233)
