### PR TITLE
check for empty cached poll data to prevent warning on load of editor

### DIFF
--- a/includes/frontend/class-crowdsignal-forms-block.php
+++ b/includes/frontend/class-crowdsignal-forms-block.php
@@ -117,7 +117,7 @@ abstract class Crowdsignal_Forms_Block {
 			return null;
 		}
 
-		if ( $this->poll_data[ $poll_id ] ) {
+		if ( ! empty( $this->poll_data[ $poll_id ] ) ) {
 			return $this->poll_data[ $poll_id ];
 		}
 


### PR DESCRIPTION
This fixes a warning in the editor that was found while testing the v1.7.1 plugin release

**Testing**
1. apply pr
2. run `make client` (maybe not necessary?)
3. add a `/poll` to a post or page
4. Save then reload the page
5. You should NOT see a warning appear "behind" the editor as it is loading that an array key does not exist