### PR TITLE
Bump to 1.8.1

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -3,8 +3,8 @@ Contributors: automattic
 Tags: polls, forms, surveys, gutenberg, block
 Requires at least: 6.0
 Requires PHP: 5.6.20
-Tested up to: 6.9
-Stable tag: 1.8.0
+Tested up to: 7.0
+Stable tag: 1.8.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,9 @@ Compare our [simple and affordable plans](https://crowdsignal.com/pricing/) or t
 4. Use the poll block inside of other blocks
 
 == Changelog ==
+
+= 1.8.1 =
+* Use a server-keyed checksum for NPS response updates (#312)
 
 = 1.8.0 =
 * Harden survey and poll data handling (#302)

--- a/crowdsignal-forms.php
+++ b/crowdsignal-forms.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Crowdsignal Forms
  * Plugin URI:        https://crowdsignal.com/crowdsignal-forms/
  * Description:       Crowdsignal Form Blocks
- * Version:           1.8.0
+ * Version:           1.8.1
  * Author:            Automattic
  * Author URI:        https://automattic.com/
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die;
 }
 
-define( 'CROWDSIGNAL_FORMS_VERSION', '1.8.0' );
+define( 'CROWDSIGNAL_FORMS_VERSION', '1.8.1' );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_FILE', __FILE__ );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/crowdsignal-forms",
-	"version": "1.8.0",
+	"version": "1.8.1",
 	"description": "Crowdsignal powered forms for WordPress",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Release 1.8.1.

- Version bumped to 1.8.1 in `package.json`, the plugin header, and `CROWDSIGNAL_FORMS_VERSION`.
- `README.TXT`: stable tag 1.8.1, changelog entry, and Tested up to 7.0.

Changelog:
* Use a server-keyed checksum for NPS response updates (#312)