### PR TITLE
Prevent blocks from being used in the Site Editor

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -1,7 +1,7 @@
 === Crowdsignal Forms ===
 Contributors: automattic
 Tags: polls, forms, surveys, gutenberg, block
-Requires at least: 5.0
+Requires at least: 6.0
 Requires PHP: 5.6.20
 Tested up to: 6.4.3
 Stable tag: 1.7.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Contributors: [Automattic](https://automattic.com)
 
 Tags: polls, forms, surveys, gutenberg, block
 
-Requires at least: 5.0
+Requires at least: 6.0
 
 Requires PHP: 5.6.20
 

--- a/client/blocks/applause/edit.js
+++ b/client/blocks/applause/edit.js
@@ -24,7 +24,20 @@ import SideBar from './sidebar';
 import { STORE_NAME } from 'state';
 
 const EditApplauseBlock = ( props ) => {
-	const { attributes, setAttributes, pollDataFromApi } = props;
+	const { attributes, setAttributes, pollDataFromApi, context } = props;
+
+	const {
+		postId,
+		queryId,
+	} = context;
+
+	// Prevent block from loading in FSE or a query loop because save handlers don't support those contexts.
+	// - double == instead of triple === used because we need to test for both null and undefined
+	if ( null == postId ) {
+		return <ErrorBanner>{ __( 'Applause blocks cannot be used outside of a post or page. The Site Editor is not supported.', 'crowdsignal-forms' ) }</ErrorBanner>;
+	} else if ( null != queryId ) {
+		return <ErrorBanner>{ __( 'Applause blocks are not supported inside a query loop.', 'crowdsignal-forms' ) }</ErrorBanner>;
+	}
 
 	const viewResultsUrl = pollDataFromApi
 		? pollDataFromApi.viewResultsUrl

--- a/client/blocks/applause/edit.js
+++ b/client/blocks/applause/edit.js
@@ -25,7 +25,7 @@ import { STORE_NAME } from 'state';
 import withFseCheck from 'components/with-fse-check';
 
 const EditApplauseBlock = ( props ) => {
-	const { attributes, setAttributes, pollDataFromApi, context } = props;
+	const { attributes, setAttributes, pollDataFromApi } = props;
 
 	const viewResultsUrl = pollDataFromApi
 		? pollDataFromApi.viewResultsUrl

--- a/client/blocks/applause/edit.js
+++ b/client/blocks/applause/edit.js
@@ -22,22 +22,10 @@ import withPollBase from 'components/with-poll-base';
 import Toolbar from './toolbar';
 import SideBar from './sidebar';
 import { STORE_NAME } from 'state';
+import withFseCheck from 'components/with-fse-check';
 
 const EditApplauseBlock = ( props ) => {
 	const { attributes, setAttributes, pollDataFromApi, context } = props;
-
-	const {
-		postId,
-		queryId,
-	} = context;
-
-	// Prevent block from loading in FSE or a query loop because save handlers don't support those contexts.
-	// - double == instead of triple === used because we need to test for both null and undefined
-	if ( null == postId ) {
-		return <ErrorBanner>{ __( 'Applause blocks cannot be used outside of a post or page. The Site Editor is not supported.', 'crowdsignal-forms' ) }</ErrorBanner>;
-	} else if ( null != queryId ) {
-		return <ErrorBanner>{ __( 'Applause blocks are not supported inside a query loop.', 'crowdsignal-forms' ) }</ErrorBanner>;
-	}
 
 	const viewResultsUrl = pollDataFromApi
 		? pollDataFromApi.viewResultsUrl
@@ -81,6 +69,7 @@ const EditApplauseBlock = ( props ) => {
 };
 
 export default compose( [
+	withFseCheck,
 	withPollBase,
 	withClientId( [ 'pollId', 'answerId' ] ),
 ] )( EditApplauseBlock );

--- a/client/blocks/applause/index.js
+++ b/client/blocks/applause/index.js
@@ -37,6 +37,7 @@ export default {
 	icon: <ApplauseIcon />,
 	edit: EditApplauseBlock,
 	attributes,
+	usesContext: [ 'postId', 'queryId' ],
 	example: {
 		attributes: {
 			size: 'large',

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -39,6 +39,7 @@ import FooterBranding from 'components/footer-branding';
 import FeedbackIcon from 'components/icon/feedback';
 import PromotionalTooltip from 'components/promotional-tooltip';
 import { STORE_NAME } from 'state';
+import withFseCheck from 'components/with-fse-check';
 
 const EditFeedbackBlock = ( props ) => {
 	const [ view, setView ] = useState( views.QUESTION );
@@ -516,4 +517,5 @@ export default compose( [
 		};
 	} ),
 	withFallbackStyles,
+	withFseCheck,
 ] )( EditFeedbackBlock );

--- a/client/blocks/feedback/index.js
+++ b/client/blocks/feedback/index.js
@@ -38,6 +38,7 @@ export default {
 		reusable: false,
 	},
 	attributes,
+	usesContext: [ 'postId', 'queryId' ],
 	example: {
 		attributes: {
 			isExample: true,

--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -32,6 +32,7 @@ import SignalWarning from 'components/signal-warning';
 import RetryNotice from 'components/retry-notice';
 import PromotionalTooltip from 'components/promotional-tooltip';
 import { STORE_NAME } from 'state';
+import withFseCheck from 'components/with-fse-check';
 
 const EditNpsBlock = ( props ) => {
 	const [ view, setView ] = useState( views.RATING );
@@ -325,4 +326,5 @@ export default compose( [
 		};
 	} ),
 	withFallbackStyles,
+	withFseCheck,
 ] )( EditNpsBlock );

--- a/client/blocks/nps/index.js
+++ b/client/blocks/nps/index.js
@@ -18,6 +18,7 @@ export default {
 	),
 	category: 'crowdsignal-forms',
 	attributes,
+	usesContext: [ 'postId', 'queryId' ],
 	supports: {
 		multiple: false,
 		html: false,

--- a/client/blocks/poll/edit.js
+++ b/client/blocks/poll/edit.js
@@ -78,7 +78,21 @@ const PollBlock = ( props ) => {
 		setAttributes,
 		renderStyleProbe,
 		pollDataFromApi,
+		context,
 	} = props;
+
+	const {
+		postId,
+		queryId,
+	} = context;
+
+	// Prevent block from loading in FSE or a query loop because save handlers don't support those contexts.
+	// - double == instead of triple === used because we need to test for both null and undefined
+	if ( null == postId ) {
+		return <ErrorBanner>{ __( 'Crowdsignal blocks cannot be used outside of a post or page. The Site Editor is not supported.', 'crowdsignal-forms' ) }</ErrorBanner>;
+	} else if ( null != queryId ) {
+		return <ErrorBanner>{ __( 'Crowdsignal blocks are not supported inside a query loop.', 'crowdsignal-forms' ) }</ErrorBanner>;
+	}
 
 	const [ isPollEditable, setIsPollEditable ] = useState( true );
 	const [ errorMessage, setErrorMessage ] = useState( '' );

--- a/client/blocks/poll/edit.js
+++ b/client/blocks/poll/edit.js
@@ -43,6 +43,7 @@ import withPollBase from 'components/with-poll-base';
 import FooterBranding from 'components/footer-branding';
 import SignalWarning from 'components/signal-warning';
 import { STORE_NAME } from 'state';
+import withFseCheck from 'components/with-fse-check';
 
 const withPollAndAnswerIds = ( Element ) => {
 	return ( props ) => {
@@ -78,21 +79,7 @@ const PollBlock = ( props ) => {
 		setAttributes,
 		renderStyleProbe,
 		pollDataFromApi,
-		context,
 	} = props;
-
-	const {
-		postId,
-		queryId,
-	} = context;
-
-	// Prevent block from loading in FSE or a query loop because save handlers don't support those contexts.
-	// - double == instead of triple === used because we need to test for both null and undefined
-	if ( null == postId ) {
-		return <ErrorBanner>{ __( 'Crowdsignal blocks cannot be used outside of a post or page. The Site Editor is not supported.', 'crowdsignal-forms' ) }</ErrorBanner>;
-	} else if ( null != queryId ) {
-		return <ErrorBanner>{ __( 'Crowdsignal blocks are not supported inside a query loop.', 'crowdsignal-forms' ) }</ErrorBanner>;
-	}
 
 	const [ isPollEditable, setIsPollEditable ] = useState( true );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
@@ -308,6 +295,7 @@ const PollBlock = ( props ) => {
 };
 
 export default compose( [
+	withFseCheck,
 	withFallbackStyles,
 	withPollBase,
 	withPollAndAnswerIds,

--- a/client/blocks/poll/index.js
+++ b/client/blocks/poll/index.js
@@ -35,6 +35,7 @@ export default {
 	icon: <PollIcon />,
 	edit: EditPollBlock,
 	attributes,
+	usesContext: ['postId', 'queryId'],
 	supports: {
 		align: [ 'center', 'wide', 'full' ],
 	},

--- a/client/blocks/poll/index.js
+++ b/client/blocks/poll/index.js
@@ -35,7 +35,7 @@ export default {
 	icon: <PollIcon />,
 	edit: EditPollBlock,
 	attributes,
-	usesContext: ['postId', 'queryId'],
+	usesContext: [ 'postId', 'queryId' ],
 	supports: {
 		align: [ 'center', 'wide', 'full' ],
 	},

--- a/client/blocks/vote/edit.js
+++ b/client/blocks/vote/edit.js
@@ -27,7 +27,20 @@ import withPollBase from 'components/with-poll-base';
 import { STORE_NAME } from 'state';
 
 const EditVoteBlock = ( props ) => {
-	const { attributes, setAttributes, className, pollDataFromApi } = props;
+	const { attributes, setAttributes, className, pollDataFromApi, context } = props;
+
+	const {
+		postId,
+		queryId,
+	} = context;
+
+	// Prevent block from loading in FSE or a query loop because save handlers don't support those contexts.
+	// - double == instead of triple === used because we need to test for both null and undefined
+	if ( null == postId ) {
+		return <ErrorBanner>{ __( 'Vote blocks cannot be used outside of a post or page. The Site Editor is not supported.', 'crowdsignal-forms' ) }</ErrorBanner>;
+	} else if ( null != queryId ) {
+		return <ErrorBanner>{ __( 'Vote blocks are not supported inside a query loop.', 'crowdsignal-forms' ) }</ErrorBanner>;
+	}
 
 	useNumberedTitle(
 		props.name,

--- a/client/blocks/vote/edit.js
+++ b/client/blocks/vote/edit.js
@@ -25,22 +25,10 @@ import { isPollClosed } from 'blocks/poll/util';
 import useNumberedTitle from 'components/use-numbered-title';
 import withPollBase from 'components/with-poll-base';
 import { STORE_NAME } from 'state';
+import withFseCheck from 'components/with-fse-check';
 
 const EditVoteBlock = ( props ) => {
-	const { attributes, setAttributes, className, pollDataFromApi, context } = props;
-
-	const {
-		postId,
-		queryId,
-	} = context;
-
-	// Prevent block from loading in FSE or a query loop because save handlers don't support those contexts.
-	// - double == instead of triple === used because we need to test for both null and undefined
-	if ( null == postId ) {
-		return <ErrorBanner>{ __( 'Vote blocks cannot be used outside of a post or page. The Site Editor is not supported.', 'crowdsignal-forms' ) }</ErrorBanner>;
-	} else if ( null != queryId ) {
-		return <ErrorBanner>{ __( 'Vote blocks are not supported inside a query loop.', 'crowdsignal-forms' ) }</ErrorBanner>;
-	}
+	const { attributes, setAttributes, className, pollDataFromApi } = props;
 
 	useNumberedTitle(
 		props.name,
@@ -114,6 +102,6 @@ const EditVoteBlock = ( props ) => {
 	);
 };
 
-export default compose( [ withPollBase, withClientId( [ 'pollId' ] ) ] )(
+export default compose( [ withFseCheck, withPollBase, withClientId( [ 'pollId' ] ) ] )(
 	EditVoteBlock
 );

--- a/client/blocks/vote/index.js
+++ b/client/blocks/vote/index.js
@@ -48,6 +48,7 @@ export default {
 	edit: EditVoteBlock,
 	save: () => <InnerBlocks.Content />,
 	attributes,
+	usesContext: [ 'postId', 'queryId' ],
 	example: {
 		attributes: {
 			className: 'crowdsignal-forms-vote__example',

--- a/client/components/with-fse-check/index.js
+++ b/client/components/with-fse-check/index.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+import ErrorBanner from 'components/poll/error-banner';
+import { __ } from '@wordpress/i18n';
+
+const withFseCheck = ( Element ) => {
+	return ( props ) => {
+		const { context } = props;
+		const { postId, queryId } = context;
+console.log('fse check')
+		// Prevent block from loading in FSE or a query loop because save handlers don't support those contexts.
+		// - double == instead of triple === used because we need to test for both null and undefined
+		if ( null == postId ) {
+			return <ErrorBanner>{ __( 'Crowdsignal blocks cannot be used outside of a post or page. The Site Editor is not supported.', 'crowdsignal-forms' ) }</ErrorBanner>;
+		} else if ( null != queryId ) {
+			return <ErrorBanner>{ __( 'Crowdsignal blocks are not supported inside a query loop.', 'crowdsignal-forms' ) }</ErrorBanner>;
+		}
+console.log('allowing through')
+		return <Element { ...props } />;
+	};
+};
+
+export default withFseCheck;

--- a/client/components/with-fse-check/index.js
+++ b/client/components/with-fse-check/index.js
@@ -10,7 +10,7 @@ const withFseCheck = ( Element ) => {
 	return ( props ) => {
 		const { context } = props;
 		const { postId, queryId } = context;
-console.log('fse check')
+
 		// Prevent block from loading in FSE or a query loop because save handlers don't support those contexts.
 		// - double == instead of triple === used because we need to test for both null and undefined
 		if ( null == postId ) {
@@ -18,7 +18,7 @@ console.log('fse check')
 		} else if ( null != queryId ) {
 			return <ErrorBanner>{ __( 'Crowdsignal blocks are not supported inside a query loop.', 'crowdsignal-forms' ) }</ErrorBanner>;
 		}
-console.log('allowing through')
+
 		return <Element { ...props } />;
 	};
 };

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN \
 		php-xdebug \
 		php8.1 \
 		php8.1-common \
-		php8.1-mysql \
+		php8.1-mysqli \
 		php8.1-xml \
 		php8.1-xmlrpc \
 		php8.1-curl \
@@ -46,6 +46,9 @@ RUN \
 		sudo \
 		vim \
 	&& rm -rf /var/lib/apt/lists/*
+
+# force php 8.1 since with new versions of ubuntu, new php will be enabled on cli.
+RUN sudo update-alternatives --set php /usr/bin/php8.1
 
 # Enable mod_rewrite in Apache
 RUN a2enmod rewrite

--- a/includes/frontend/blocks/class-crowdsignal-forms-applause-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-applause-block.php
@@ -64,7 +64,7 @@ class Crowdsignal_Forms_Applause_Block extends Crowdsignal_Forms_Block {
 	 * @return string
 	 */
 	public function render( $attributes ) {
-		if ( $this->should_hide_block() ) {
+		if ( $this->should_hide_block( $attributes ) ) {
 			return '';
 		}
 
@@ -91,7 +91,12 @@ class Crowdsignal_Forms_Applause_Block extends Crowdsignal_Forms_Block {
 	 *
 	 * @return bool
 	 */
-	private function should_hide_block() {
+	private function should_hide_block( $attributes ) {
+		$platform_poll_data = $this->get_platform_poll_data( $attributes['pollId'] ?? null );
+		if ( empty( $platform_poll_data ) ) {
+			return true;
+		}
+
 		return ! $this->is_cs_connected();
 	}
 

--- a/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-feedback-block.php
@@ -103,6 +103,10 @@ class Crowdsignal_Forms_Feedback_Block extends Crowdsignal_Forms_Block {
 				return true;
 		}
 
+		if ( empty( $attributes['surveyId'] ) ) {
+			return true;
+		}
+
 		if ( isset( $attributes['status'] ) ) {
 			if ( self::STATUS_TYPE_CLOSED === $attributes['status'] ) {
 				return true;

--- a/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
@@ -91,6 +91,7 @@ class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 	/**
 	 * Determines if the NPS block should be rendered or not.
 	 *
+	 * @param array $attributes The block's saved attributes.
 	 * @return bool
 	 */
 	private function should_hide_block( $attributes ) {

--- a/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-nps-block.php
@@ -71,7 +71,7 @@ class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 	 * @return string
 	 */
 	public function render( $attributes ) {
-		if ( $this->should_hide_block() ) {
+		if ( $this->should_hide_block( $attributes ) ) {
 			return '';
 		}
 
@@ -93,8 +93,8 @@ class Crowdsignal_Forms_Nps_Block extends Crowdsignal_Forms_Block {
 	 *
 	 * @return bool
 	 */
-	private function should_hide_block() {
-		return ! $this->is_cs_connected() || ! is_singular();
+	private function should_hide_block( $attributes ) {
+		return ! $this->is_cs_connected() || ! is_singular() || empty( $attributes['surveyId'] );
 	}
 
 	/**

--- a/includes/frontend/blocks/class-crowdsignal-forms-poll-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-poll-block.php
@@ -96,7 +96,9 @@ class Crowdsignal_Forms_Poll_Block extends Crowdsignal_Forms_Block {
 	 * @return bool
 	 */
 	private function should_hide_block( $attributes ) {
-		if ( empty( $attributes['question'] ) ) {
+		$platform_poll_data = $this->get_platform_poll_data( $attributes['pollId'] );
+
+		if ( empty( $attributes['question'] ) || empty( $platform_poll_data ) ) {
 			return true;
 		}
 

--- a/includes/frontend/blocks/class-crowdsignal-forms-poll-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-poll-block.php
@@ -96,7 +96,7 @@ class Crowdsignal_Forms_Poll_Block extends Crowdsignal_Forms_Block {
 	 * @return bool
 	 */
 	private function should_hide_block( $attributes ) {
-		$platform_poll_data = $this->get_platform_poll_data( $attributes['pollId'] );
+		$platform_poll_data = $this->get_platform_poll_data( $attributes['pollId'] ?? null );
 
 		if ( empty( $attributes['question'] ) || empty( $platform_poll_data ) ) {
 			return true;

--- a/includes/frontend/blocks/class-crowdsignal-forms-vote-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-vote-block.php
@@ -88,7 +88,7 @@ class Crowdsignal_Forms_Vote_Block extends Crowdsignal_Forms_Block {
 	/**
 	 * Determines if the vote block should be rendered or not.
 	 *
-	 * @param  array $attributes The poll's saved attributes.
+	 * @param  array $attributes The block's saved attributes.
 	 * @return bool
 	 */
 	private function should_hide_block( $attributes ) {

--- a/includes/frontend/blocks/class-crowdsignal-forms-vote-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-vote-block.php
@@ -65,7 +65,7 @@ class Crowdsignal_Forms_Vote_Block extends Crowdsignal_Forms_Block {
 	 * @return string
 	 */
 	public function render( $attributes, $rendered_inner_blocks ) {
-		if ( $this->should_hide_block() ) {
+		if ( $this->should_hide_block( $attributes ) ) {
 			return '';
 		}
 
@@ -88,9 +88,16 @@ class Crowdsignal_Forms_Vote_Block extends Crowdsignal_Forms_Block {
 	/**
 	 * Determines if the vote block should be rendered or not.
 	 *
+	 * @param  array $attributes The poll's saved attributes.
 	 * @return bool
 	 */
-	private function should_hide_block() {
+	private function should_hide_block( $attributes ) {
+		$platform_poll_data = $this->get_platform_poll_data( $attributes['pollId'] );
+
+		if ( empty( $platform_poll_data ) ) {
+			return true;
+		}
+
 		return ! $this->is_cs_connected();
 	}
 

--- a/includes/frontend/blocks/class-crowdsignal-forms-vote-block.php
+++ b/includes/frontend/blocks/class-crowdsignal-forms-vote-block.php
@@ -92,7 +92,7 @@ class Crowdsignal_Forms_Vote_Block extends Crowdsignal_Forms_Block {
 	 * @return bool
 	 */
 	private function should_hide_block( $attributes ) {
-		$platform_poll_data = $this->get_platform_poll_data( $attributes['pollId'] );
+		$platform_poll_data = $this->get_platform_poll_data( $attributes['pollId'] ?? null );
 
 		if ( empty( $platform_poll_data ) ) {
 			return true;

--- a/includes/frontend/class-crowdsignal-forms-block.php
+++ b/includes/frontend/class-crowdsignal-forms-block.php
@@ -33,6 +33,13 @@ abstract class Crowdsignal_Forms_Block {
 	private static $is_cs_connected = null;
 
 	/**
+	 * Cached poll data. Array is indexed by poll_id (guid).
+	 *
+	 * @var array
+	 */
+	private $poll_data = [];
+
+	/**
 	 * Registers the Gutenberg block.
 	 */
 	abstract public function register();
@@ -110,14 +117,25 @@ abstract class Crowdsignal_Forms_Block {
 			return null;
 		}
 
+		if ( $this->poll_data[ $poll_id ] ) {
+			return $this->poll_data[ $poll_id ];
+		}
+
 		$post = get_post();
 
 		if ( null === $post ) {
 			return null;
 		}
 
-		return Crowdsignal_Forms::instance()
+		$data = Crowdsignal_Forms::instance()
 			->get_post_poll_meta_gateway()
 			->get_poll_data_for_poll_client_id( $post->ID, $poll_id );
+
+		if ( empty( $data ) ) {
+			return null;
+		}
+
+		$this->poll_data[ $poll_id ] = $data;
+		return $data;
 	}
 }

--- a/includes/gateways/class-post-poll-meta-gateway.php
+++ b/includes/gateways/class-post-poll-meta-gateway.php
@@ -53,7 +53,14 @@ class Post_Poll_Meta_Gateway {
 				$platform_poll_data = array();
 			}
 		} else {
-			$platform_poll_data = (array) get_post_meta( $post_id, $poll_meta_key, true );
+
+			$meta_value = get_post_meta( $post_id, $poll_meta_key, true );
+
+			if ( '' === $meta_value ) {
+				$platform_poll_data = array();
+			} else {
+				$platform_poll_data = (array) $meta_value;
+			}
 		}
 
 		if ( empty( $platform_poll_data ) ) {


### PR DESCRIPTION
There have been a few instances recently where users have been trying to use Poll blocks in FSE and when attempting to vote on the public page, there is a JS error saying an attribute is missing. This plugin may have been created before FSE was available so this scenario was not properly handled.

All of the crowdsignal blocks only support being rendered in a Post context in order for their content to be properly saved since they only get processed on post save hooks.

This PR adds some checks to the block in the editor to try to determine if it is running in an FSE context (no post id) or in a query loop (queryId is available in context). Query loop should not be supported on FSE or in a post because the save hook would always attempt to save against the post that is being saved, not the dynamic post id from the query loop. So the result would be weird.

This PR also adds a check on the rendered page, so if "platform data" (for polls) or surveyId is missing (the data that matches the poll and options to IDs on Crowdsignal) then it won't attempt to render the poll. This is to protect against any existing polls that may have already been created. Hopefully the missing poll on the page would prompt someone to check the editor, see the message, and then not contact support because of a broken poll. This change required a small refactor to cache the data since the "platform data" function is being called twice now, as well as a small bug fix for a weird array with a space in it when data could not be found.

Finally, this PR fixes some issues with the docker container used for local dev / testing.

There is currently an issue with the NPS block prior to this PR where if you open a post for editing that already had an NPS block on it, it fails to render in the editor. I've opened a separate issue to track this https://github.com/Automattic/crowdsignal-forms/issues/273

I also bumped the minimum WordPress version to ensure that we have support for `usesContext` because it seems it was only added at some point in 2020 (WP 5.5?), and current minimum 5.0 version was released in 2018. But having a more modern version will allow us to use more modern features when we are ready to.

**Testing**
1. Apply this PR to get the docker fixes, then run the steps to setup the dev environment. See https://github.com/Automattic/crowdsignal-forms/tree/master/docker#setup
2. Check out `master` again. We want to do these next steps against existing code.
3. On a new post, create a Poll, Vote and Applause block.
   - use the `/poll`, `/vote` and `/applause` blocks, not the embeds
   - also test with the `/nps` and `/feedback` blocks
4. Save the post
6. In FSE, add a Poll, Vote and Applause block anywhere on the homepage not in a query loop
7. In FSE, add a Poll, Vote and Applause block to a query loop's "Post Template"
8. Save the page and view the public pages.
9. The polls should render, but voting should fail with console errors on the homepage
10. Checkout this PR branch again
11. run `make client`
12. refresh the public page, none of the Poll, Vote or Applause blocks should render
13. View the public post page, voting should work as expected
14. View FSE, you should see error messages in replacement of the blocks
15. View the Post editor for your test post. The block should render as expected (with the exception of the nps block as noted in the description above)