### PR TITLE
disable PostPreviewButton because it is crashing the block on re-renders

### DIFF
--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -152,16 +152,18 @@ const EditNpsBlock = ( props ) => {
 					isDismissible={ false }
 					icon="visibility"
 					componentActions={ [
-						<PostPreviewButton
-							key={ 1 }
-							className={ [
-								'is-secondary',
-								'components-notice__action',
-								'crowdsignal-forms-nps__preview-button',
-								attributes.surveyId ? '' : 'is-disabled',
-							] }
-							textContent={ __( 'Preview', 'crowdsignal-forms' ) }
-						/>,
+						// Temporarily disabled to prevent block render error,
+						// until we can figure out why it is breaking (maybe a new WP version?)
+						// <PostPreviewButton
+						// 	key={ 1 }
+						// 	className={ [
+						// 		'is-secondary',
+						// 		'components-notice__action',
+						// 		'crowdsignal-forms-nps__preview-button',
+						// 		attributes.surveyId ? '' : 'is-disabled',
+						// 	] }
+						// 	textContent={ __( 'Preview', 'crowdsignal-forms' ) }
+						// />,
 					] }
 				>
 					{ sprintf(


### PR DESCRIPTION
This PR removes the "Preview" button on the NPS block because its presense is causing the block to blow up in the editor.

Tracking in https://github.com/Automattic/crowdsignal-forms/issues/273


**Testing**
1. First test in `master`
2. Add an NPS block to a post
3. Publish the post
4. refresh the editor
5. The block will show a "This block has encountered an error and cannot be previewed" error
6. Apply this branch
7. run `make client`
8. refresh the editor
9. The block will render