### PR TITLE
Wrap closed banner messaging in span tags

### DIFF
--- a/client/components/poll/closed-banner.js
+++ b/client/components/poll/closed-banner.js
@@ -20,11 +20,16 @@ const ClosedBanner = ( {
 
 	return (
 		<div className={ classes }>
-			{ isPollHidden && __( 'This Poll is Hidden', 'crowdsignal-forms' ) }
+			{ isPollHidden && (
+				<span>{ __( 'This Poll is Hidden', 'crowdsignal-forms' ) }</span>
+			) }
 			{ isPollClosed &&
-				! isPollHidden &&
-				__( 'This Poll is Closed', 'crowdsignal-forms' ) }
-			{ hasVoted && __( 'Thanks For Voting!', 'crowdsignal-forms' ) }
+				!isPollHidden && (
+				<span>{ __( 'This Poll is Closed', 'crowdsignal-forms' ) }</span>
+			) }
+			{ hasVoted && (
+				<span>{ __( 'Thanks For Voting!', 'crowdsignal-forms' ) }</span>
+			) }
 		</div>
 	);
 };

--- a/client/components/poll/closed-banner.js
+++ b/client/components/poll/closed-banner.js
@@ -18,18 +18,18 @@ const ClosedBanner = ( {
 		'crowdsignal-forms-poll__closed-banner'
 	);
 
+	let message = '';
+	if ( isPollHidden ) {
+		message = __( 'This Poll is Hidden', 'crowdsignal-forms' );
+	} else if ( !isPollHidden && isPollClosed ) {
+		message = __( 'This Poll is Closed', 'crowdsignal-forms' );
+	} else if ( !isPollHidden && hasVoted ) {
+		message = __( 'Thanks For Voting!', 'crowdsignal-forms' );
+	}
+
 	return (
 		<div className={ classes }>
-			{ isPollHidden && (
-				<span>{ __( 'This Poll is Hidden', 'crowdsignal-forms' ) }</span>
-			) }
-			{ isPollClosed &&
-				!isPollHidden && (
-				<span>{ __( 'This Poll is Closed', 'crowdsignal-forms' ) }</span>
-			) }
-			{ hasVoted && (
-				<span>{ __( 'Thanks For Voting!', 'crowdsignal-forms' ) }</span>
-			) }
+			{ message }
 		</div>
 	);
 };

--- a/client/components/poll/closed-banner.js
+++ b/client/components/poll/closed-banner.js
@@ -21,9 +21,9 @@ const ClosedBanner = ( {
 	let message = '';
 	if ( isPollHidden ) {
 		message = __( 'This Poll is Hidden', 'crowdsignal-forms' );
-	} else if ( !isPollHidden && isPollClosed ) {
+	} else if ( isPollClosed ) {
 		message = __( 'This Poll is Closed', 'crowdsignal-forms' );
-	} else if ( !isPollHidden && hasVoted ) {
+	} else if ( hasVoted ) {
 		message = __( 'Thanks For Voting!', 'crowdsignal-forms' );
 	}
 

--- a/client/components/poll/style.scss
+++ b/client/components/poll/style.scss
@@ -289,10 +289,12 @@ input[type="radio"].crowdsignal-forms-poll__input {
 }
 
 .crowdsignal-forms-poll__closed-banner {
+	align-items: center;
 	background-color: var(--crowdsignal-forms-border-color);
 	box-sizing: border-box;
 	display: flex;
 	color: var(--crowdsignal-forms-submit-button-text-color);
+	flex-direction: column;
 	font-family: $font-sans-serif;
 	justify-content: center;
 	padding: calc(var(--crowdsignal-forms-border-width) + 0.2em) 0 0.2em;

--- a/client/components/poll/style.scss
+++ b/client/components/poll/style.scss
@@ -289,12 +289,10 @@ input[type="radio"].crowdsignal-forms-poll__input {
 }
 
 .crowdsignal-forms-poll__closed-banner {
-	align-items: center;
 	background-color: var(--crowdsignal-forms-border-color);
 	box-sizing: border-box;
 	display: flex;
 	color: var(--crowdsignal-forms-submit-button-text-color);
-	flex-direction: column;
 	font-family: $font-sans-serif;
 	justify-content: center;
 	padding: calc(var(--crowdsignal-forms-border-width) + 0.2em) 0 0.2em;


### PR DESCRIPTION
The Closed Banner messaging on polls does not include line breaks.  This PR would wrap the various messages in `<span>` tags and add additional styles so that each message would be on it's own line. 


See also this issue: https://github.com/Automattic/crowdsignal-forms/issues/185


![70e3d8f5ade76eb96a4ec191a7d41b0d](https://github.com/Automattic/crowdsignal-forms/assets/15174237/2afb3942-388c-4376-b0e9-a110ef8f70ab)
