### PR TITLE
check for null `core/edit-post` selector which is causing a crash in 6.5

### DIFF
--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -503,6 +503,19 @@ export default compose( [
 			url = select( 'core' ).getSite() && select( 'core' ).getSite().url;
 		}
 		const editPost = select( 'core/edit-post' );
+
+		// Need to return same object, but values don't necessarily matter because
+		// this block won't render in FSE.
+		if ( ! editPost ) {
+			return {
+				isFullscreen: false,
+				isInserterActive: false,
+				isListViewActive: false,
+				isSidebarActive: false,
+				sourceLink: url,
+			}
+		}
+
 		const isFullscreen =
 			'isFeatureActive' in editPost
 				? editPost.isFeatureActive( 'fullscreenMode' )


### PR DESCRIPTION
This PR fixes a crash introduced in WordPress 6.5 where the `core/edit-post` selector is no longer available in FSE.

**Testing**

1. Apply this PR to get the docker fixes, then run the steps to setup the dev environment. See https://github.com/Automattic/crowdsignal-forms/tree/master/docker#setup
2. run `make client`
3. in FSE, add a `/feedback` block
4. The warning message should appear, and NOT a "this block has experienced a problem" message
