### PR TITLE
Load blockObserver on DOM ready instead of window load

### DIFF
--- a/client/lib/mutation-observer/index.js
+++ b/client/lib/mutation-observer/index.js
@@ -9,7 +9,7 @@ const MutationObserver = ( dataAttributeName, blockBuilder ) => {
 		return blockObserver( dataAttributeName, blockBuilder );
 	}
 
-	window.addEventListener( 'load', () =>
+	document.addEventListener( 'DOMContentLoaded', () =>
 		blockObserver( dataAttributeName, blockBuilder )
 	);
 };

--- a/client/lib/mutation-observer/index.js
+++ b/client/lib/mutation-observer/index.js
@@ -5,7 +5,7 @@ import { render } from 'react-dom';
 import { camelCase, isEmpty, forEach } from 'lodash';
 
 const MutationObserver = ( dataAttributeName, blockBuilder ) => {
-	if ( 'complete' === document.readyState ) {
+	if ( 'complete' === document.readyState || 'interactive' === document.readyState ) {
 		return blockObserver( dataAttributeName, blockBuilder );
 	}
 


### PR DESCRIPTION
Resolves #250 

On sites with 3rd party elements and dependency scripts (like Ads) the components take a while to load because of the window load event trigger.
This switches the `blockObserver` to load on DOM load/ready for a more optimized delivery and load of the components to the user.