### PR TITLE
Block Sidebar: group settings together

### DIFF
--- a/client/blocks/feedback/sidebar.js
+++ b/client/blocks/feedback/sidebar.js
@@ -105,57 +105,6 @@ const Sidebar = ( {
 					<SidebarPromote signalWarning={ signalWarning } />
 				) }
 			</PanelBody>
-
-			<PanelColorSettings
-				title={ __( 'Feedback Button', 'crowdsignal-forms' ) }
-				initialOpen={ false }
-				colorSettings={ [
-					{
-						label: __( 'Background color', 'crowdsignal-forms' ),
-						onChange: handleChangeAttribute(
-							'triggerBackgroundColor'
-						),
-						value: attributes.triggerBackgroundColor,
-					},
-					{
-						label: __( 'Text color', 'crowdsignal-forms' ),
-						onChange: handleChangeAttribute( 'triggerTextColor' ),
-						value: attributes.triggerTextColor,
-					},
-				] }
-			>
-				<ToggleControl
-					label={ __( 'Hide Shadow', 'crowdsignal-forms' ) }
-					checked={ attributes.hideTriggerShadow }
-					onChange={ handleChangeAttribute( 'hideTriggerShadow' ) }
-				/>
-			</PanelColorSettings>
-			<PanelColorSettings
-				title={ __( 'Block styling', 'crowdsignal-forms' ) }
-				initialOpen={ false }
-				colorSettings={ [
-					{
-						label: __( 'Background color', 'crowdsignal-forms' ),
-						onChange: handleChangeAttribute( 'backgroundColor' ),
-						value: attributes.backgroundColor,
-					},
-					{
-						label: __( 'Text color', 'crowdsignal-forms' ),
-						onChange: handleChangeAttribute( 'textColor' ),
-						value: attributes.textColor,
-					},
-					{
-						label: __( 'Button color', 'crowdsignal-forms' ),
-						onChange: handleChangeAttribute( 'buttonColor' ),
-						value: attributes.buttonColor,
-					},
-					{
-						label: __( 'Button text color', 'crowdsignal-forms' ),
-						onChange: handleChangeAttribute( 'buttonTextColor' ),
-						value: attributes.buttonTextColor,
-					},
-				] }
-			/>
 			<PanelBody
 				title={ __( 'Settings', 'crowdsignal-forms' ) }
 				initialOpen={ false }
@@ -230,6 +179,56 @@ const Sidebar = ( {
 					onChange={ handleChangeAttribute( 'emailRequired' ) }
 				/>
 			</PanelBody>
+			<PanelColorSettings
+				title={ __( 'Feedback Button', 'crowdsignal-forms' ) }
+				initialOpen={ false }
+				colorSettings={ [
+					{
+						label: __( 'Background color', 'crowdsignal-forms' ),
+						onChange: handleChangeAttribute(
+							'triggerBackgroundColor'
+						),
+						value: attributes.triggerBackgroundColor,
+					},
+					{
+						label: __( 'Text color', 'crowdsignal-forms' ),
+						onChange: handleChangeAttribute( 'triggerTextColor' ),
+						value: attributes.triggerTextColor,
+					},
+				] }
+			>
+				<ToggleControl
+					label={ __( 'Hide Shadow', 'crowdsignal-forms' ) }
+					checked={ attributes.hideTriggerShadow }
+					onChange={ handleChangeAttribute( 'hideTriggerShadow' ) }
+				/>
+			</PanelColorSettings>
+			<PanelColorSettings
+				title={ __( 'Block styling', 'crowdsignal-forms' ) }
+				initialOpen={ false }
+				colorSettings={ [
+					{
+						label: __( 'Background color', 'crowdsignal-forms' ),
+						onChange: handleChangeAttribute( 'backgroundColor' ),
+						value: attributes.backgroundColor,
+					},
+					{
+						label: __( 'Text color', 'crowdsignal-forms' ),
+						onChange: handleChangeAttribute( 'textColor' ),
+						value: attributes.textColor,
+					},
+					{
+						label: __( 'Button color', 'crowdsignal-forms' ),
+						onChange: handleChangeAttribute( 'buttonColor' ),
+						value: attributes.buttonColor,
+					},
+					{
+						label: __( 'Button text color', 'crowdsignal-forms' ),
+						onChange: handleChangeAttribute( 'buttonTextColor' ),
+						value: attributes.buttonTextColor,
+					},
+				] }
+			/>
 		</InspectorControls>
 	);
 };

--- a/client/blocks/nps/sidebar.js
+++ b/client/blocks/nps/sidebar.js
@@ -83,32 +83,6 @@ const Sidebar = ( {
 					<SidebarPromote signalWarning={ signalWarning } />
 				) }
 			</PanelBody>
-			<PanelColorSettings
-				title={ __( 'Block styling', 'crowdsignal-forms' ) }
-				initialOpen={ false }
-				colorSettings={ [
-					{
-						label: __( 'Background color', 'crowdsignal-forms' ),
-						onChange: handleChangeAttribute( 'backgroundColor' ),
-						value: attributes.backgroundColor,
-					},
-					{
-						label: __( 'Text color', 'crowdsignal-forms' ),
-						onChange: handleChangeAttribute( 'textColor' ),
-						value: attributes.textColor,
-					},
-					{
-						label: __( 'Button color', 'crowdsignal-forms' ),
-						onChange: handleChangeAttribute( 'buttonColor' ),
-						value: attributes.buttonColor,
-					},
-					{
-						label: __( 'Button text color', 'crowdsignal-forms' ),
-						onChange: handleChangeAttribute( 'buttonTextColor' ),
-						value: attributes.buttonTextColor,
-					},
-				] }
-			/>
 			<PanelBody
 				title={ __( 'Settings', 'crowdsignal-forms' ) }
 				initialOpen={ false }
@@ -154,6 +128,32 @@ const Sidebar = ( {
 					/>
 				) }
 			</PanelBody>
+			<PanelColorSettings
+				title={ __( 'Block styling', 'crowdsignal-forms' ) }
+				initialOpen={ false }
+				colorSettings={ [
+					{
+						label: __( 'Background color', 'crowdsignal-forms' ),
+						onChange: handleChangeAttribute( 'backgroundColor' ),
+						value: attributes.backgroundColor,
+					},
+					{
+						label: __( 'Text color', 'crowdsignal-forms' ),
+						onChange: handleChangeAttribute( 'textColor' ),
+						value: attributes.textColor,
+					},
+					{
+						label: __( 'Button color', 'crowdsignal-forms' ),
+						onChange: handleChangeAttribute( 'buttonColor' ),
+						value: attributes.buttonColor,
+					},
+					{
+						label: __( 'Button text color', 'crowdsignal-forms' ),
+						onChange: handleChangeAttribute( 'buttonTextColor' ),
+						value: attributes.buttonTextColor,
+					},
+				] }
+			/>
 		</InspectorControls>
 	);
 };

--- a/client/blocks/poll/sidebar.js
+++ b/client/blocks/poll/sidebar.js
@@ -321,6 +321,27 @@ const SideBar = ( {
 					/>
 				) }
 			</PanelBody>
+			<PanelBody
+				title={ __( 'Answer settings', 'crowdsignal-forms' ) }
+				initialOpen={ true }
+			>
+				<CheckboxControl
+					checked={ attributes.hasOneResponsePerComputer }
+					label={ __(
+						'One response per computer',
+						'crowdsignal-forms'
+					) }
+					onChange={ handleChangeHasOneResponsePerComputer }
+				/>
+				<CheckboxControl
+					checked={ attributes.randomizeAnswers }
+					label={ __(
+						'Randomize answer order',
+						'crowdsignal-forms'
+					) }
+					onChange={ handleChangeRandomizeAnswers }
+				/>
+			</PanelBody>
 			<PanelColorSettings
 				title={ __( 'Block styling', 'crowdsignal-forms' ) }
 				initialOpen={ false }
@@ -547,27 +568,6 @@ const SideBar = ( {
 					/>
 				) }
 			</PanelColorSettings>
-			<PanelBody
-				title={ __( 'Answer settings', 'crowdsignal-forms' ) }
-				initialOpen={ true }
-			>
-				<CheckboxControl
-					checked={ attributes.hasOneResponsePerComputer }
-					label={ __(
-						'One response per computer',
-						'crowdsignal-forms'
-					) }
-					onChange={ handleChangeHasOneResponsePerComputer }
-				/>
-				<CheckboxControl
-					checked={ attributes.randomizeAnswers }
-					label={ __(
-						'Randomize answer order',
-						'crowdsignal-forms'
-					) }
-					onChange={ handleChangeRandomizeAnswers }
-				/>
-			</PanelBody>
 		</InspectorControls>
 	);
 };


### PR DESCRIPTION
When using the Poll block, I didn't realize there were more settings regarding the poll itself after the styling panel. Suggesting moving the Answer Settings panel above the styling to sit alongside the other settings panels.

The Feedback and NPS blocks are similar; updated PR to include those.