### PR TITLE
Refactor withFallbackStyles to remove wrapper div and use iframe-safe APIs

### DIFF
--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -281,6 +281,7 @@ const EditFeedbackBlock = ( props ) => {
 	);
 
 	return (
+		<div ref={ props.fallbackStylesRef }>
 		<ConnectToCrowdsignal
 			blockName={ __( 'Feedback Button', 'crowdsignal-forms' ) }
 			blockIcon={ <FeedbackIcon /> }
@@ -453,6 +454,7 @@ const EditFeedbackBlock = ( props ) => {
 
 			{ props.renderStyleProbe() }
 		</ConnectToCrowdsignal>
+		</div>
 	);
 };
 

--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -38,6 +38,7 @@ const EditNpsBlock = ( props ) => {
 	const {
 		attributes,
 		fallbackStyles,
+		fallbackStylesRef,
 		isSelected,
 		setAttributes,
 		renderStyleProbe,
@@ -96,6 +97,7 @@ const EditNpsBlock = ( props ) => {
 			get( accountInfo, [ 'signalCount', 'userLimit' ] );
 
 	return (
+		<div ref={ fallbackStylesRef }>
 		<ConnectToCrowdsignal
 			blockIcon={ null }
 			blockName={ __( 'Crowdsignal NPS', 'crowdsignal-forms' ) }
@@ -279,6 +281,7 @@ const EditNpsBlock = ( props ) => {
 
 			{ renderStyleProbe() }
 		</ConnectToCrowdsignal>
+		</div>
 	);
 };
 

--- a/client/blocks/poll/edit.js
+++ b/client/blocks/poll/edit.js
@@ -75,6 +75,7 @@ const PollBlock = ( props ) => {
 		attributes,
 		className,
 		fallbackStyles,
+		fallbackStylesRef,
 		isSelected,
 		setAttributes,
 		renderStyleProbe,
@@ -181,6 +182,7 @@ const PollBlock = ( props ) => {
 				resizeRatio={ 2 }
 			>
 				<div
+					ref={ fallbackStylesRef }
 					className={ getBlockCssClasses(
 						attributes,
 						className,

--- a/client/blocks/vote-item/edit.js
+++ b/client/blocks/vote-item/edit.js
@@ -17,10 +17,10 @@ import VoteItem from 'components/vote/vote-item';
 import { withFallbackStyles } from 'components/with-fallback-styles';
 
 const EditVoteItemBlock = ( props ) => {
-	const { attributes, className, fallbackStyles, renderStyleProbe } = props;
+	const { attributes, className, fallbackStyles, fallbackStylesRef, renderStyleProbe } = props;
 
 	return (
-		<>
+		<div ref={ fallbackStylesRef }>
 			<SideBar { ...props } />
 
 			<VoteItem
@@ -33,7 +33,7 @@ const EditVoteItemBlock = ( props ) => {
 			/>
 
 			{ renderStyleProbe() }
-		</>
+		</div>
 	);
 };
 

--- a/client/components/applause/index.js
+++ b/client/components/applause/index.js
@@ -17,7 +17,7 @@ import BrandLink from 'components/brand-link';
 import ApplauseAnimation from './animation';
 
 const Applause = ( props ) => {
-	const { attributes, fallbackStyles, renderStyleProbe } = props;
+	const { attributes, fallbackStyles, fallbackStylesRef, renderStyleProbe } = props;
 	const apiPollId = attributes.apiPollData ? attributes.apiPollData.id : null;
 	const { hasVoted, vote } = usePollVote( apiPollId, true );
 	const [ currentVote, setCurrentVote ] = useState( 0 );
@@ -85,6 +85,7 @@ const Applause = ( props ) => {
 	return (
 		<>
 			<div
+				ref={ fallbackStylesRef }
 				className={ classes }
 				style={ styleVars }
 				onClick={ handleVote }

--- a/client/components/feedback/index.js
+++ b/client/components/feedback/index.js
@@ -38,7 +38,7 @@ const adjustFrameOffset = ( position, verticalAlign, width, height ) => {
 	};
 };
 
-const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
+const Feedback = ( { attributes, fallbackStyles, fallbackStylesRef, renderStyleProbe } ) => {
 	const [ position, setPosition ] = useState( {} );
 
 	const toggle = useRef( null );
@@ -89,7 +89,7 @@ const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 	};
 
 	return (
-		<>
+		<div ref={ fallbackStylesRef }>
 			<div className={ classes } style={ styles }>
 				<Dropdown
 					popoverProps={ {
@@ -119,7 +119,7 @@ const Feedback = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 			</div>
 
 			{ renderStyleProbe() }
-		</>
+		</div>
 	);
 };
 

--- a/client/components/nps/index.js
+++ b/client/components/nps/index.js
@@ -24,6 +24,7 @@ const Nps = ( {
 	attributes,
 	contentWidth,
 	fallbackStyles,
+	fallbackStylesRef,
 	onClose,
 	renderStyleProbe,
 } ) => {
@@ -52,7 +53,7 @@ const Nps = ( {
 	};
 
 	return (
-		<>
+		<div ref={ fallbackStylesRef }>
 			<div className="crowdsignal-forms-nps" style={ style }>
 				<h3
 					className="crowdsignal-forms-nps__question"
@@ -99,7 +100,7 @@ const Nps = ( {
 			</div>
 
 			{ renderStyleProbe() }
-		</>
+		</div>
 	);
 };
 

--- a/client/components/poll/index.js
+++ b/client/components/poll/index.js
@@ -32,7 +32,7 @@ import { CrowdsignalFormsError } from 'data/poll';
 import ErrorBanner from './error-banner';
 import SubmitMessage from './submit-message';
 
-const Poll = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
+const Poll = ( { attributes, fallbackStyles, fallbackStylesRef, renderStyleProbe } ) => {
 	const [ randomAnswerSeed ] = useState( Math.random() );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
 	const [ dismissSubmitMessage, setDismissSubmitMessage ] = useState( false );
@@ -152,7 +152,7 @@ const Poll = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 	}
 
 	return (
-		<div className={ classes } style={ blockStyle }>
+		<div ref={ fallbackStylesRef } className={ classes } style={ blockStyle }>
 			{ errorMessage && <ErrorBanner>{ errorMessage }</ErrorBanner> }
 
 			<div className={ contentClasses }>

--- a/client/components/vote/index.js
+++ b/client/components/vote/index.js
@@ -15,7 +15,7 @@ import { withFallbackStyles } from 'components/with-fallback-styles';
 import BrandLink from 'components/brand-link';
 import { isPollClosed } from 'blocks/poll/util';
 
-const Vote = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
+const Vote = ( { attributes, fallbackStyles, fallbackStylesRef, renderStyleProbe } ) => {
 	const apiPollId = attributes.apiPollData.id;
 	const [ votedOnId, setVotedOnId ] = useState( 0 );
 	const { hasVoted, vote, storedCookieValue } = usePollVote(
@@ -56,7 +56,7 @@ const Vote = ( { attributes, fallbackStyles, renderStyleProbe } ) => {
 	);
 
 	return (
-		<div className={ classes } style={ voteStyleVars }>
+		<div ref={ fallbackStylesRef } className={ classes } style={ voteStyleVars }>
 			<div className="crowdsignal-forms-vote__items">
 				{ map( attributes.innerBlocks, ( voteAttributes ) => {
 					const apiAnswerId =

--- a/client/components/with-fallback-styles/index.js
+++ b/client/components/with-fallback-styles/index.js
@@ -35,9 +35,11 @@ const getStyles = ( node ) => {
 	const h3Node = node.querySelector( 'h3' );
 	const wideContentNode = node.querySelector( '.alignwide' );
 
+	const computedStyle = node.ownerDocument.defaultView.getComputedStyle;
+
 	let accentColor = getBackgroundColor( buttonNode );
 	const backgroundColor = getBackgroundColor( textNode );
-	const textColor = window.getComputedStyle( textNode ).color;
+	const textColor = computedStyle( textNode ).color;
 
 	// Ensure that we don't end up with the same color for surface and accent.
 	// Falls back to button border color, then text color.
@@ -50,11 +52,11 @@ const getStyles = ( node ) => {
 		accentColor,
 		backgroundColor,
 		textColor,
-		textColorInverted: window.getComputedStyle( buttonNode ).color,
-		textFont: window.getComputedStyle( textNode ).fontFamily,
-		textSize: window.getComputedStyle( textNode ).fontSize,
-		headingFont: window.getComputedStyle( h3Node ).fontFamily,
-		contentWideWidth: window.getComputedStyle( wideContentNode ).maxWidth,
+		textColorInverted: computedStyle( buttonNode ).color,
+		textFont: computedStyle( textNode ).fontFamily,
+		textSize: computedStyle( textNode ).fontSize,
+		headingFont: computedStyle( h3Node ).fontFamily,
+		contentWideWidth: computedStyle( wideContentNode ).maxWidth,
 	};
 };
 
@@ -65,7 +67,7 @@ export const withFallbackStyles = ( WrappedComponent ) => {
 		),
 	} ) );
 
-	return getFallbackStyles( ( { fallbackStyles, ...props } ) => {
+	return getFallbackStyles( ( { fallbackStyles, fallbackStylesRef, ...props } ) => {
 		const renderProbe = () => {
 			if ( fallbackStyles ) {
 				return null;
@@ -77,6 +79,7 @@ export const withFallbackStyles = ( WrappedComponent ) => {
 		return (
 			<WrappedComponent
 				fallbackStyles={ fallbackStyles || {} }
+				fallbackStylesRef={ fallbackStylesRef }
 				renderStyleProbe={ renderProbe }
 				{ ...props }
 			/>

--- a/client/components/with-fallback-styles/index.js
+++ b/client/components/with-fallback-styles/index.js
@@ -35,11 +35,11 @@ const getStyles = ( node ) => {
 	const h3Node = node.querySelector( 'h3' );
 	const wideContentNode = node.querySelector( '.alignwide' );
 
-	const computedStyle = node.ownerDocument.defaultView.getComputedStyle;
+	const view = node.ownerDocument.defaultView;
 
 	let accentColor = getBackgroundColor( buttonNode );
 	const backgroundColor = getBackgroundColor( textNode );
-	const textColor = computedStyle( textNode ).color;
+	const textColor = view.getComputedStyle( textNode ).color;
 
 	// Ensure that we don't end up with the same color for surface and accent.
 	// Falls back to button border color, then text color.
@@ -52,11 +52,11 @@ const getStyles = ( node ) => {
 		accentColor,
 		backgroundColor,
 		textColor,
-		textColorInverted: computedStyle( buttonNode ).color,
-		textFont: computedStyle( textNode ).fontFamily,
-		textSize: computedStyle( textNode ).fontSize,
-		headingFont: computedStyle( h3Node ).fontFamily,
-		contentWideWidth: computedStyle( wideContentNode ).maxWidth,
+		textColorInverted: view.getComputedStyle( buttonNode ).color,
+		textFont: view.getComputedStyle( textNode ).fontFamily,
+		textSize: view.getComputedStyle( textNode ).fontSize,
+		headingFont: view.getComputedStyle( h3Node ).fontFamily,
+		contentWideWidth: view.getComputedStyle( wideContentNode ).maxWidth,
 	};
 };
 

--- a/client/components/with-fallback-styles/util.js
+++ b/client/components/with-fallback-styles/util.js
@@ -8,16 +8,17 @@
  * @return {string}  The background colour of the node
  */
 export const getBackgroundColor = ( backgroundColorNode ) => {
-	const computedStyle =
-		backgroundColorNode.ownerDocument.defaultView.getComputedStyle;
-	let backgroundColor = computedStyle( backgroundColorNode ).backgroundColor;
+	const view = backgroundColorNode.ownerDocument.defaultView;
+	let backgroundColor = view.getComputedStyle( backgroundColorNode )
+		.backgroundColor;
 	while (
 		backgroundColor === 'rgba(0, 0, 0, 0)' &&
 		backgroundColorNode.parentNode &&
 		backgroundColorNode.parentNode.nodeType === 1
 	) {
 		backgroundColorNode = backgroundColorNode.parentNode;
-		backgroundColor = computedStyle( backgroundColorNode ).backgroundColor;
+		backgroundColor = view.getComputedStyle( backgroundColorNode )
+			.backgroundColor;
 	}
 	return backgroundColor;
 };
@@ -31,11 +32,11 @@ export const getBackgroundColor = ( backgroundColorNode ) => {
  * @return {string|null} The border colour value of null if invalid
  */
 export const getBorderColor = ( borderNode ) => {
-	const computedStyle =
-		borderNode.ownerDocument.defaultView.getComputedStyle;
-	const borderWidth = computedStyle( borderNode ).borderBlockStartWidth;
+	const view = borderNode.ownerDocument.defaultView;
+	const borderWidth = view.getComputedStyle( borderNode )
+		.borderBlockStartWidth;
 	return borderWidth !== '0px'
-		? computedStyle( borderNode ).borderBlockStartColor
+		? view.getComputedStyle( borderNode ).borderBlockStartColor
 		: null;
 };
 

--- a/client/components/with-fallback-styles/util.js
+++ b/client/components/with-fallback-styles/util.js
@@ -8,16 +8,16 @@
  * @return {string}  The background colour of the node
  */
 export const getBackgroundColor = ( backgroundColorNode ) => {
-	let backgroundColor = window.getComputedStyle( backgroundColorNode )
-		.backgroundColor;
+	const computedStyle =
+		backgroundColorNode.ownerDocument.defaultView.getComputedStyle;
+	let backgroundColor = computedStyle( backgroundColorNode ).backgroundColor;
 	while (
 		backgroundColor === 'rgba(0, 0, 0, 0)' &&
 		backgroundColorNode.parentNode &&
-		backgroundColorNode.parentNode.nodeType === window.Node.ELEMENT_NODE
+		backgroundColorNode.parentNode.nodeType === 1
 	) {
 		backgroundColorNode = backgroundColorNode.parentNode;
-		backgroundColor = window.getComputedStyle( backgroundColorNode )
-			.backgroundColor;
+		backgroundColor = computedStyle( backgroundColorNode ).backgroundColor;
 	}
 	return backgroundColor;
 };
@@ -31,10 +31,11 @@ export const getBackgroundColor = ( backgroundColorNode ) => {
  * @return {string|null} The border colour value of null if invalid
  */
 export const getBorderColor = ( borderNode ) => {
-	const borderWidth = window.getComputedStyle( borderNode )
-		.borderBlockStartWidth;
+	const computedStyle =
+		borderNode.ownerDocument.defaultView.getComputedStyle;
+	const borderWidth = computedStyle( borderNode ).borderBlockStartWidth;
 	return borderWidth !== '0px'
-		? window.getComputedStyle( borderNode ).borderBlockStartColor
+		? computedStyle( borderNode ).borderBlockStartColor
 		: null;
 };
 
@@ -101,16 +102,12 @@ export const withWordPressFallbackStyles = ( mapNodeToProps ) =>
 			}
 
 			render() {
-				const wrappedComponent = (
+				return (
 					<WrappedComponent
 						{ ...this.props }
 						{ ...this.state.fallbackStyles }
+						fallbackStylesRef={ this.bindRef }
 					/>
-				);
-				return this.props.node ? (
-					wrappedComponent
-				) : (
-					<div ref={ this.bindRef }> { wrappedComponent } </div>
 				);
 			}
 		};


### PR DESCRIPTION
## Summary

WordPress 7.0 moves the block editor into an iframe, which means blocks using
`window.getComputedStyle()` will measure the wrong document. The
`withFallbackStyles` HOC also wraps every consumer in an extra `<div ref>`,
which will conflict with the `useBlockProps()` requirement in Block API v3
(the outermost element must carry block props).

See [Migrating Blocks for iframe Editor Compatibility](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/block-migration-for-iframe-editor-compatibility/).

This PR:

- Removes the wrapper `<div ref={this.bindRef}>` from the HOC; passes a
  `fallbackStylesRef` callback prop instead, letting each consumer attach
  the ref to its own root element
- Replaces all `window.getComputedStyle()` calls with
  `node.ownerDocument.defaultView.getComputedStyle()` so style measurement
  works inside an iframe
- Updates all 9 consumers (4 editor blocks + 5 frontend components) to
  attach the new ref

### Files changed (11 files)

**HOC core:**
- `client/components/with-fallback-styles/util.js` — removed wrapper div, iframe-safe getComputedStyle
- `client/components/with-fallback-styles/index.js` — pass through fallbackStylesRef, iframe-safe getComputedStyle

**Editor blocks** (attach `fallbackStylesRef`):
- `client/blocks/poll/edit.js`
- `client/blocks/vote-item/edit.js`
- `client/blocks/nps/edit.js`
- `client/blocks/feedback/edit.js`

**Frontend components** (attach `fallbackStylesRef`):
- `client/components/poll/index.js`
- `client/components/vote/index.js`
- `client/components/applause/index.js`
- `client/components/nps/index.js`
- `client/components/feedback/index.js`

## Testing

1. Build: `nvm use 18 && pnpm build` — no errors
2. Insert poll, NPS, feedback, and vote-item blocks in the editor — verify
   theme color detection still works (fallback styles probe measures correctly)
3. Preview frontend rendering of poll, vote, applause, NPS, and feedback
   blocks — verify theme-matched colors appear
4. No new console errors or warnings related to this change