### PR TITLE
i18n: Fix omitted dollar signs in printf placeholders

### DIFF
--- a/includes/admin/views/html-admin-dashboard-teaser.php
+++ b/includes/admin/views/html-admin-dashboard-teaser.php
@@ -39,9 +39,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<?php
 						echo wp_kses_post(
 							sprintf(
-								// translators: Argument is a link to Crowdsignal's contact page.
+								// translators: %1$s is a link to Crowdsignal's support page.
 								__(
-									'Do you want to know more about Crowdsignal? <a href="%1s" target="_blank">Learn more</a>.',
+									'Do you want to know more about Crowdsignal? <a href="%1$s" target="_blank">Learn more</a>.',
 									'crowdsignal-forms'
 								),
 								'https://crowdsignal.com/support/'

--- a/includes/admin/views/html-admin-setup-step-3.php
+++ b/includes/admin/views/html-admin-setup-step-3.php
@@ -36,9 +36,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php
 					echo wp_kses_post(
 						sprintf(
-							// translators: Argument is a link to Crowdsignal's support page.
+							// translators: %1$s is a link to Crowdsignal's support page.
 							__(
-								'Do you want to know more about Crowdsignal and our blocks? <a href="%1s" target="_blank">Learn more</a>.',
+								'Do you want to know more about Crowdsignal and our blocks? <a href="%1$s" target="_blank">Learn more</a>.',
 								'crowdsignal-forms'
 							),
 							'https://crowdsignal.com/support/'


### PR DESCRIPTION
This is part of an effort to fix placeholder issues in translatable strings across Automattic products (pxLjZ-8oQ-p2).

`%1s` is a string placeholder with a minimum width of 1, whereas a numbered placeholder (`%1$s`) was likely intended. It doesn't cause problems here because there's only one placeholder. However, if there had been more (e.g. `%1s` and `%2s`), translators wouldn't be able to change the order of the placeholders, so it's best to keep it safe and fix them here too.

**Testing**
1. Start the plugin locally (https://github.com/Automattic/crowdsignal-forms/tree/master/docker#setup).
2. Activate/connect the plugin.
3. Go to the Crowdsignal settings (http://localhost:8000/wp-admin/options-general.php?page=crowdsignal-settings) and verify that the texts are still displayed normally and that the links still work:

![image](https://github.com/Automattic/crowdsignal-forms/assets/75777864/b9fb8f04-f369-44e6-ae68-c9b72f51dc43)
