### PR TITLE
add nvmrc file with note about install on lower version

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,2 @@
-v12.13.1
+14.15.0
+// maybe install with 12.13.1 but run with 14.15.0


### PR DESCRIPTION
Add .nvmrc file with a note: install works fine with the old v12 version, but then npm run will error. Npm run works fine with defined (v14) version on the file, but likely to throw errors when installing.