### PR TITLE
crowdsignal applause block: Only try to fetch poll data if a pollId exists (php 8.1 warning)

### DIFF
--- a/includes/frontend/blocks/class-crowdsignal-forms-applause-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-applause-block.php
@@ -72,7 +72,10 @@ class Crowdsignal_Forms_Applause_Block extends Crowdsignal_Forms_Block {
 		wp_enqueue_style( $this->asset_identifier() );
 
 		$attributes['hideBranding'] = $this->should_hide_branding();
-		$platform_poll_data         = $this->get_platform_poll_data( $attributes['pollId'] );
+		$platform_poll_data = null;
+		if ( ! empty( $attributes['pollId'] ) ) {
+			$platform_poll_data = $this->get_platform_poll_data( $attributes['pollId'] );
+		}
 		if ( ! empty( $platform_poll_data ) ) {
 			$attributes['apiPollData'] = $platform_poll_data;
 		}


### PR DESCRIPTION
Fixes warnings like:
```
Warning: Undefined array key "pollId" in ...crowdsignal-forms/next/includes/frontend/blocks/class-crowdsignal-forms-applause-block.php on line 76
```
`$attributes['pollId']` could be blank, so only run `get_platform_poll_data()` on it if it exists.

See testing directions on D135692-code. I started there but then realized that file probably belongs to an external repository.