### PR TITLE
Make editor DOM access iframe-safe for Block API v3

### DIFF
--- a/client/blocks/feedback/edit.js
+++ b/client/blocks/feedback/edit.js
@@ -100,7 +100,8 @@ const EditFeedbackBlock = ( props ) => {
 		// The sidebar itself is rendered off the same setting
 		// hence the need to wait until it's re-rendered
 		// so we can measure it properly.
-		window.requestAnimationFrame( () =>
+		const win = blockElement.current?.ownerDocument.defaultView ?? window;
+		win.requestAnimationFrame( () =>
 			setSidebarChanged( ! sidebarChanged )
 		);
 	}, [ isInserterActive, isListViewActive, isSidebarActive ] );
@@ -109,6 +110,9 @@ const EditFeedbackBlock = ( props ) => {
 		if ( isExample || ! triggerButton.current || widgetEditor ) {
 			return;
 		}
+
+		const doc = blockElement.current.ownerDocument;
+		const win = doc.defaultView;
 
 		setPosition(
 			getFeedbackButtonPosition(
@@ -122,9 +126,10 @@ const EditFeedbackBlock = ( props ) => {
 					top: isSelected ? 80 : 20,
 					bottom: 20,
 				},
-				document.getElementsByClassName(
+				doc.getElementsByClassName(
 					'interface-interface-skeleton__content'
-				)[ 0 ]
+				)[ 0 ],
+				win
 			),
 			triggerButton.current.offsetWidth,
 			triggerButton.current.offsetHeight
@@ -183,10 +188,18 @@ const EditFeedbackBlock = ( props ) => {
 			return;
 		}
 
-		if (
-			triggerButton.current &&
-			triggerButton.current.ownerDocument !== document
-		) {
+		if ( ! triggerButton.current ) {
+			return;
+		}
+
+		const doc = triggerButton.current.ownerDocument;
+		const win = doc.defaultView;
+
+		const contentWrapper = doc.getElementsByClassName(
+			'interface-interface-skeleton__content'
+		)[ 0 ];
+
+		if ( ! contentWrapper ) {
 			setOverlayPosition( {
 				bottom: 0,
 				left: 0,
@@ -197,15 +210,12 @@ const EditFeedbackBlock = ( props ) => {
 			return;
 		}
 
-		const contentWrapper = document.getElementsByClassName(
-			'interface-interface-skeleton__content'
-		)[ 0 ];
 		const contentBox = contentWrapper.getBoundingClientRect();
 
 		setOverlayPosition( {
-			bottom: window.innerHeight - ( contentBox.top + contentBox.height ),
+			bottom: win.innerHeight - ( contentBox.top + contentBox.height ),
 			left: contentBox.left,
-			right: window.innerWidth - ( contentBox.left + contentBox.width ),
+			right: win.innerWidth - ( contentBox.left + contentBox.width ),
 			top: contentBox.top,
 		} );
 	}, [ sidebarChanged, isFullscreen, isSelected, triggerButton.current ] );

--- a/client/blocks/poll/edit.js
+++ b/client/blocks/poll/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { get, filter, isEmpty, map, round, some } from 'lodash';
 
 /**
@@ -83,6 +83,7 @@ const PollBlock = ( props ) => {
 	} = props;
 
 	const blockProps = useBlockProps();
+	const blockRef = useRef( null );
 
 	const [ isPollEditable, setIsPollEditable ] = useState( true );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
@@ -147,8 +148,8 @@ const PollBlock = ( props ) => {
 
 	const answerStyle = getAnswerStyle( attributes, className );
 
-	if ( attributes.fontFamily ) {
-		loadCustomFont( attributes.fontFamily );
+	if ( attributes.fontFamily && blockRef.current ) {
+		loadCustomFont( attributes.fontFamily, blockRef.current.ownerDocument );
 	}
 
 	const shouldPromote = get( accountInfo, [
@@ -160,8 +161,14 @@ const PollBlock = ( props ) => {
 		get( accountInfo, [ 'signalCount', 'count' ] ) >=
 			get( accountInfo, [ 'signalCount', 'userLimit' ] );
 
+	const mergedBlockRef = ( node ) => {
+		if ( typeof blockProps.ref === 'function' ) blockProps.ref( node );
+		else if ( blockProps.ref ) blockProps.ref.current = node;
+		blockRef.current = node;
+	};
+
 	return (
-		<div { ...blockProps }>
+		<div { ...blockProps } ref={ mergedBlockRef }>
 			<ConnectToCrowdsignal
 				blockIcon={ <PollIcon /> }
 				blockName={ __( 'Crowdsignal Poll', 'crowdsignal-forms' ) }

--- a/client/blocks/poll/edit.js
+++ b/client/blocks/poll/edit.js
@@ -148,9 +148,11 @@ const PollBlock = ( props ) => {
 
 	const answerStyle = getAnswerStyle( attributes, className );
 
-	if ( attributes.fontFamily && blockRef.current ) {
-		loadCustomFont( attributes.fontFamily, blockRef.current.ownerDocument );
-	}
+	useEffect( () => {
+		if ( attributes.fontFamily && blockRef.current ) {
+			loadCustomFont( attributes.fontFamily, blockRef.current.ownerDocument );
+		}
+	}, [ attributes.fontFamily ] );
 
 	const shouldPromote = get( accountInfo, [
 		'signalCount',

--- a/client/components/feedback/util.js
+++ b/client/components/feedback/util.js
@@ -3,18 +3,18 @@
  */
 import { isObject } from 'lodash';
 
-const addFrameOffsets = ( offset, frame ) => ( {
-	left: offset.left + frame.x + window.scrollX,
+const addFrameOffsets = ( offset, frame, win = window ) => ( {
+	left: offset.left + frame.x + win.scrollX,
 	right:
 		offset.right +
-		( window.innerWidth > frame.left + frame.width
-			? window.innerWidth - frame.left - frame.width
+		( win.innerWidth > frame.left + frame.width
+			? win.innerWidth - frame.left - frame.width
 			: 0 ),
-	top: offset.top + frame.y + window.scrollY,
+	top: offset.top + frame.y + win.scrollY,
 	bottom:
 		offset.bottom +
-		( window.innerHeight > frame.top + frame.height
-			? window.innerHeight - frame.top - frame.height
+		( win.innerHeight > frame.top + frame.height
+			? win.innerHeight - frame.top - frame.height
 			: 0 ),
 } );
 
@@ -25,10 +25,10 @@ const getFeedbackButtonHorizontalPosition = ( align, width, offset ) => {
 	};
 };
 
-const getFeedbackButtonVerticalPosition = ( verticalAlign, height, offset ) => {
+const getFeedbackButtonVerticalPosition = ( verticalAlign, height, offset, win = window ) => {
 	if ( verticalAlign === 'center' ) {
 		return {
-			top: ( window.innerHeight - height ) / 2,
+			top: ( win.innerHeight - height ) / 2,
 			bottom: null,
 		};
 	}
@@ -45,7 +45,8 @@ export const getFeedbackButtonPosition = (
 	width,
 	height,
 	padding,
-	frameElement = null
+	frameElement = null,
+	win = window
 ) => {
 	let offset = {
 		left: isObject( padding ) ? padding.left : padding,
@@ -57,12 +58,13 @@ export const getFeedbackButtonPosition = (
 	if ( frameElement ) {
 		offset = addFrameOffsets(
 			offset,
-			frameElement.getBoundingClientRect()
+			frameElement.getBoundingClientRect(),
+			win
 		);
 	}
 
 	return {
 		...getFeedbackButtonHorizontalPosition( align, width, offset ),
-		...getFeedbackButtonVerticalPosition( verticalAlign, height, offset ),
+		...getFeedbackButtonVerticalPosition( verticalAlign, height, offset, win ),
 	};
 };

--- a/client/components/poll/util.js
+++ b/client/components/poll/util.js
@@ -62,7 +62,7 @@ export const isAnswerEmpty = ( answer ) =>
  *
  * @param {*} font The name of the Google font
  */
-export const loadCustomFont = ( font ) => {
+export const loadCustomFont = ( font, doc = document ) => {
 	if (
 		isEmpty( font ) ||
 		FontFamilyType.THEME_DEFAULT === font ||
@@ -73,15 +73,15 @@ export const loadCustomFont = ( font ) => {
 
 	const googleFontsLink = `https://fonts.googleapis.com/css2?family=${ font }:wght@400;600;700&display=swap`;
 	const crowdsignalFonts = filter(
-		Array.from( document.head.childNodes ),
+		Array.from( doc.head.childNodes ),
 		( node ) =>
 			node.nodeName.toLowerCase() === 'link' &&
 			node.href === googleFontsLink
 	);
 
 	if ( crowdsignalFonts.length === 0 ) {
-		document.head.appendChild(
-			tap( document.createElement( 'link' ), ( link ) => {
+		doc.head.appendChild(
+			tap( doc.createElement( 'link' ), ( link ) => {
 				link.type = 'text/css';
 				link.rel = 'stylesheet';
 				link.href = googleFontsLink;

--- a/client/components/with-fixed-position/index.js
+++ b/client/components/with-fixed-position/index.js
@@ -78,9 +78,11 @@ export const withFixedPositionControl = ( BlockEdit ) => {
 
 		const setPosition = useCallback(
 			( value ) => {
-				setOffset[ props.clientId ](
-					pick( value, [ 'top', 'left', 'right', 'bottom' ] )
-				);
+				if ( typeof setOffset[ props.clientId ] === 'function' ) {
+					setOffset[ props.clientId ](
+						pick( value, [ 'top', 'left', 'right', 'bottom' ] )
+					);
+				}
 			},
 			[ props.clientId ]
 		);


### PR DESCRIPTION
## Summary

Depends on #306.

With Block API v3, the editor runs inside an iframe where `window` and
`document` refer to the parent frame, not the editor frame. This PR replaces
all remaining global DOM access in editor code with iframe-safe equivalents
using `ownerDocument` / `defaultView` from element refs.

See [Migrating Blocks for iframe Editor Compatibility](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/block-migration-for-iframe-editor-compatibility/).

**feedback/edit.js:**
- Replaced `window.requestAnimationFrame` with `defaultView.requestAnimationFrame`
- Replaced `document.getElementsByClassName` with `ownerDocument.getElementsByClassName`
- Replaced `window.innerHeight` / `window.innerWidth` with `defaultView` equivalents
- Simplified the overlay position guard (removed `ownerDocument !== document`
  check, now uses presence of the content wrapper element)

**components/feedback/util.js:**
- Added `win` parameter to `addFrameOffsets`, `getFeedbackButtonVerticalPosition`,
  and `getFeedbackButtonPosition` so callers can pass the correct window context

**components/poll/util.js:**
- Added `doc` parameter to `loadCustomFont` — replaces `document.head` and
  `document.createElement` with the passed document reference

**blocks/poll/edit.js:**
- Added `blockRef` merged with `blockProps.ref` to provide `ownerDocument`
  to `loadCustomFont`

**components/with-fixed-position/index.js:**
- Guarded `setOffset[clientId]()` call — the registry callback may not be
  ready on the first render cycle in the iframe editor

### Files changed (5 files)

- `client/blocks/feedback/edit.js`
- `client/blocks/poll/edit.js`
- `client/components/feedback/util.js`
- `client/components/poll/util.js`
- `client/components/with-fixed-position/index.js`

## Testing

1. Build: `nvm use 18 && pnpm build` — no errors
2. In WordPress 7.0 (iframe editor): insert a feedback block — confirm it
   positions correctly and no console errors appear
3. Insert a poll block with a custom Google Font — confirm the font loads
   (check `<head>` of the iframe document for the Google Fonts `<link>`)
4. Open and close the feedback popover overlay — confirm overlay dimensions
   match the editor content area