### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -28,7 +28,7 @@ jobs:
         run: echo "Triggered by ${{ github.event_name }}"
 
       - name: Setup PHP 8.1 with PECL extension
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '8.1'
 
@@ -38,7 +38,7 @@ jobs:
           node-version: '18.13.0'
 
       - name: Install PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
         with:
           version: '9'
 
@@ -68,7 +68,7 @@ jobs:
           scripts/package-for-release.sh
 
       - name: Create nightly build release
-        uses: marvinpinto/action-automatic-releases@latest
+        uses: marvinpinto/action-automatic-releases@d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1 # latest
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           automatic_release_tag: ${{ github.event.inputs.releaseName }}


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

This PR was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 3
- Repo-level unpinned usage count from the trunk recheck: 3
- Dependabot GitHub Actions coverage: created (.github/dependabot.yml)

Known label limitations:
- `marvinpinto/action-automatic-releases` keeps `# latest` because the upstream `latest` tag is the only tag pointing to the frozen commit. The `v1.2.1` tag exists, but it points to a different commit, so switching to it would be an action version change rather than a relabel.

Verification commands:

```bash
# marvinpinto/action-automatic-releases # latest -> d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1
gh api repos/marvinpinto/action-automatic-releases/commits/latest --jq '.sha'
# expected: d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1

# pnpm/action-setup # v2.4.1 -> eae0cfeb286e66ffb5155f1a79b90583a127a68b
gh api repos/pnpm/action-setup/commits/v2.4.1 --jq '.sha'
# expected: eae0cfeb286e66ffb5155f1a79b90583a127a68b

# shivammathur/setup-php # 2.37.1 -> 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
gh api repos/shivammathur/setup-php/commits/2.37.1 --jq '.sha'
# expected: 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
```
