### PR TITLE
Bump tested version to 6.2

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -3,7 +3,7 @@ Contributors: automattic
 Tags: polls, forms, surveys, gutenberg, block
 Requires at least: 5.0
 Requires PHP: 5.6.20
-Tested up to: 6.1.1
+Tested up to: 6.2
 Stable tag: 1.6.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
A small update to change the tested version of WordPress to 6.2.