### PR TITLE
Migrate to React 19-compatible render APIs

### DIFF
--- a/client/components/vote/vote-item.js
+++ b/client/components/vote/vote-item.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { CSSTransition, SwitchTransition } from 'react-transition-group';
 
@@ -28,6 +28,14 @@ const VoteItem = ( props ) => {
 	const { className, type } = attributes;
 
 	const [ currentVote, setCurrentVote ] = useState( 0 );
+
+	// Two refs alternated by parity so SwitchTransition's overlapping
+	// entering/exiting children each keep a stable nodeRef. Required
+	// because react-transition-group calls findDOMNode without it,
+	// which React 19 removes.
+	const refEven = useRef( null );
+	const refOdd = useRef( null );
+	const nodeRef = currentVote % 2 === 0 ? refEven : refOdd;
 
 	const handleVote = () => {
 		if ( disabled || ! onVote ) {
@@ -73,10 +81,14 @@ const VoteItem = ( props ) => {
 				<SwitchTransition mode="in-out">
 					<CSSTransition
 						key={ currentVote }
+						nodeRef={ nodeRef }
 						classNames="crowdsignal-forms-vote-item__count"
 						timeout={ 300 }
 					>
-						<div className="crowdsignal-forms-vote-item__count">
+						<div
+							ref={ nodeRef }
+							className="crowdsignal-forms-vote-item__count"
+						>
 							{ formatVoteCount( displayedVoteCount ) }
 						</div>
 					</CSSTransition>

--- a/client/lib/mutation-observer/index.js
+++ b/client/lib/mutation-observer/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from 'react-dom';
+import { createRoot } from '@wordpress/element';
 import { camelCase, isEmpty, forEach } from 'lodash';
 
 const MutationObserver = ( dataAttributeName, blockBuilder ) => {
@@ -30,7 +30,7 @@ const initBlocks = ( dataAttributeName, blockBuilder ) =>
 
 				element.removeAttribute( dataAttributeName );
 
-				render( block, element );
+				createRoot( element ).render( block );
 			} catch ( error ) {
 				// eslint-disable-next-line
 				console.error(

--- a/client/nps.js
+++ b/client/nps.js
@@ -2,8 +2,12 @@
  * External dependencies
  */
 import React from 'react';
-import { render } from 'react-dom';
 import { forEach } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { createRoot } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -49,17 +53,26 @@ window.addEventListener( 'load', () =>
 					}
 				}
 
-				const closeDialog = () => element.remove();
+				const root = createRoot( element );
+				let isUnmounted = false;
 
-				render(
+				const closeDialog = () => {
+					if ( isUnmounted ) {
+						return;
+					}
+					isUnmounted = true;
+					root.unmount();
+					element.remove();
+				};
+
+				root.render(
 					<DialogWrapper onClose={ closeDialog }>
 						<NpsBlock
 							attributes={ attributes }
 							contentWidth={ element.scrollWidth }
 							onClose={ closeDialog }
 						/>
-					</DialogWrapper>,
-					element
+					</DialogWrapper>
 				);
 			} catch ( error ) {
 				// eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary

Replaces legacy `ReactDOM.render` calls with `createRoot()`, and adds `nodeRef` to `react-transition-group`'s `CSSTransition` so the library no longer falls back to `findDOMNode`. Both APIs are removed in React 19, which ships in WordPress 7.1.

Source-level changes (3 commits, 3 files):

- **`client/lib/mutation-observer/index.js`** — `import { render } from 'react-dom'` → `import { createRoot } from '@wordpress/element'`; `render( block, element )` → `createRoot( element ).render( block )`. This is the shared frontend renderer for the Poll, Vote, Applause, and Feedback bundles.
- **`client/nps.js`** — same migration, plus the dialog's close callback now calls `root.unmount()` before `element.remove()` so the React tree tears down cleanly. Includes a small `isUnmounted` idempotency guard so a future double-close (e.g. if both `DialogWrapper.onClose` and `NpsBlock.onClose` fire for the same interaction) can't log a React warning.
- **`client/components/vote/vote-item.js`** — adds `nodeRef` to the `<CSSTransition>` inside `<SwitchTransition mode="in-out">`. Uses two alternating refs (`refEven` / `refOdd` keyed by `currentVote % 2`) because in-out mode keeps both children mounted briefly during the swap, so a shared single ref would be ambiguous. This pattern matches the official react-transition-group SwitchTransition guidance. Affects the `vote` frontend bundle and the `editor` bundle (which imports the same `VoteItem` via `client/blocks/vote-item/edit.js`).

Imports go via `@wordpress/element` (auto-externalized to `wp.element` by the dependency-extraction plugin), so when WP 7.1 swaps in React 19 the runtime picks up the new implementation automatically — no second migration required.

## Notes for reviewers

- **`findDOMNode` will still appear in `build/vote.js` and `build/editor.js`** as a literal string, but it's now dead code. `react-transition-group@4.4.5` keeps `findDOMNode` inside a `this.props.nodeRef ? this.props.nodeRef.current : findDOMNode(this)` ternary; once `nodeRef` is always supplied (this PR), the fallback branch is never executed at runtime. Eliminating the string entirely would require upgrading to `react-transition-group@5` (still pre-release as of this PR), which is intentionally out of scope.
- **`vote.asset.php` still declares `react-dom`** as a dependency because the bundled `react-transition-group` references `window.ReactDOM` for that dead-code path. Harmless under React 19's compat shim; will fall away with the `react-transition-group@5` upgrade.
- **`build/` is gitignored** — only source is in this PR.

## References

- WP Core announcement: https://make.wordpress.org/core/2026/05/27/react-19-upgrade-in-wordpress/
- Gutenberg tracking issue: https://github.com/WordPress/gutenberg/issues/71336
- React 19 upgrade guide: https://react.dev/blog/2024/04/25/react-19-upgrade-guide

## Test plan

Verified locally on a clean WP 7.0 install with a connected Crowdsignal account:

- [x] `pnpm lint:js` — pre-existing baseline only (this branch has 2 fewer errors than `master` because the removed `react-dom` imports were unresolvable to the path-alias resolver)
- [x] `pnpm test` — 45/45 unit tests pass (same pre-existing `with-fallback-styles` suite-load failure on `master` and this branch — unrelated)
- [x] `pnpm build` — clean, all bundles emit, `wp-element` correctly declared in `vote.asset.php` / `applause.asset.php` / `poll.asset.php` / `feedback.asset.php` / `nps.asset.php`
- [x] **Editor**: Poll / Vote / Applause / Feedback / NPS all render their normal edit UI with no console errors
- [x] **Frontend Poll** — renders, options selectable
- [x] **Frontend Vote** — thumbs-up click animates the count from 0 → 1; `crowdsignal-forms-vote-item__count-enter-done` class observed after transition (confirms CSSTransition lifecycle completed via `nodeRef`, NOT via `findDOMNode` fallback)
- [x] **Frontend Applause** — clicks increment count; clap animation plays
- [x] **Frontend NPS** — dialog opens at view threshold; **close button cleanly tears down React tree with no "orphaned root" / "cannot update unmounted root" warnings** (the key Task 2 regression check)
- [x] Frontend console clean throughout — no React errors, no `findDOMNode` warnings, no `ReactDOM.render` deprecations

## Out of scope (for follow-ups)

1. `forwardRef` in `client/components/feedback/toggle.js` — deprecated but not removed in React 19; future cleanup.
2. Upgrade to `react-transition-group@5` once stable — would obviate the `nodeRef` workaround and drop the `react-dom` external from the vote bundle.
3. CI guard that fails the build if `build/*.js` ever reintroduces direct `ReactDOM.render` patterns.
