### PR TITLE
Fix deprecated Toolbar and defaultProps usage

### DIFF
--- a/client/blocks/applause/toolbar.js
+++ b/client/blocks/applause/toolbar.js
@@ -13,7 +13,6 @@ import {
 	Popover,
 	TextControl,
 	ToolbarGroup,
-	Toolbar,
 } from '@wordpress/components';
 
 /**
@@ -61,7 +60,7 @@ const ToolBar = ( { attributes, setAttributes } ) => {
 					};
 				} ) }
 			/>
-			<Toolbar
+			<ToolbarGroup
 				controls={ [
 					{
 						icon: BorderIcon,

--- a/client/blocks/poll/toolbar.js
+++ b/client/blocks/poll/toolbar.js
@@ -8,7 +8,7 @@ import { map } from 'lodash';
  * WordPress dependencies
  */
 import { BlockControls } from '@wordpress/block-editor';
-import { Toolbar } from '@wordpress/components';
+import { ToolbarGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -44,7 +44,7 @@ const PollToolbar = ( { attributes, setAttributes } ) => {
 
 	return (
 		<BlockControls>
-			<Toolbar controls={ multipleChoiceToolbar } />
+			<ToolbarGroup controls={ multipleChoiceToolbar } />
 		</BlockControls>
 	);
 };

--- a/client/components/block-alignment-control/index.js
+++ b/client/components/block-alignment-control/index.js
@@ -18,10 +18,10 @@ import Grid from './grid';
 import Icon from './icon';
 
 const BlockAlignmentControl = ( {
-	closeOnSelectionChanged,
+	closeOnSelectionChanged = false,
 	disabled,
-	label,
-	onChange,
+	label = __( 'Change block position', 'crowdsignal-forms' ),
+	onChange = noop,
 	rows,
 	columns,
 	value,
@@ -84,12 +84,6 @@ const BlockAlignmentControl = ( {
 			} }
 		/>
 	);
-};
-
-BlockAlignmentControl.defaultProps = {
-	closeOnSelectionChanged: false,
-	label: __( 'Change block position', 'crowdsignal-forms' ),
-	onChange: noop,
 };
 
 export default BlockAlignmentControl;


### PR DESCRIPTION
## Summary

- Replace `Toolbar` with `ToolbarGroup` in applause and poll block toolbars to silence the WP 5.6 deprecation warning about `Toolbar` without a `label` prop
- Move `BlockAlignmentControl.defaultProps` to default parameter values for React 19 compatibility (React is removing `defaultProps` for function components)

### Files changed (3 files)

- `client/blocks/applause/toolbar.js`
- `client/blocks/poll/toolbar.js`
- `client/components/block-alignment-control/index.js`

## Test plan

- Insert an applause block — confirm the border settings toolbar popover opens and works
- Insert a poll block — confirm the single/multiple choice toggle works
- Insert a feedback block — confirm the position grid dropdown opens and responds to clicks
- Verify no `Toolbar without label` deprecation warnings in the console