### PR TITLE
Add the site_url() to the wp-json URL so directory installs work.

### DIFF
--- a/client/apifetch/middleware.js
+++ b/client/apifetch/middleware.js
@@ -7,7 +7,7 @@
  */
 export const formatURL = ( options, next ) => {
 	if ( options.path.indexOf( '/crowdsignal-forms/v1' ) === 0 ) {
-		options.path = `/wp-json${ options.path }`;
+		options.path = _crowdsignalFormsURL + `/wp-json${ options.path }`;
 	}
 
 	return next( options );

--- a/includes/frontend/class-crowdsignal-forms-blocks-assets.php
+++ b/includes/frontend/class-crowdsignal-forms-blocks-assets.php
@@ -105,6 +105,14 @@ class Crowdsignal_Forms_Blocks_Assets {
 				'before'
 			);
 		}
+
+		if ( self::APIFETCH === $id ) {
+			wp_add_inline_script(
+				self::APIFETCH,
+				sprintf( "_crowdsignalFormsURL='%s';", site_url() ),
+				'before'
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
If a site is installed in a sub directory so that it doesn't live at "/" on the host, then feedback (and probably NPS) will fail because it sends wp-json requests to /wp-json/, not /sub-directory/wp-json/.

This patch fixes that by prefixing the wp-json path with the site_url().

To test:
1. Apply patch.
2. Run `npm run build:apifetch`.
3. That will update build/apifetch.js
4. Configure a WordPress install that is served off a directory, not "/", ie. https://example.com/test/ rather than https://example.com/
5. Install the Crowdsignal Forms plugin and connect it to Crowdsignal
6. copy build/apifetch.js and includes/frontend/class-crowdsignal-forms-blocks-assets.php into the wp-content/plugins/crowdsignal-forms/ directory, overwriting what was there.
7. Add a feedback button to a post and send feedback. Make sure it loaded from the right directory.

Also try posting feedback before updating those files and you should see a 404 error in the web network.