### PR TITLE
Migrate all blocks to Block API v3 with useBlockProps

### DIFF
--- a/client/blocks/applause/edit.js
+++ b/client/blocks/applause/edit.js
@@ -55,19 +55,19 @@ const EditApplauseBlock = ( props ) => {
 
 	return (
 		<div { ...blockProps }>
-		<ConnectToCrowdsignal
-			blockIcon={ null }
-			blockName={ __( 'Crowdsignal Applause', 'crowdsignal-forms' ) }
-		>
-			<SideBar
-				{ ...props }
-				shouldPromote={ shouldPromote }
-				signalWarning={ signalWarning }
-				viewResultsUrl={ viewResultsUrl }
-			/>
-			<Toolbar { ...props } />
-			<Applause { ...props } />
-		</ConnectToCrowdsignal>
+			<ConnectToCrowdsignal
+				blockIcon={ null }
+				blockName={ __( 'Crowdsignal Applause', 'crowdsignal-forms' ) }
+			>
+				<SideBar
+					{ ...props }
+					shouldPromote={ shouldPromote }
+					signalWarning={ signalWarning }
+					viewResultsUrl={ viewResultsUrl }
+				/>
+				<Toolbar { ...props } />
+				<Applause { ...props } />
+			</ConnectToCrowdsignal>
 		</div>
 	);
 };

--- a/client/blocks/applause/edit.js
+++ b/client/blocks/applause/edit.js
@@ -7,6 +7,7 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { useBlockProps } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
@@ -26,6 +27,7 @@ import withFseCheck from 'components/with-fse-check';
 
 const EditApplauseBlock = ( props ) => {
 	const { attributes, setAttributes, pollDataFromApi } = props;
+	const blockProps = useBlockProps();
 
 	const viewResultsUrl = pollDataFromApi
 		? pollDataFromApi.viewResultsUrl
@@ -52,6 +54,7 @@ const EditApplauseBlock = ( props ) => {
 			get( accountInfo, [ 'signalCount', 'userLimit' ] );
 
 	return (
+		<div { ...blockProps }>
 		<ConnectToCrowdsignal
 			blockIcon={ null }
 			blockName={ __( 'Crowdsignal Applause', 'crowdsignal-forms' ) }
@@ -65,6 +68,7 @@ const EditApplauseBlock = ( props ) => {
 			<Toolbar { ...props } />
 			<Applause { ...props } />
 		</ConnectToCrowdsignal>
+		</div>
 	);
 };
 

--- a/client/blocks/applause/index.js
+++ b/client/blocks/applause/index.js
@@ -11,6 +11,7 @@ import EditApplauseBlock from './edit';
 import attributes from './attributes';
 
 export default {
+	apiVersion: 3,
 	title: __( 'Applause', 'crowdsignal-forms' ),
 	description: __(
 		'Let your audience cheer with a big round of applause — powered by Crowdsignal.',

--- a/client/blocks/applause/util.js
+++ b/client/blocks/applause/util.js
@@ -13,12 +13,21 @@ export const getApplauseStyleVars = ( attributes, fallbackStyles ) => {
 		? fallbackStyles.textColor
 		: attributes.textColor;
 
+	// When the style probe can't detect proper theme button colors
+	// (e.g., in the iframed block editor), accentColor and textColorInverted
+	// both resolve to the same value. Don't set those CSS variables so the
+	// theme's styles apply instead.
+	const fallbacksValid =
+		fallbackStyles.accentColor !== fallbackStyles.textColorInverted;
+
 	return mapKeys(
 		{
 			bgColor:
 				attributes.backgroundColor || fallbackStyles.backgroundColor,
 			textColor,
-			hoverColor: fallbackStyles.accentColor,
+			hoverColor: fallbacksValid
+				? fallbackStyles.accentColor
+				: undefined,
 			borderRadius: `${ attributes.borderRadius || 0 }px`,
 			borderWidth: `${ attributes.borderWidth || 0 }px`,
 			borderColor: attributes.borderColor,

--- a/client/blocks/cs-embed/edit.js
+++ b/client/blocks/cs-embed/edit.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
-import { View } from '@wordpress/primitives';
+import { useBlockProps } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
@@ -25,6 +25,7 @@ import Toolbar from './toolbar';
 import { STORE_NAME } from 'state';
 
 const EmbedForm = ( { attributes, setAttributes } ) => {
+	const blockProps = useBlockProps();
 	const [ isEditingURL, setIsEditingURL ] = useState( true );
 
 	const {
@@ -85,7 +86,7 @@ const EmbedForm = ( { attributes, setAttributes } ) => {
 
 	if ( fetching ) {
 		return (
-			<View>
+			<div { ...blockProps }>
 				<Sidebar
 					attributes={ attributes }
 					shouldPromote={ shouldPromote }
@@ -95,12 +96,12 @@ const EmbedForm = ( { attributes, setAttributes } ) => {
 				<Placeholder>
 					<EmbedLoading />
 				</Placeholder>
-			</View>
+			</div>
 		);
 	}
 
 	return (
-		<View>
+		<div { ...blockProps }>
 			<Sidebar
 				attributes={ attributes }
 				shouldPromote={ shouldPromote }
@@ -154,7 +155,7 @@ const EmbedForm = ( { attributes, setAttributes } ) => {
 					</ExternalLink>
 				</Placeholder>
 			) }
-		</View>
+		</div>
 	);
 };
 export default EmbedForm;

--- a/client/blocks/cs-embed/embed-preview.js
+++ b/client/blocks/cs-embed/embed-preview.js
@@ -2,12 +2,7 @@
  * WordPress dependencies
  */
 import { SandBox } from '@wordpress/components';
-import { useBlockProps } from '@wordpress/block-editor';
 
 export default function EmbedPreview( { html } ) {
-	return (
-		<div { ...useBlockProps() }>
-			<SandBox html={ html } />
-		</div>
-	);
+	return <SandBox html={ html } />;
 }

--- a/client/blocks/cs-embed/index.js
+++ b/client/blocks/cs-embed/index.js
@@ -13,6 +13,7 @@ import attributes from './attributes';
 import variations from './variations';
 
 export default {
+	apiVersion: 3,
 	title: __( 'Survey', 'crowdsignal-forms' ),
 	description: __(
 		'Create a multipage survey on crowdsignal.com and embed it.',
@@ -28,7 +29,4 @@ export default {
 	supports: {
 		align: [ 'center', 'wide', 'full' ],
 	},
-	getEditWrapperProps: ( { align } ) => ( {
-		'data-align': align,
-	} ),
 };

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -289,178 +289,178 @@ const EditFeedbackBlock = ( props ) => {
 
 	return (
 		<div { ...blockProps } ref={ mergedRef }>
-		<ConnectToCrowdsignal
-			blockName={ __( 'Feedback Button', 'crowdsignal-forms' ) }
-			blockIcon={ <FeedbackIcon /> }
-		>
-			<Toolbar
-				currentView={ view }
-				onViewChange={ setView }
-				{ ...props }
-			/>
-			<Sidebar
-				shouldPromote={ shouldPromote }
-				signalWarning={ signalWarning }
-				email={ email }
-				resolvedSurveyId={ resolvedSurveyId }
-				{ ...props }
-			/>
+			<ConnectToCrowdsignal
+				blockName={ __( 'Feedback Button', 'crowdsignal-forms' ) }
+				blockIcon={ <FeedbackIcon /> }
+			>
+				<Toolbar
+					currentView={ view }
+					onViewChange={ setView }
+					{ ...props }
+				/>
+				<Sidebar
+					shouldPromote={ shouldPromote }
+					signalWarning={ signalWarning }
+					email={ email }
+					resolvedSurveyId={ resolvedSurveyId }
+					{ ...props }
+				/>
 
-			{ widgetEditor && (
-				<>
-					{ ! isExample && ! widgetEditor && signalWarning && (
-						<SignalWarning />
-					) }
-					<EditorNotice
-						icon="warning"
-						status="warn"
-						isDismissible={ false }
-					>
-						{ __(
-							'This widget will appear in a fixed position as selected, in a corner or at an edge.',
-							'crowdsignal-forms'
+				{ widgetEditor && (
+					<>
+						{ ! isExample && ! widgetEditor && signalWarning && (
+							<SignalWarning />
 						) }
-					</EditorNotice>
-				</>
-			) }
+						<EditorNotice
+							icon="warning"
+							status="warn"
+							isDismissible={ false }
+						>
+							{ __(
+								'This widget will appear in a fixed position as selected, in a corner or at an edge.',
+								'crowdsignal-forms'
+							) }
+						</EditorNotice>
+					</>
+				) }
 
-			<div ref={ blockElement } className={ classes } style={ styles }>
-				<div className="crowdsignal-forms-feedback__trigger-preview">
-					<div className="wp-block-button crowdsignal-forms-feedback__trigger-wrapper">
-						<RichText
-							ref={ triggerButton }
-							className="wp-block-button__link crowdsignal-forms-feedback__trigger"
-							onChange={ handleChangeAttribute( 'triggerLabel' ) }
-							value={ triggerLabel }
-							allowedFormats={ [] }
-							multiline={ false }
-							disableLineBreaks={ true }
-						/>
+				<div ref={ blockElement } className={ classes } style={ styles }>
+					<div className="crowdsignal-forms-feedback__trigger-preview">
+						<div className="wp-block-button crowdsignal-forms-feedback__trigger-wrapper">
+							<RichText
+								ref={ triggerButton }
+								className="wp-block-button__link crowdsignal-forms-feedback__trigger"
+								onChange={ handleChangeAttribute( 'triggerLabel' ) }
+								value={ triggerLabel }
+								allowedFormats={ [] }
+								multiline={ false }
+								disableLineBreaks={ true }
+							/>
+						</div>
+					</div>
+
+					<div className="crowdsignal-forms-feedback__popover-preview">
+						{ ( isExample || isSelected || widgetEditor ) && (
+							<>
+								{ ! widgetEditor && (
+									<>
+										{ /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */ }
+										<div
+											aria-modal="true"
+											role="dialog"
+											className="crowdsignal-forms-feedback__popover-overlay"
+											onClick={ toggleBlock }
+											style={ overlayPosition }
+										/>
+									</>
+								) }
+
+								{ ! isExample &&
+									! widgetEditor &&
+									signalWarning && <SignalWarning /> }
+
+								{ view === views.QUESTION && (
+									<div
+										ref={ popover }
+										className="crowdsignal-forms-feedback__popover"
+									>
+										<RichText
+											tagName="h3"
+											className="crowdsignal-forms-feedback__header"
+											onChange={ handleChangeAttribute(
+												'header'
+											) }
+											value={ attributes.header }
+											allowedFormats={ [] }
+										/>
+
+										<TextareaControl
+											className="crowdsignal-forms-feedback__input"
+											rows={ 6 }
+											onChange={ handleChangeAttribute(
+												'feedbackPlaceholder'
+											) }
+											value={ attributes.feedbackPlaceholder }
+										/>
+
+										<TextControl
+											className="crowdsignal-forms-feedback__input"
+											onChange={ handleChangeAttribute(
+												'emailPlaceholder'
+											) }
+											value={ attributes.emailPlaceholder }
+										/>
+
+										<div className="wp-block-button crowdsignal-forms-feedback__button-wrapper">
+											<RichText
+												className="wp-block-button__link crowdsignal-forms-feedback__feedback-button"
+												onChange={ handleChangeAttribute(
+													'submitButtonLabel'
+												) }
+												value={
+													attributes.submitButtonLabel
+												}
+												allowedFormats={ [] }
+												multiline={ false }
+												disableLineBreaks={ true }
+											/>
+										</div>
+										{ ! hideBranding && (
+											<FooterBranding
+												trackRef="cs-forms-feedback"
+												message={ __(
+													'Collect your own feedback with Crowdsignal',
+													'crowdsignal-forms'
+												) }
+											>
+												<PromotionalTooltip />
+											</FooterBranding>
+										) }
+									</div>
+								) }
+
+								{ view === views.SUBMIT && (
+									<div
+										className="crowdsignal-forms-feedback__popover"
+										style={ popoverStyles }
+									>
+										<RichText
+											tagName="h3"
+											className="crowdsignal-forms-feedback__header"
+											onChange={ handleChangeAttribute(
+												'submitText'
+											) }
+											value={ attributes.submitText }
+											allowedFormats={ [] }
+										/>
+										{ ! hideBranding && (
+											<FooterBranding
+												trackRef="cs-forms-feedback"
+												message={ __(
+													'Collect your own feedback with Crowdsignal',
+													'crowdsignal-forms'
+												) }
+											>
+												<PromotionalTooltip />
+											</FooterBranding>
+										) }
+									</div>
+								) }
+								{ isClosed && (
+									<div className="crowdsignal-forms-feedback__closed-notice">
+										{ __(
+											'This Feedback Form is Closed',
+											'crowdsignal-forms'
+										) }
+									</div>
+								) }
+							</>
+						) }
 					</div>
 				</div>
 
-				<div className="crowdsignal-forms-feedback__popover-preview">
-					{ ( isExample || isSelected || widgetEditor ) && (
-						<>
-							{ ! widgetEditor && (
-								<>
-									{ /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */ }
-									<div
-										aria-modal="true"
-										role="dialog"
-										className="crowdsignal-forms-feedback__popover-overlay"
-										onClick={ toggleBlock }
-										style={ overlayPosition }
-									/>
-								</>
-							) }
-
-							{ ! isExample &&
-								! widgetEditor &&
-								signalWarning && <SignalWarning /> }
-
-							{ view === views.QUESTION && (
-								<div
-									ref={ popover }
-									className="crowdsignal-forms-feedback__popover"
-								>
-									<RichText
-										tagName="h3"
-										className="crowdsignal-forms-feedback__header"
-										onChange={ handleChangeAttribute(
-											'header'
-										) }
-										value={ attributes.header }
-										allowedFormats={ [] }
-									/>
-
-									<TextareaControl
-										className="crowdsignal-forms-feedback__input"
-										rows={ 6 }
-										onChange={ handleChangeAttribute(
-											'feedbackPlaceholder'
-										) }
-										value={ attributes.feedbackPlaceholder }
-									/>
-
-									<TextControl
-										className="crowdsignal-forms-feedback__input"
-										onChange={ handleChangeAttribute(
-											'emailPlaceholder'
-										) }
-										value={ attributes.emailPlaceholder }
-									/>
-
-									<div className="wp-block-button crowdsignal-forms-feedback__button-wrapper">
-										<RichText
-											className="wp-block-button__link crowdsignal-forms-feedback__feedback-button"
-											onChange={ handleChangeAttribute(
-												'submitButtonLabel'
-											) }
-											value={
-												attributes.submitButtonLabel
-											}
-											allowedFormats={ [] }
-											multiline={ false }
-											disableLineBreaks={ true }
-										/>
-									</div>
-									{ ! hideBranding && (
-										<FooterBranding
-											trackRef="cs-forms-feedback"
-											message={ __(
-												'Collect your own feedback with Crowdsignal',
-												'crowdsignal-forms'
-											) }
-										>
-											<PromotionalTooltip />
-										</FooterBranding>
-									) }
-								</div>
-							) }
-
-							{ view === views.SUBMIT && (
-								<div
-									className="crowdsignal-forms-feedback__popover"
-									style={ popoverStyles }
-								>
-									<RichText
-										tagName="h3"
-										className="crowdsignal-forms-feedback__header"
-										onChange={ handleChangeAttribute(
-											'submitText'
-										) }
-										value={ attributes.submitText }
-										allowedFormats={ [] }
-									/>
-									{ ! hideBranding && (
-										<FooterBranding
-											trackRef="cs-forms-feedback"
-											message={ __(
-												'Collect your own feedback with Crowdsignal',
-												'crowdsignal-forms'
-											) }
-										>
-											<PromotionalTooltip />
-										</FooterBranding>
-									) }
-								</div>
-							) }
-							{ isClosed && (
-								<div className="crowdsignal-forms-feedback__closed-notice">
-									{ __(
-										'This Feedback Form is Closed',
-										'crowdsignal-forms'
-									) }
-								</div>
-							) }
-						</>
-					) }
-				</div>
-			</div>
-
-			{ props.renderStyleProbe() }
-		</ConnectToCrowdsignal>
+				{ props.renderStyleProbe() }
+			</ConnectToCrowdsignal>
 		</div>
 	);
 };

--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -15,7 +15,7 @@ import { v4 as uuidv4 } from 'uuid';
 /**
  * WordPress depenencies
  */
-import { RichText } from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { TextControl, TextareaControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withSelect, dispatch, useSelect } from '@wordpress/data';
@@ -280,8 +280,15 @@ const EditFeedbackBlock = ( props ) => {
 		'hide-branding'
 	);
 
+	const blockProps = useBlockProps();
+	const mergedRef = ( node ) => {
+		if ( typeof blockProps.ref === 'function' ) blockProps.ref( node );
+		else if ( blockProps.ref ) blockProps.ref.current = node;
+		if ( props.fallbackStylesRef ) props.fallbackStylesRef( node );
+	};
+
 	return (
-		<div ref={ props.fallbackStylesRef }>
+		<div { ...blockProps } ref={ mergedRef }>
 		<ConnectToCrowdsignal
 			blockName={ __( 'Feedback Button', 'crowdsignal-forms' ) }
 			blockIcon={ <FeedbackIcon /> }

--- a/client/blocks/feedback/index.js
+++ b/client/blocks/feedback/index.js
@@ -11,6 +11,7 @@ import attributes from './attributes';
 import EditFeedbackBlock from './edit';
 
 export default {
+	apiVersion: 3,
 	title: __( 'Feedback Button', 'crowdsignal-forms' ),
 	description: __(
 		'Add an always visible button that allows your audience to share feedback anytime.',

--- a/client/blocks/feedback/util.js
+++ b/client/blocks/feedback/util.js
@@ -3,21 +3,38 @@
  */
 import { kebabCase, mapKeys } from 'lodash';
 
-export const getStyleVars = ( attributes, fallbackStyles ) =>
-	mapKeys(
+export const getStyleVars = ( attributes, fallbackStyles ) => {
+	// When the style probe can't detect proper theme button colors
+	// (e.g., in the iframed block editor), accentColor and textColorInverted
+	// both resolve to the same value. Don't set those CSS variables so the
+	// theme's .wp-block-button__link styles apply instead.
+	const fallbacksValid =
+		fallbackStyles.accentColor !== fallbackStyles.textColorInverted;
+
+	return mapKeys(
 		{
 			backgroundColor: attributes.backgroundColor || '#ffffff',
-			buttonColor: attributes.buttonColor || fallbackStyles.accentColor,
+			buttonColor:
+				attributes.buttonColor ||
+				( fallbacksValid ? fallbackStyles.accentColor : undefined ),
 			buttonTextColor:
-				attributes.buttonTextColor || fallbackStyles.textColorInverted,
+				attributes.buttonTextColor ||
+				( fallbacksValid
+					? fallbackStyles.textColorInverted
+					: undefined ),
 			textColor: attributes.textColor || fallbackStyles.textColor,
 			textSize: fallbackStyles.textSize,
 			triggerBackgroundColor:
-				attributes.triggerBackgroundColor || fallbackStyles.accentColor,
+				attributes.triggerBackgroundColor ||
+				( fallbacksValid ? fallbackStyles.accentColor : undefined ),
 			triggerTextColor:
-				attributes.triggerTextColor || fallbackStyles.textColorInverted,
+				attributes.triggerTextColor ||
+				( fallbacksValid
+					? fallbackStyles.textColorInverted
+					: undefined ),
 		},
 		( _, key ) => `--crowdsignal-forms-${ kebabCase( key ) }`
 	);
+};
 
 export const isWidgetEditor = () => !! window.wp.customizeWidgets;

--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -105,189 +105,189 @@ const EditNpsBlock = ( props ) => {
 
 	return (
 		<div { ...blockProps } ref={ mergedRef }>
-		<ConnectToCrowdsignal
-			blockIcon={ null }
-			blockName={ __( 'Crowdsignal NPS', 'crowdsignal-forms' ) }
-		>
-			<Toolbar
-				currentView={ view }
-				onViewChange={ setView }
-				{ ...props }
-			/>
-			<Sidebar
-				shouldPromote={ shouldPromote }
-				signalWarning={ signalWarning }
-				resolvedSurveyId={ resolvedSurveyId }
-				{ ...props }
-			/>
-			{ ! isExample && signalWarning && <SignalWarning /> }
+			<ConnectToCrowdsignal
+				blockIcon={ null }
+				blockName={ __( 'Crowdsignal NPS', 'crowdsignal-forms' ) }
+			>
+				<Toolbar
+					currentView={ view }
+					onViewChange={ setView }
+					{ ...props }
+				/>
+				<Sidebar
+					shouldPromote={ shouldPromote }
+					signalWarning={ signalWarning }
+					resolvedSurveyId={ resolvedSurveyId }
+					{ ...props }
+				/>
+				{ ! isExample && signalWarning && <SignalWarning /> }
 
-			{ ! isExample && (
-				<EditorNotice
-					isDismissible={ false }
-					icon="visibility"
-					componentActions={ [
-						// Temporarily disabled to prevent block render error,
-						// until we can figure out why it is breaking (maybe a new WP version?)
-						// <PostPreviewButton
-						// 	key={ 1 }
-						// 	className={ [
-						// 		'is-secondary',
-						// 		'components-notice__action',
-						// 		'crowdsignal-forms-nps__preview-button',
-						// 		attributes.surveyId ? '' : 'is-disabled',
-						// 	] }
-						// 	textContent={ __( 'Preview', 'crowdsignal-forms' ) }
-						// />,
-					] }
-				>
-					{ sprintf(
-						/* translators: %d: number of pageviews */
-						_n(
-							'This block will appear as a popup window to people who have visited this page at least %d time.',
-							'This block will appear as a popup window to people who have visited this page at least %d times.',
-							viewThreshold,
-							'crowdsignal-forms'
-						),
-						viewThreshold
-					) }
-				</EditorNotice>
-			) }
-
-			{ ( view === views.RATING || ! isSelected ) && (
-				<div
-					className={ classes }
-					style={ getStyleVars( attributes, fallbackStyles ) }
-				>
-					<RichText
-						tagName="h3"
-						className="crowdsignal-forms-nps__question"
-						placeholder={ __(
-							'Enter your rating question',
-							'crowdsignal-forms'
+				{ ! isExample && (
+					<EditorNotice
+						isDismissible={ false }
+						icon="visibility"
+						componentActions={ [
+							// Temporarily disabled to prevent block render error,
+							// until we can figure out why it is breaking (maybe a new WP version?)
+							// <PostPreviewButton
+							// 	key={ 1 }
+							// 	className={ [
+							// 		'is-secondary',
+							// 		'components-notice__action',
+							// 		'crowdsignal-forms-nps__preview-button',
+							// 		attributes.surveyId ? '' : 'is-disabled',
+							// 	] }
+							// 	textContent={ __( 'Preview', 'crowdsignal-forms' ) }
+							// />,
+						] }
+					>
+						{ sprintf(
+							/* translators: %d: number of pageviews */
+							_n(
+								'This block will appear as a popup window to people who have visited this page at least %d time.',
+								'This block will appear as a popup window to people who have visited this page at least %d times.',
+								viewThreshold,
+								'crowdsignal-forms'
+							),
+							viewThreshold
 						) }
-						onChange={ handleChangeAttribute( 'ratingQuestion' ) }
-						value={ ratingQuestion }
-						allowedFormats={ [] }
-					/>
+					</EditorNotice>
+				) }
 
-					<div className="crowdsignal-forms-nps__rating">
-						<div className="crowdsignal-forms-nps__rating-labels">
-							<RichText
-								tagName="span"
-								placeholder={ __(
-									'Not likely',
-									'crowdsignal-forms'
-								) }
-								onChange={ handleChangeAttribute(
-									'lowRatingLabel'
-								) }
-								value={ attributes.lowRatingLabel }
-								allowedFormats={ [] }
-								multiline={ false }
-								disableLineBreaks={ true }
-							/>
-							<RichText
-								tagName="span"
-								placeholder={ __(
-									'Very likely',
-									'crowdsignal-forms'
-								) }
-								onChange={ handleChangeAttribute(
-									'highRatingLabel'
-								) }
-								value={ attributes.highRatingLabel }
-								allowedFormats={ [] }
-								multiline={ false }
-								disableLineBreaks={ true }
-							/>
-						</div>
-
-						<div className="crowdsignal-forms-nps__rating-scale">
-							{ times( 11, ( n ) => (
-								<div
-									key={ `rating-${ n }` }
-									className="crowdsignal-forms-nps__rating-button"
-								>
-									{ n }
-								</div>
-							) ) }
-						</div>
-
-						{ ! hideBranding && (
-							<FooterBranding
-								trackRef="cs-forms-nps"
-								message={ __(
-									'Collect your own feedback with Crowdsignal',
-									'crowdsignal-forms'
-								) }
-							>
-								<PromotionalTooltip />
-							</FooterBranding>
-						) }
-					</div>
-				</div>
-			) }
-
-			{ view === views.FEEDBACK && isSelected && (
-				<div
-					className={ classes }
-					style={ getStyleVars( attributes, fallbackStyles ) }
-				>
-					<div className="crowdsignal-forms-nps__feedback">
+				{ ( view === views.RATING || ! isSelected ) && (
+					<div
+						className={ classes }
+						style={ getStyleVars( attributes, fallbackStyles ) }
+					>
 						<RichText
 							tagName="h3"
 							className="crowdsignal-forms-nps__question"
 							placeholder={ __(
-								'Enter your feedback question',
+								'Enter your rating question',
 								'crowdsignal-forms'
 							) }
-							onChange={ handleChangeAttribute(
-								'feedbackQuestion'
-							) }
-							value={ feedbackQuestion }
+							onChange={ handleChangeAttribute( 'ratingQuestion' ) }
+							value={ ratingQuestion }
 							allowedFormats={ [] }
 						/>
 
-						<TextareaControl
-							className="crowdsignal-forms-nps__feedback-text"
-							rows={ 6 }
-							onChange={ handleChangeAttribute(
-								'feedbackPlaceholder'
+						<div className="crowdsignal-forms-nps__rating">
+							<div className="crowdsignal-forms-nps__rating-labels">
+								<RichText
+									tagName="span"
+									placeholder={ __(
+										'Not likely',
+										'crowdsignal-forms'
+									) }
+									onChange={ handleChangeAttribute(
+										'lowRatingLabel'
+									) }
+									value={ attributes.lowRatingLabel }
+									allowedFormats={ [] }
+									multiline={ false }
+									disableLineBreaks={ true }
+								/>
+								<RichText
+									tagName="span"
+									placeholder={ __(
+										'Very likely',
+										'crowdsignal-forms'
+									) }
+									onChange={ handleChangeAttribute(
+										'highRatingLabel'
+									) }
+									value={ attributes.highRatingLabel }
+									allowedFormats={ [] }
+									multiline={ false }
+									disableLineBreaks={ true }
+								/>
+							</div>
+
+							<div className="crowdsignal-forms-nps__rating-scale">
+								{ times( 11, ( n ) => (
+									<div
+										key={ `rating-${ n }` }
+										className="crowdsignal-forms-nps__rating-button"
+									>
+										{ n }
+									</div>
+								) ) }
+							</div>
+
+							{ ! hideBranding && (
+								<FooterBranding
+									trackRef="cs-forms-nps"
+									message={ __(
+										'Collect your own feedback with Crowdsignal',
+										'crowdsignal-forms'
+									) }
+								>
+									<PromotionalTooltip />
+								</FooterBranding>
 							) }
-							value={ attributes.feedbackPlaceholder }
-						/>
-
-						<div className="wp-block-button crowdsignal-forms-nps__feedback-button-wrapper">
-							<RichText
-								className="wp-block-button__link crowdsignal-forms-nps__feedback-button"
-								onChange={ handleChangeAttribute(
-									'submitButtonLabel'
-								) }
-								value={ attributes.submitButtonLabel }
-								allowedFormats={ [] }
-								multiline={ false }
-								disableLineBreaks={ true }
-							/>
 						</div>
+					</div>
+				) }
 
-						{ ! hideBranding && (
-							<FooterBranding
-								trackRef="cs-forms-nps"
-								message={ __(
-									'Collect your own feedback with Crowdsignal',
+				{ view === views.FEEDBACK && isSelected && (
+					<div
+						className={ classes }
+						style={ getStyleVars( attributes, fallbackStyles ) }
+					>
+						<div className="crowdsignal-forms-nps__feedback">
+							<RichText
+								tagName="h3"
+								className="crowdsignal-forms-nps__question"
+								placeholder={ __(
+									'Enter your feedback question',
 									'crowdsignal-forms'
 								) }
-							>
-								<PromotionalTooltip />
-							</FooterBranding>
-						) }
-					</div>
-				</div>
-			) }
+								onChange={ handleChangeAttribute(
+									'feedbackQuestion'
+								) }
+								value={ feedbackQuestion }
+								allowedFormats={ [] }
+							/>
 
-			{ renderStyleProbe() }
-		</ConnectToCrowdsignal>
+							<TextareaControl
+								className="crowdsignal-forms-nps__feedback-text"
+								rows={ 6 }
+								onChange={ handleChangeAttribute(
+									'feedbackPlaceholder'
+								) }
+								value={ attributes.feedbackPlaceholder }
+							/>
+
+							<div className="wp-block-button crowdsignal-forms-nps__feedback-button-wrapper">
+								<RichText
+									className="wp-block-button__link crowdsignal-forms-nps__feedback-button"
+									onChange={ handleChangeAttribute(
+										'submitButtonLabel'
+									) }
+									value={ attributes.submitButtonLabel }
+									allowedFormats={ [] }
+									multiline={ false }
+									disableLineBreaks={ true }
+								/>
+							</div>
+
+							{ ! hideBranding && (
+								<FooterBranding
+									trackRef="cs-forms-nps"
+									message={ __(
+										'Collect your own feedback with Crowdsignal',
+										'crowdsignal-forms'
+									) }
+								>
+									<PromotionalTooltip />
+								</FooterBranding>
+							) }
+						</div>
+					</div>
+				) }
+
+				{ renderStyleProbe() }
+			</ConnectToCrowdsignal>
 		</div>
 	);
 };

--- a/client/blocks/nps/edit.js
+++ b/client/blocks/nps/edit.js
@@ -10,7 +10,7 @@ import { v4 as uuidv4 } from 'uuid';
  * WordPress dependencies
  */
 import { TextareaControl } from '@wordpress/components';
-import { RichText } from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -96,8 +96,15 @@ const EditNpsBlock = ( props ) => {
 		get( accountInfo, [ 'signalCount', 'count' ] ) >=
 			get( accountInfo, [ 'signalCount', 'userLimit' ] );
 
+	const blockProps = useBlockProps();
+	const mergedRef = ( node ) => {
+		if ( typeof blockProps.ref === 'function' ) blockProps.ref( node );
+		else if ( blockProps.ref ) blockProps.ref.current = node;
+		if ( fallbackStylesRef ) fallbackStylesRef( node );
+	};
+
 	return (
-		<div ref={ fallbackStylesRef }>
+		<div { ...blockProps } ref={ mergedRef }>
 		<ConnectToCrowdsignal
 			blockIcon={ null }
 			blockName={ __( 'Crowdsignal NPS', 'crowdsignal-forms' ) }

--- a/client/blocks/nps/index.js
+++ b/client/blocks/nps/index.js
@@ -11,6 +11,7 @@ import attributes from './attributes';
 import edit from './edit';
 
 export default {
+	apiVersion: 3,
 	title: __( 'Measure NPS', 'crowdsignal-forms' ),
 	description: __(
 		'Calculate your Net Promoter Score! Collect feedback and track customer satisfaction over time. — powered by Crowdsignal.',

--- a/client/blocks/poll/edit.js
+++ b/client/blocks/poll/edit.js
@@ -162,140 +162,140 @@ const PollBlock = ( props ) => {
 
 	return (
 		<div { ...blockProps }>
-		<ConnectToCrowdsignal
-			blockIcon={ <PollIcon /> }
-			blockName={ __( 'Crowdsignal Poll', 'crowdsignal-forms' ) }
-		>
-			<Toolbar { ...props } />
-			<SideBar
-				{ ...props }
-				viewResultsUrl={ viewResultsUrl }
-				shouldPromote={ shouldPromote }
-				signalWarning={ signalWarning }
-			/>
-			{ signalWarning && <SignalWarning /> }
-			<ResizableBox
-				className="crowdsignal-forms-poll__resize-wrapper"
-				size={ { height: 'auto', width: blockWidth } }
-				minWidth="25%"
-				maxWidth="100%"
-				enable={ { left: true, right: true } }
-				onResizeStop={ handleResize }
-				showHandle={ isResizable }
-				resizeRatio={ 2 }
+			<ConnectToCrowdsignal
+				blockIcon={ <PollIcon /> }
+				blockName={ __( 'Crowdsignal Poll', 'crowdsignal-forms' ) }
 			>
-				<div
-					ref={ fallbackStylesRef }
-					className={ getBlockCssClasses(
-						attributes,
-						className,
-						{
-							'is-selected-in-editor': isSelected,
-							'is-closed': isClosed,
-							'is-hidden': isHidden,
-						},
-						'crowdsignal-forms-poll'
-					) }
-					style={ getStyleVars( attributes, fallbackStyles ) }
+				<Toolbar { ...props } />
+				<SideBar
+					{ ...props }
+					viewResultsUrl={ viewResultsUrl }
+					shouldPromote={ shouldPromote }
+					signalWarning={ signalWarning }
+				/>
+				{ signalWarning && <SignalWarning /> }
+				<ResizableBox
+					className="crowdsignal-forms-poll__resize-wrapper"
+					size={ { height: 'auto', width: blockWidth } }
+					minWidth="25%"
+					maxWidth="100%"
+					enable={ { left: true, right: true } }
+					onResizeStop={ handleResize }
+					showHandle={ isResizable }
+					resizeRatio={ 2 }
 				>
-					{ showEditBar && (
-						<EditBar
-							onEditClick={ () => {
-								setIsPollEditable( true );
-							} }
-						/>
-					) }
-					{ errorMessage && (
-						<ErrorBanner>{ errorMessage }</ErrorBanner>
-					) }
-					<div className="crowdsignal-forms-poll__content">
-						{ isPollEditable ? (
-							<RichText
-								tagName="h3"
-								className="crowdsignal-forms-poll__question"
-								placeholder={ __(
-									'Enter your question',
-									'crowdsignal-forms'
-								) }
-								onChange={ handleChangeQuestion }
-								value={ attributes.question }
-								allowedFormats={ [] }
-								disableLineBreaks={ true }
+					<div
+						ref={ fallbackStylesRef }
+						className={ getBlockCssClasses(
+							attributes,
+							className,
+							{
+								'is-selected-in-editor': isSelected,
+								'is-closed': isClosed,
+								'is-hidden': isHidden,
+							},
+							'crowdsignal-forms-poll'
+						) }
+						style={ getStyleVars( attributes, fallbackStyles ) }
+					>
+						{ showEditBar && (
+							<EditBar
+								onEditClick={ () => {
+									setIsPollEditable( true );
+								} }
 							/>
-						) : (
-							<h3 className="crowdsignal-forms-poll__question">
-								{ attributes.question ||
-									__(
+						) }
+						{ errorMessage && (
+							<ErrorBanner>{ errorMessage }</ErrorBanner>
+						) }
+						<div className="crowdsignal-forms-poll__content">
+							{ isPollEditable ? (
+								<RichText
+									tagName="h3"
+									className="crowdsignal-forms-poll__question"
+									placeholder={ __(
 										'Enter your question',
 										'crowdsignal-forms'
 									) }
-							</h3>
-						) }
-
-						{ showNote &&
-							( isPollEditable ? (
-								<RichText
-									tagName="p"
-									className="crowdsignal-forms-poll__note"
-									placeholder={ __(
-										'Add a note (optional)',
-										'crowdsignal-forms'
-									) }
-									onChange={ handleChangeNote }
-									value={ attributes.note }
+									onChange={ handleChangeQuestion }
+									value={ attributes.question }
 									allowedFormats={ [] }
 									disableLineBreaks={ true }
 								/>
 							) : (
-								<div className="crowdsignal-forms-poll__note">
-									{ attributes.note ||
+								<h3 className="crowdsignal-forms-poll__question">
+									{ attributes.question ||
 										__(
+											'Enter your question',
+											'crowdsignal-forms'
+										) }
+								</h3>
+							) }
+
+							{ showNote &&
+								( isPollEditable ? (
+									<RichText
+										tagName="p"
+										className="crowdsignal-forms-poll__note"
+										placeholder={ __(
 											'Add a note (optional)',
 											'crowdsignal-forms'
 										) }
-								</div>
-							) ) }
+										onChange={ handleChangeNote }
+										value={ attributes.note }
+										allowedFormats={ [] }
+										disableLineBreaks={ true }
+									/>
+								) : (
+									<div className="crowdsignal-forms-poll__note">
+										{ attributes.note ||
+											__(
+												'Add a note (optional)',
+												'crowdsignal-forms'
+											) }
+									</div>
+								) ) }
 
-						{ ! showResults && (
-							<EditAnswers
-								{ ...props }
-								setAttributes={ setAttributes }
-								disabled={ ! isPollEditable }
-								answerStyle={ answerStyle }
-								buttonAlignment={ attributes.buttonAlignment }
+							{ ! showResults && (
+								<EditAnswers
+									{ ...props }
+									setAttributes={ setAttributes }
+									disabled={ ! isPollEditable }
+									answerStyle={ answerStyle }
+									buttonAlignment={ attributes.buttonAlignment }
+								/>
+							) }
+
+							{ showResults && (
+								<PollResults
+									answers={ addApiAnswerIds(
+										filter(
+											attributes.answers,
+											( answer ) => ! isAnswerEmpty( answer )
+										),
+										answerIdMap
+									) }
+									pollIdFromApi={ pollIdFromApi }
+									hideBranding={ hideBranding }
+									setErrorMessage={ setErrorMessage }
+								/>
+							) }
+							{ ! hideBranding && (
+								<FooterBranding />
+							) }
+						</div>
+
+						{ isClosed && (
+							<ClosedBanner
+								isPollHidden={ isHidden }
+								isPollClosed={ isClosed }
 							/>
 						) }
 
-						{ showResults && (
-							<PollResults
-								answers={ addApiAnswerIds(
-									filter(
-										attributes.answers,
-										( answer ) => ! isAnswerEmpty( answer )
-									),
-									answerIdMap
-								) }
-								pollIdFromApi={ pollIdFromApi }
-								hideBranding={ hideBranding }
-								setErrorMessage={ setErrorMessage }
-							/>
-						) }
-						{ ! hideBranding && (
-							<FooterBranding />
-						) }
+						{ renderStyleProbe() }
 					</div>
-
-					{ isClosed && (
-						<ClosedBanner
-							isPollHidden={ isHidden }
-							isPollClosed={ isClosed }
-						/>
-					) }
-
-					{ renderStyleProbe() }
-				</div>
-			</ResizableBox>
-		</ConnectToCrowdsignal>
+				</ResizableBox>
+			</ConnectToCrowdsignal>
 		</div>
 	);
 };

--- a/client/blocks/poll/edit.js
+++ b/client/blocks/poll/edit.js
@@ -7,7 +7,7 @@ import { get, filter, isEmpty, map, round, some } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { ResizableBox } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -81,6 +81,8 @@ const PollBlock = ( props ) => {
 		renderStyleProbe,
 		pollDataFromApi,
 	} = props;
+
+	const blockProps = useBlockProps();
 
 	const [ isPollEditable, setIsPollEditable ] = useState( true );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
@@ -159,6 +161,7 @@ const PollBlock = ( props ) => {
 			get( accountInfo, [ 'signalCount', 'userLimit' ] );
 
 	return (
+		<div { ...blockProps }>
 		<ConnectToCrowdsignal
 			blockIcon={ <PollIcon /> }
 			blockName={ __( 'Crowdsignal Poll', 'crowdsignal-forms' ) }
@@ -293,6 +296,7 @@ const PollBlock = ( props ) => {
 				</div>
 			</ResizableBox>
 		</ConnectToCrowdsignal>
+		</div>
 	);
 };
 

--- a/client/blocks/poll/edit.scss
+++ b/client/blocks/poll/edit.scss
@@ -7,11 +7,16 @@
 		margin-right: 0;
 	}
 
+	// Alignment: with apiVersion 3 + useBlockProps, core puts alignwide/alignfull on the
+	// block list wrapper. Older setups used getEditWrapperProps data-align — keep both.
+	.block-editor-block-list__block[data-type="crowdsignal-forms/poll"].alignfull .crowdsignal-forms-poll,
 	.block-editor-block-list__block[data-type="crowdsignal-forms/poll"][data-align="full"] .crowdsignal-forms-poll {
 		border-left-width: 0;
 		border-right-width: 0;
 	}
 
+	.block-editor-block-list__block[data-type="crowdsignal-forms/poll"].alignwide .crowdsignal-forms-poll__content,
+	.block-editor-block-list__block[data-type="crowdsignal-forms/poll"].alignfull .crowdsignal-forms-poll__content,
 	.block-editor-block-list__block[data-type="crowdsignal-forms/poll"][data-align="wide"] .crowdsignal-forms-poll__content,
 	.block-editor-block-list__block[data-type="crowdsignal-forms/poll"][data-align="full"] .crowdsignal-forms-poll__content {
 

--- a/client/blocks/poll/index.js
+++ b/client/blocks/poll/index.js
@@ -12,6 +12,7 @@ import EditPollBlock from './edit';
 import attributes from './attributes';
 
 export default {
+	apiVersion: 3,
 	title: __( 'Poll', 'crowdsignal-forms' ),
 	description: __(
 		'Create polls and get your audience’s opinion — powered by Crowdsignal.',
@@ -39,9 +40,6 @@ export default {
 	supports: {
 		align: [ 'center', 'wide', 'full' ],
 	},
-	getEditWrapperProps: ( { align } ) => ( {
-		'data-align': align,
-	} ),
 	example: {
 		attributes: {
 			question: __( 'How did you hear about us?', 'crowdsignal-forms' ),

--- a/client/blocks/vote-item/edit.js
+++ b/client/blocks/vote-item/edit.js
@@ -6,6 +6,7 @@ import React from 'react';
 /**
  * WordPress dependencies
  */
+import { useBlockProps } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 
 /**
@@ -19,8 +20,15 @@ import { withFallbackStyles } from 'components/with-fallback-styles';
 const EditVoteItemBlock = ( props ) => {
 	const { attributes, className, fallbackStyles, fallbackStylesRef, renderStyleProbe } = props;
 
+	const blockProps = useBlockProps();
+	const mergedRef = ( node ) => {
+		if ( typeof blockProps.ref === 'function' ) blockProps.ref( node );
+		else if ( blockProps.ref ) blockProps.ref.current = node;
+		if ( fallbackStylesRef ) fallbackStylesRef( node );
+	};
+
 	return (
-		<div ref={ fallbackStylesRef }>
+		<div { ...blockProps } ref={ mergedRef }>
 			<SideBar { ...props } />
 
 			<VoteItem

--- a/client/blocks/vote-item/index.js
+++ b/client/blocks/vote-item/index.js
@@ -11,6 +11,7 @@ import EditVoteItemBlock from './edit';
 import attributes from './attributes';
 
 export default {
+	apiVersion: 3,
 	title: __( 'Vote Item', 'crowdsignal-forms' ),
 	description: __(
 		'Allow your audience to rate your work or express their opinion — powered by Crowdsignal.',

--- a/client/blocks/vote/edit.js
+++ b/client/blocks/vote/edit.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
@@ -29,6 +29,7 @@ import withFseCheck from 'components/with-fse-check';
 
 const EditVoteBlock = ( props ) => {
 	const { attributes, setAttributes, className, pollDataFromApi } = props;
+	const blockProps = useBlockProps();
 
 	useNumberedTitle(
 		props.name,
@@ -72,6 +73,7 @@ const EditVoteBlock = ( props ) => {
 			get( accountInfo, [ 'signalCount', 'userLimit' ] );
 
 	return (
+		<div { ...blockProps }>
 		<ConnectToCrowdsignal
 			blockIcon={ null }
 			blockName={ __( 'Crowdsignal Vote', 'crowdsignal-forms' ) }
@@ -99,6 +101,7 @@ const EditVoteBlock = ( props ) => {
 				</div>
 			</div>
 		</ConnectToCrowdsignal>
+		</div>
 	);
 };
 

--- a/client/blocks/vote/edit.js
+++ b/client/blocks/vote/edit.js
@@ -74,33 +74,33 @@ const EditVoteBlock = ( props ) => {
 
 	return (
 		<div { ...blockProps }>
-		<ConnectToCrowdsignal
-			blockIcon={ null }
-			blockName={ __( 'Crowdsignal Vote', 'crowdsignal-forms' ) }
-		>
-			<SideBar
-				{ ...props }
-				shouldPromote={ shouldPromote }
-				signalWarning={ signalWarning }
-				viewResultsUrl={ viewResultsUrl }
-			/>
-			<ToolBar { ...props } />
+			<ConnectToCrowdsignal
+				blockIcon={ null }
+				blockName={ __( 'Crowdsignal Vote', 'crowdsignal-forms' ) }
+			>
+				<SideBar
+					{ ...props }
+					shouldPromote={ shouldPromote }
+					signalWarning={ signalWarning }
+					viewResultsUrl={ viewResultsUrl }
+				/>
+				<ToolBar { ...props } />
 
-			<div className={ classes } style={ voteItemStyleVars }>
-				<div className="crowdsignal-forms-vote__items">
-					<InnerBlocks
-						template={ [
-							[ 'crowdsignal-forms/vote-item', { type: 'up' } ],
-							[ 'crowdsignal-forms/vote-item', { type: 'down' } ],
-						] }
-						templateInsertUpdatesSelection={ false }
-						allowedBlocks={ [ 'crowdsignal-forms/vote-item' ] }
-						orientation="horizontal"
-						__experimentalMoverDirection="horizontal" // required for pre WP 5.5, post 5.5 only requires `orientation` to be set
-					/>
+				<div className={ classes } style={ voteItemStyleVars }>
+					<div className="crowdsignal-forms-vote__items">
+						<InnerBlocks
+							template={ [
+								[ 'crowdsignal-forms/vote-item', { type: 'up' } ],
+								[ 'crowdsignal-forms/vote-item', { type: 'down' } ],
+							] }
+							templateInsertUpdatesSelection={ false }
+							allowedBlocks={ [ 'crowdsignal-forms/vote-item' ] }
+							orientation="horizontal"
+							__experimentalMoverDirection="horizontal" // required for pre WP 5.5, post 5.5 only requires `orientation` to be set
+						/>
+					</div>
 				</div>
-			</div>
-		</ConnectToCrowdsignal>
+			</ConnectToCrowdsignal>
 		</div>
 	);
 };

--- a/client/blocks/vote/index.js
+++ b/client/blocks/vote/index.js
@@ -12,6 +12,7 @@ import EditVoteBlock from './edit';
 import attributes from './attributes';
 
 export default {
+	apiVersion: 3,
 	title: __( 'Vote', 'crowdsignal-forms' ),
 	description: __(
 		'Allow your audience to rate your work or express their opinion — powered by Crowdsignal.',


### PR DESCRIPTION
## Summary

Depends on #305.

WordPress 7.0 deprecates Block API versions 1 and 2. All 7 Crowdsignal Forms
blocks default to v1 (no `apiVersion` declared), producing deprecation warnings
and preventing the editor from running blocks inside its iframe.

See [Migrating Blocks for iframe Editor Compatibility](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/block-migration-for-iframe-editor-compatibility/).

This PR adds `apiVersion: 3` and `useBlockProps()` to every block:

- **All 7 blocks:** added `apiVersion: 3` to block registration
- **Blocks with `withFallbackStyles`** (poll, vote-item, nps, feedback):
  merged `blockProps.ref` with `fallbackStylesRef` via a callback ref so
  both the editor and the style-measurement HOC share a single DOM node
- **Blocks without** (vote, applause): wrapped edit output in
  `<div {...useBlockProps()}>`
- **cs-embed:** moved `useBlockProps()` from `embed-preview.js` up to
  `edit.js` (called once at the top, before conditional returns); replaced
  `<View>` with `<div {...blockProps}>`
- **poll, cs-embed:** removed `getEditWrapperProps` (redundant with
  `supports.align` + `useBlockProps`)
- **poll/edit.scss:** added `.alignwide` / `.alignfull` class selectors
  alongside the legacy `[data-align]` selectors, since `useBlockProps`
  applies alignment via class names instead of data attributes

Vote block save remains `() => <InnerBlocks.Content />` — this is correct
for dynamic blocks where PHP controls the output.

### Files changed (16 files)

**Block registration** (`apiVersion: 3`):
- `client/blocks/{poll,vote,vote-item,applause,nps,feedback,cs-embed}/index.js`

**Edit components** (`useBlockProps`):
- `client/blocks/{poll,vote,vote-item,applause,nps,feedback,cs-embed}/edit.js`
- `client/blocks/cs-embed/embed-preview.js` (removed useBlockProps, now in parent)

**Styles:**
- `client/blocks/poll/edit.scss`

## Testing

1. Build: `nvm use 18 && pnpm build` — no errors
2. Open the block editor in WordPress 6.9+ or 7.0 — insert each of the 7
   block types and confirm **zero** Block API deprecation warnings in the
   console
3. Edit an existing post containing vote or cs-embed blocks — confirm no
   "block recovery" prompt
4. Set poll alignment to wide and full — confirm padding/border styles apply
   correctly (inspect DOM for `.alignwide`/`.alignfull` classes)