### PR TITLE
Fix line jumps on polls

### DIFF
--- a/client/components/applause/index.js
+++ b/client/components/applause/index.js
@@ -24,9 +24,8 @@ const Applause = ( props ) => {
 	const [ queuedVotes, setQueuedVotes ] = useState( 0 );
 	const [ timeoutHandle, setTimeoutHandle ] = useState( null );
 	const [ animationActiveState, setAnimationActiveState ] = useState( false );
-	const [ animationTimeoutHandle, setAnimationTimeoutHandle ] = useState(
-		null
-	);
+	const [ animationTimeoutHandle, setAnimationTimeoutHandle ] =
+		useState( null );
 	const { results } = usePollResults( apiPollId );
 
 	const isClosed = isPollClosed(

--- a/client/components/poll/index.js
+++ b/client/components/poll/index.js
@@ -156,13 +156,23 @@ const Poll = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 			{ errorMessage && <ErrorBanner>{ errorMessage }</ErrorBanner> }
 
 			<div className={ contentClasses }>
-				<h3 className="crowdsignal-forms-poll__question">
-					{ decodeEntities( attributes.question ) }
+				<h3
+					className="crowdsignal-forms-poll__question"
+					style={ { whiteSpace: 'pre-wrap' } }
+				>
+					{ decodeEntities( attributes.question )
+						.split( '<br>' )
+						.join( '\n' ) }
 				</h3>
 
 				{ attributes.note && (
-					<div className="crowdsignal-forms-poll__note">
-						{ decodeEntities( attributes.note ) }
+					<div
+						className="crowdsignal-forms-poll__note"
+						style={ { whiteSpace: 'pre-wrap' } }
+					>
+						{ decodeEntities( attributes.note )
+							.split( '<br>' )
+							.join( '\n' ) }
 					</div>
 				) }
 


### PR DESCRIPTION
This PR applies the split/join strategy to fix line jump rendering on poll question and note after our RawHTML deprecation.

## Test instructions

Publish a poll. Add line jumps on question and note. Published post should reflect the line jumps instead of rendering `<br>`