### PR TITLE
Remove RawHTML use from the blocks

### DIFF
--- a/client/components/feedback/form.js
+++ b/client/components/feedback/form.js
@@ -59,7 +59,7 @@ const FeedbackForm = ( { attributes, onSubmit } ) => {
 				className="crowdsignal-forms-feedback__header"
 				style={ { whiteSpace: 'pre-wrap' } }
 			>
-				{ decodeEntities( header ).split( '<br>' ).join( '\n' ) }
+				{ decodeEntities( attributes.header ).split( '<br>' ).join( '\n' ) }
 			</h3>
 
 			<TextareaControl

--- a/client/components/feedback/form.js
+++ b/client/components/feedback/form.js
@@ -55,8 +55,11 @@ const FeedbackForm = ( { attributes, onSubmit } ) => {
 
 	return (
 		<form onSubmit={ handleSubmit }>
-			<h3 className="crowdsignal-forms-feedback__header">
-				{ decodeEntities( attributes.header ) }
+			<h3
+				className="crowdsignal-forms-feedback__header"
+				style={ { whiteSpace: 'pre-wrap' } }
+			>
+				{ decodeEntities( header ).split( '<br>' ).join( '\n' ) }
 			</h3>
 
 			<TextareaControl

--- a/client/components/feedback/form.js
+++ b/client/components/feedback/form.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { RawHTML } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 import { TextControl, TextareaControl } from '@wordpress/components';
 
 /**
@@ -56,7 +56,7 @@ const FeedbackForm = ( { attributes, onSubmit } ) => {
 	return (
 		<form onSubmit={ handleSubmit }>
 			<h3 className="crowdsignal-forms-feedback__header">
-				<RawHTML>{ attributes.header }</RawHTML>
+				{ decodeEntities( attributes.header ) }
 			</h3>
 
 			<TextareaControl

--- a/client/components/feedback/submit.js
+++ b/client/components/feedback/submit.js
@@ -6,11 +6,11 @@ import React from 'react';
 /**
  * Wordpress dependencies
  */
-import { RawHTML } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 
 const FeedbackSubmit = ( { attributes } ) => (
 	<h3 className="crowdsignal-forms-feedback__header">
-		<RawHTML>{ attributes.submitText }</RawHTML>
+		{ decodeEntities( attributes.submitText ) }
 	</h3>
 );
 

--- a/client/components/feedback/submit.js
+++ b/client/components/feedback/submit.js
@@ -9,8 +9,8 @@ import React from 'react';
 import { decodeEntities } from '@wordpress/html-entities';
 
 const FeedbackSubmit = ( { attributes } ) => (
-	<h3 className="crowdsignal-forms-feedback__header">
-		{ decodeEntities( attributes.submitText ) }
+	<h3 className="crowdsignal-forms-feedback__header" style={ { whiteSpace: 'pre-wrap' } }>
+        { decodeEntities( attributes.submitText ).split( '<br>' ).join( '\n' ) }
 	</h3>
 );
 

--- a/client/components/feedback/toggle.js
+++ b/client/components/feedback/toggle.js
@@ -12,8 +12,8 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
-import { RawHTML } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -62,7 +62,7 @@ const FeedbackToggle = (
 					onMouseEnter={ handleHover }
 				>
 					<div className="crowdsignal-forms-feedback__trigger-text">
-						<RawHTML>{ attributes.triggerLabel }</RawHTML>
+						{ decodeEntities( attributes.triggerLabel ) }
 					</div>
 				</button>
 			) }

--- a/client/components/nps/index.js
+++ b/client/components/nps/index.js
@@ -55,8 +55,8 @@ const Nps = ( {
 	return (
 		<>
 			<div className="crowdsignal-forms-nps" style={ style }>
-				<h3 className="crowdsignal-forms-nps__question">
-					{ decodeEntities( questionText ) }
+				<h3 className="crowdsignal-forms-nps__question" style={ { whiteSpace: 'pre-wrap' } }>
+					{ decodeEntities( questionText ).split( '<br>' ).join( '\n' ) }
 				</h3>
 
 				<button

--- a/client/components/nps/index.js
+++ b/client/components/nps/index.js
@@ -8,8 +8,8 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { Icon } from '@wordpress/components';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
-import { RawHTML } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -56,7 +56,7 @@ const Nps = ( {
 		<>
 			<div className="crowdsignal-forms-nps" style={ style }>
 				<h3 className="crowdsignal-forms-nps__question">
-					<RawHTML>{ questionText }</RawHTML>
+					{ decodeEntities( questionText ) }
 				</h3>
 
 				<button


### PR DESCRIPTION
Followup on #252.

This patch removes remaining instances of `<RawHTML>` from the plugin blocks and replaces it with `decodeEntities()`.

#Testing

This patch affects the feedback and NPS blocks. They should still work as expected and you shouldn't be able to embed XSS payloads inside either of their fields.