### PR TITLE
fix block spacing for better theme compatibility

### DIFF
--- a/client/blocks/poll/edit.scss
+++ b/client/blocks/poll/edit.scss
@@ -33,6 +33,7 @@
 
 		&.wp-block-button__link {
 			cursor: text;
+			display: block;
 
 			&:hover {
 				opacity: inherit;
@@ -44,6 +45,11 @@
 .crowdsignal-forms-poll__resize-wrapper {
 	margin-left: auto;
 	margin-right: auto;
+	margin-bottom: 3em;
+
+	&:not(:first-child) {
+		margin-top: 3em;
+	}
 }
 
 

--- a/client/components/poll/style.scss
+++ b/client/components/poll/style.scss
@@ -285,7 +285,6 @@ input[type="radio"].crowdsignal-forms-poll__input {
 
 	.wp-block-button.crowdsignal-forms-poll__block-button {
 		margin: 0;
-		line-height: 0;
 	}
 }
 


### PR DESCRIPTION
This PR changes some margin/paddings and display styles so buttons and blocks are more theme change tolerant.

Tested on themes 2020, 2021, 2022, 2023, Astra and Seedlet

## Test instructions

Publish a post with one of each Poll (default/button and MC variations), Applause, Vote, Feedback and NPS bocks.

Compare editor and published UI/layout to see they match as much as possible. An issue with border-radius remain as old themes used to provide those in a different manner.