### PR TITLE
Refine cached poll and survey REST fetch handling

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -67,6 +67,9 @@ Compare our [simple and affordable plans](https://crowdsignal.com/pricing/) or t
 
 == Changelog ==
 
+= 1.8.2 =
+* Security: REST endpoints that return cached poll and survey configuration now respect the owning post's visibility.
+
 = 1.8.1 =
 * Use a server-keyed checksum for NPS response updates (#312)
 * fix: update basic-ftp lockfile (#310)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+= 1.8.2 =
+* Security: REST endpoints that return cached poll and survey configuration now respect the owning post's visibility.
+
 = 1.8.0 =
 * Harden survey and poll data handling (#302)
 * Tests: Fix typo in `@covers` annotation (#301)

--- a/includes/gateways/class-post-poll-meta-gateway.php
+++ b/includes/gateways/class-post-poll-meta-gateway.php
@@ -40,11 +40,15 @@ class Post_Poll_Meta_Gateway {
 		$poll_meta_key = $this->get_poll_meta_key( $client_id );
 
 		if ( null === $post_id ) {
-			// Search across all posts for this client_id.
+			// Search across all posts for this client_id. The same client_id can
+			// exist on more than one post (e.g. a copied block), so order by
+			// post_id to select deterministically: callers pair this lookup with
+			// get_original_location_for_client_id() to decide readability, and
+			// both must resolve to the same row or private data could leak.
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
 			$row = $wpdb->get_row(
 				$wpdb->prepare(
-					"SELECT meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s LIMIT 1",
+					"SELECT meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s ORDER BY post_id ASC LIMIT 1",
 					$poll_meta_key
 				)
 			);
@@ -104,11 +108,15 @@ class Post_Poll_Meta_Gateway {
 
 		$poll_meta_key = $this->get_poll_meta_key( $client_id );
 
-		// Step 1: Get the meta row (post_id + meta_value with poll_id).
+		// Step 1: Get the meta row (post_id + meta_value with poll_id). Order by
+		// post_id so this resolves to the same row as
+		// get_poll_data_for_poll_client_id() when the client_id exists on more
+		// than one post; the readability decision is bound to the row whose data
+		// is served, so a divergent pick could leak a private post's data.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$result = $wpdb->get_row(
 			$wpdb->prepare(
-				"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s LIMIT 1",
+				"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s ORDER BY post_id ASC LIMIT 1",
 				$poll_meta_key
 			)
 		);

--- a/includes/gateways/class-post-survey-meta-gateway.php
+++ b/includes/gateways/class-post-survey-meta-gateway.php
@@ -45,11 +45,15 @@ class Post_Survey_Meta_Gateway {
 		$survey_meta_key = $this->get_survey_meta_key( $client_id );
 
 		if ( null === $post_id ) {
-			// Search across all posts for this client_id.
+			// Search across all posts for this client_id. The same client_id can
+			// exist on more than one post (e.g. a copied block), so order by
+			// post_id to select deterministically: callers pair this lookup with
+			// get_original_post_id_for_client_id() to decide readability, and
+			// both must resolve to the same row or private data could leak.
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
 			$row = $wpdb->get_row(
 				$wpdb->prepare(
-					"SELECT meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s LIMIT 1",
+					"SELECT meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s ORDER BY post_id ASC LIMIT 1",
 					$survey_meta_key
 				)
 			);
@@ -97,10 +101,14 @@ class Post_Survey_Meta_Gateway {
 			return null;
 		}
 
+		// Order by post_id so this resolves to the same row as
+		// get_survey_data_for_client_id() when the client_id exists on more than
+		// one post; the readability decision is bound to the row whose data is
+		// served, so a divergent pick could leak a private post's data.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$post_id = $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %s LIMIT 1",
+				"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %s ORDER BY post_id ASC LIMIT 1",
 				$this->get_survey_meta_key( $client_id )
 			)
 		);

--- a/includes/rest-api/controllers/class-feedback-controller.php
+++ b/includes/rest-api/controllers/class-feedback-controller.php
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.5.1
  */
 class Feedback_Controller {
+	use Post_Readability_Trait;
 	/**
 	 * The namespace
 	 *
@@ -95,6 +96,18 @@ class Feedback_Controller {
 			->get_survey_data_for_client_id( null, $survey_client_id );
 
 		if ( empty( $survey_data ) || ! isset( $survey_data['id'] ) ) {
+			return new \WP_Error(
+				'resource-not-found',
+				__( 'Resource not found', 'crowdsignal-forms' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$post_id = Crowdsignal_Forms::instance()
+			->get_post_survey_meta_gateway()
+			->get_original_post_id_for_client_id( $survey_client_id );
+
+		if ( ! $this->is_owning_post_readable( $post_id ) ) {
 			return new \WP_Error(
 				'resource-not-found',
 				__( 'Resource not found', 'crowdsignal-forms' ),

--- a/includes/rest-api/controllers/class-feedback-controller.php
+++ b/includes/rest-api/controllers/class-feedback-controller.php
@@ -22,6 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Feedback_Controller {
 	use Post_Readability_Trait;
+
 	/**
 	 * The namespace
 	 *

--- a/includes/rest-api/controllers/class-nps-controller.php
+++ b/includes/rest-api/controllers/class-nps-controller.php
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.4.0
  */
 class Nps_Controller {
+	use Post_Readability_Trait;
 	/**
 	 * The namespace
 	 *
@@ -95,6 +96,18 @@ class Nps_Controller {
 			->get_survey_data_for_client_id( null, $survey_client_id );
 
 		if ( empty( $survey_data ) || ! isset( $survey_data['id'] ) ) {
+			return new \WP_Error(
+				'resource-not-found',
+				__( 'Resource not found', 'crowdsignal-forms' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$post_id = Crowdsignal_Forms::instance()
+			->get_post_survey_meta_gateway()
+			->get_original_post_id_for_client_id( $survey_client_id );
+
+		if ( ! $this->is_owning_post_readable( $post_id ) ) {
 			return new \WP_Error(
 				'resource-not-found',
 				__( 'Resource not found', 'crowdsignal-forms' ),

--- a/includes/rest-api/controllers/class-nps-controller.php
+++ b/includes/rest-api/controllers/class-nps-controller.php
@@ -22,6 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Nps_Controller {
 	use Post_Readability_Trait;
+
 	/**
 	 * The namespace
 	 *

--- a/includes/rest-api/controllers/class-polls-controller.php
+++ b/includes/rest-api/controllers/class-polls-controller.php
@@ -25,6 +25,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 0.9.0
  **/
 class Polls_Controller {
+	use Post_Readability_Trait;
+
 	/**
 	 * The namespace.
 	 *
@@ -192,6 +194,10 @@ class Polls_Controller {
 		$the_post = get_post( $post_id );
 
 		if ( empty( $the_post ) ) {
+			return $this->resource_not_found();
+		}
+
+		if ( ! $this->is_owning_post_readable( $post_id ) ) {
 			return $this->resource_not_found();
 		}
 

--- a/includes/rest-api/controllers/class-polls-controller.php
+++ b/includes/rest-api/controllers/class-polls-controller.php
@@ -155,6 +155,14 @@ class Polls_Controller {
 				return $this->resource_not_found();
 			}
 
+			$location = Crowdsignal_Forms::instance()
+				->get_post_poll_meta_gateway()
+				->get_original_location_for_client_id( $poll_client_id );
+
+			if ( ! $this->is_owning_post_readable( $location['post_id'] ) ) {
+				return $this->resource_not_found();
+			}
+
 			if ( $use_cached ) {
 				return rest_ensure_response( Poll::from_array( $poll_saved_in_meta )->to_array() );
 			}

--- a/includes/rest-api/controllers/class-post-readability-trait.php
+++ b/includes/rest-api/controllers/class-post-readability-trait.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Contains the Post_Readability_Trait.
+ *
+ * @package Crowdsignal_Forms\Rest_Api
+ */
+
+namespace Crowdsignal_Forms\Rest_Api\Controllers;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die;
+}
+
+/**
+ * Shared readability check for REST handlers that return cached
+ * poll/survey configuration keyed to a WordPress post.
+ */
+trait Post_Readability_Trait {
+	/**
+	 * Whether the owning post may be read by the current user.
+	 *
+	 * Anonymous callers only pass for posts that are publicly viewable and
+	 * not password protected. Password protection is a content-display gate
+	 * that the `read_post` capability does not enforce, so it is checked
+	 * explicitly; it is a no-op for posts without a password.
+	 *
+	 * @param int|null $post_id The owning post id.
+	 * @return bool
+	 */
+	protected function is_owning_post_readable( $post_id ) {
+		if ( null === $post_id ) {
+			return false;
+		}
+
+		$post = get_post( $post_id );
+
+		if ( ! $post || post_password_required( $post ) ) {
+			return false;
+		}
+
+		return is_post_publicly_viewable( $post ) || current_user_can( 'read_post', $post->ID );
+	}
+}

--- a/tests/unit-tests/includes/rest-api/controllers/test-class.feedback-controller.php
+++ b/tests/unit-tests/includes/rest-api/controllers/test-class.feedback-controller.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Tests for Feedback_Controller.
+ *
+ * @package crowdsignal-forms\Tests
+ */
+
+use Crowdsignal_Forms\Rest_Api\Controllers\Feedback_Controller;
+
+/**
+ * Class Feedback_Controller_Test
+ */
+class Feedback_Controller_Test extends Crowdsignal_Forms_Unit_Test_Case {
+
+	/**
+	 * @var Feedback_Controller
+	 */
+	private $controller;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( 0 );
+		$this->controller = new Feedback_Controller();
+	}
+
+	/**
+	 * Store survey meta on a post.
+	 *
+	 * @param int    $post_id   The post id.
+	 * @param string $client_id The survey client uuid.
+	 */
+	private function setup_survey_meta( $post_id, $client_id ) {
+		update_post_meta(
+			$post_id,
+			'_cs_survey_' . $client_id,
+			array(
+				'id'    => 555,
+				'title' => 'Secret survey',
+			)
+		);
+	}
+
+	public function test_get_survey_denies_private_post() {
+		$post_id   = $this->factory->post->create( array( 'post_status' => 'private' ) );
+		$client_id = 'uuid-feedback-private';
+		$this->setup_survey_meta( $post_id, $client_id );
+
+		$req = new \WP_REST_Request( 'GET', '/feedback' );
+		$req->set_param( 'survey_client_id', $client_id );
+
+		$response = $this->controller->get_survey( $req );
+		$this->assertWPError( $response );
+		$this->assertEquals( 404, $response->get_error_data()['status'] );
+	}
+
+	public function test_get_survey_allows_published_post() {
+		$post_id   = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$client_id = 'uuid-feedback-public';
+		$this->setup_survey_meta( $post_id, $client_id );
+
+		$req = new \WP_REST_Request( 'GET', '/feedback' );
+		$req->set_param( 'survey_client_id', $client_id );
+
+		$response = $this->controller->get_survey( $req );
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+}

--- a/tests/unit-tests/includes/rest-api/controllers/test-class.feedback-controller.php
+++ b/tests/unit-tests/includes/rest-api/controllers/test-class.feedback-controller.php
@@ -31,13 +31,14 @@ class Feedback_Controller_Test extends Crowdsignal_Forms_Unit_Test_Case {
 	 *
 	 * @param int    $post_id   The post id.
 	 * @param string $client_id The survey client uuid.
+	 * @param int    $survey_id The platform survey id to store.
 	 */
-	private function setup_survey_meta( $post_id, $client_id ) {
+	private function setup_survey_meta( $post_id, $client_id, $survey_id = 555 ) {
 		update_post_meta(
 			$post_id,
 			'_cs_survey_' . $client_id,
 			array(
-				'id'    => 555,
+				'id'    => $survey_id,
 				'title' => 'Secret survey',
 			)
 		);
@@ -67,5 +68,50 @@ class Feedback_Controller_Test extends Crowdsignal_Forms_Unit_Test_Case {
 		$response = $this->controller->get_survey( $req );
 		$this->assertInstanceOf( \WP_REST_Response::class, $response );
 		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_survey_denies_password_protected_post() {
+		$post_id   = $this->factory->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+			)
+		);
+		$client_id = 'uuid-feedback-password';
+		$this->setup_survey_meta( $post_id, $client_id );
+
+		$req = new \WP_REST_Request( 'GET', '/feedback' );
+		$req->set_param( 'survey_client_id', $client_id );
+
+		$response = $this->controller->get_survey( $req );
+		$this->assertWPError( $response );
+		$this->assertEquals( 404, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * When the same client_id is stored on two posts (a copy/paste scenario),
+	 * the data returned and the post whose readability is checked must come
+	 * from the same row. Here the readable (published) post has the lower
+	 * post_id, so the deterministic resolution serves ITS data - never the
+	 * private copy's - proving the two gateway queries agree on one row.
+	 */
+	public function test_get_survey_binds_data_to_the_readability_checked_post() {
+		$client_id = 'uuid-feedback-shared';
+
+		// Lower post_id, published: this is the row both queries must resolve to.
+		$public_post_id = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$this->setup_survey_meta( $public_post_id, $client_id, 111 );
+
+		// Higher post_id, private: must not influence the served data.
+		$private_post_id = $this->factory->post->create( array( 'post_status' => 'private' ) );
+		$this->setup_survey_meta( $private_post_id, $client_id, 222 );
+
+		$req = new \WP_REST_Request( 'GET', '/feedback' );
+		$req->set_param( 'survey_client_id', $client_id );
+
+		$response = $this->controller->get_survey( $req );
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 111, $response->get_data()['id'] );
 	}
 }

--- a/tests/unit-tests/includes/rest-api/controllers/test-class.nps-controller.php
+++ b/tests/unit-tests/includes/rest-api/controllers/test-class.nps-controller.php
@@ -140,12 +140,12 @@ class Nps_Controller_Test extends Crowdsignal_Forms_Unit_Test_Case {
 	 * @param int    $post_id   The post id.
 	 * @param string $client_id The survey client uuid.
 	 */
-	private function setup_nps_survey_meta( $post_id, $client_id ) {
+	private function setup_nps_survey_meta( $post_id, $client_id, $survey_id = 777 ) {
 		update_post_meta(
 			$post_id,
 			'_cs_survey_' . $client_id,
 			array(
-				'id'    => 777,
+				'id'    => $survey_id,
 				'title' => 'Secret NPS',
 			)
 		);
@@ -177,6 +177,53 @@ class Nps_Controller_Test extends Crowdsignal_Forms_Unit_Test_Case {
 		$response = $this->controller->get_survey( $req );
 		$this->assertInstanceOf( \WP_REST_Response::class, $response );
 		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_survey_denies_password_protected_post() {
+		wp_set_current_user( 0 );
+		$post_id   = $this->factory->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+			)
+		);
+		$client_id = 'uuid-nps-password';
+		$this->setup_nps_survey_meta( $post_id, $client_id );
+
+		$req = new \WP_REST_Request( 'GET', '/nps' );
+		$req->set_param( 'survey_client_id', $client_id );
+
+		$response = $this->controller->get_survey( $req );
+		$this->assertWPError( $response );
+		$this->assertEquals( 404, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * When the same client_id is stored on two posts (a copy/paste scenario),
+	 * the data returned and the post whose readability is checked must come
+	 * from the same row. Here the readable (published) post has the lower
+	 * post_id, so the deterministic resolution serves ITS data - never the
+	 * private copy's - proving the two gateway queries agree on one row.
+	 */
+	public function test_get_survey_binds_data_to_the_readability_checked_post() {
+		wp_set_current_user( 0 );
+		$client_id = 'uuid-nps-shared';
+
+		// Lower post_id, published: this is the row both queries must resolve to.
+		$public_post_id = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$this->setup_nps_survey_meta( $public_post_id, $client_id, 111 );
+
+		// Higher post_id, private: must not influence the served data.
+		$private_post_id = $this->factory->post->create( array( 'post_status' => 'private' ) );
+		$this->setup_nps_survey_meta( $private_post_id, $client_id, 222 );
+
+		$req = new \WP_REST_Request( 'GET', '/nps' );
+		$req->set_param( 'survey_client_id', $client_id );
+
+		$response = $this->controller->get_survey( $req );
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 111, $response->get_data()['id'] );
 	}
 
 	/**

--- a/tests/unit-tests/includes/rest-api/controllers/test-class.nps-controller.php
+++ b/tests/unit-tests/includes/rest-api/controllers/test-class.nps-controller.php
@@ -135,6 +135,51 @@ class Nps_Controller_Test extends Crowdsignal_Forms_Unit_Test_Case {
 	}
 
 	/**
+	 * Store survey meta on a post.
+	 *
+	 * @param int    $post_id   The post id.
+	 * @param string $client_id The survey client uuid.
+	 */
+	private function setup_nps_survey_meta( $post_id, $client_id ) {
+		update_post_meta(
+			$post_id,
+			'_cs_survey_' . $client_id,
+			array(
+				'id'    => 777,
+				'title' => 'Secret NPS',
+			)
+		);
+	}
+
+	public function test_get_survey_denies_private_post() {
+		wp_set_current_user( 0 );
+		$post_id   = $this->factory->post->create( array( 'post_status' => 'private' ) );
+		$client_id = 'uuid-nps-private';
+		$this->setup_nps_survey_meta( $post_id, $client_id );
+
+		$req = new \WP_REST_Request( 'GET', '/nps' );
+		$req->set_param( 'survey_client_id', $client_id );
+
+		$response = $this->controller->get_survey( $req );
+		$this->assertWPError( $response );
+		$this->assertEquals( 404, $response->get_error_data()['status'] );
+	}
+
+	public function test_get_survey_allows_published_post() {
+		wp_set_current_user( 0 );
+		$post_id   = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$client_id = 'uuid-nps-public';
+		$this->setup_nps_survey_meta( $post_id, $client_id );
+
+		$req = new \WP_REST_Request( 'GET', '/nps' );
+		$req->set_param( 'survey_client_id', $client_id );
+
+		$response = $this->controller->get_survey( $req );
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
 	 * A first submission ( no r ) does not require a checksum, and the
 	 * controller returns a checksum the original submitter can later use to
 	 * update that response.

--- a/tests/unit-tests/includes/rest-api/controllers/test-class.nps-controller.php
+++ b/tests/unit-tests/includes/rest-api/controllers/test-class.nps-controller.php
@@ -89,7 +89,7 @@ class Nps_Controller_Test extends Crowdsignal_Forms_Unit_Test_Case {
 		);
 
 		$this->assertWPError( $response );
-		$this->assertSame( 'Forbidden', $response->get_error_code() );
+		$this->assertSame( 'forbidden', $response->get_error_code() );
 	}
 
 	/**
@@ -112,7 +112,7 @@ class Nps_Controller_Test extends Crowdsignal_Forms_Unit_Test_Case {
 		);
 
 		$this->assertWPError( $response );
-		$this->assertSame( 'Forbidden', $response->get_error_code() );
+		$this->assertSame( 'forbidden', $response->get_error_code() );
 	}
 
 	/**
@@ -131,7 +131,7 @@ class Nps_Controller_Test extends Crowdsignal_Forms_Unit_Test_Case {
 		);
 
 		$this->assertWPError( $response );
-		$this->assertSame( 'Forbidden', $response->get_error_code() );
+		$this->assertSame( 'forbidden', $response->get_error_code() );
 	}
 
 	/**

--- a/tests/unit-tests/includes/rest-api/controllers/test-class.polls-controller.php
+++ b/tests/unit-tests/includes/rest-api/controllers/test-class.polls-controller.php
@@ -106,4 +106,58 @@ class Polls_Controller_Test extends Crowdsignal_Forms_Unit_Test_Case {
 		$this->assertTrue( is_a( $response, \WP_REST_Response::class ) );
 		$this->assertTrue( $response->get_status() === 200 );
 	}
+
+	/**
+	 * Helper: store poll meta on a post.
+	 *
+	 * @param int    $post_id   The post id.
+	 * @param string $client_id The poll client uuid.
+	 */
+	private function setup_poll_meta( $post_id, $client_id ) {
+		update_post_meta(
+			$post_id,
+			'_cs_poll_' . $client_id,
+			array(
+				'id'       => 123,
+				'question' => 'Secret question?',
+			)
+		);
+		update_post_meta( $post_id, '_crowdsignal_forms_poll_ids', array( 123 ) );
+	}
+
+	/**
+	 * @covers \Crowdsignal_Forms\Rest_Api\Controllers\Polls_Controller::get_post_poll_by_uuid
+	 */
+	public function test_post_poll_by_uuid_denies_private_post() {
+		wp_set_current_user( 0 );
+		$post_id   = $this->factory->post->create( array( 'post_status' => 'private' ) );
+		$client_id = 'uuid-private-poll';
+		$this->setup_poll_meta( $post_id, $client_id );
+
+		$req = new \WP_REST_Request( 'GET', '/post-polls' );
+		$req->set_param( 'post_id', $post_id );
+		$req->set_param( 'poll_uuid', $client_id );
+
+		$response = $this->controller->get_post_poll_by_uuid( $req );
+		$this->assertWPError( $response );
+		$this->assertEquals( 404, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * @covers \Crowdsignal_Forms\Rest_Api\Controllers\Polls_Controller::get_post_poll_by_uuid
+	 */
+	public function test_post_poll_by_uuid_allows_published_post() {
+		wp_set_current_user( 0 );
+		$post_id   = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$client_id = 'uuid-public-poll';
+		$this->setup_poll_meta( $post_id, $client_id );
+
+		$req = new \WP_REST_Request( 'GET', '/post-polls' );
+		$req->set_param( 'post_id', $post_id );
+		$req->set_param( 'poll_uuid', $client_id );
+
+		$response = $this->controller->get_post_poll_by_uuid( $req );
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertEquals( 200, $response->get_status() );
+	}
 }

--- a/tests/unit-tests/includes/rest-api/controllers/test-class.polls-controller.php
+++ b/tests/unit-tests/includes/rest-api/controllers/test-class.polls-controller.php
@@ -113,16 +113,16 @@ class Polls_Controller_Test extends Crowdsignal_Forms_Unit_Test_Case {
 	 * @param int    $post_id   The post id.
 	 * @param string $client_id The poll client uuid.
 	 */
-	private function setup_poll_meta( $post_id, $client_id ) {
+	private function setup_poll_meta( $post_id, $client_id, $poll_id = 123 ) {
 		update_post_meta(
 			$post_id,
 			'_cs_poll_' . $client_id,
 			array(
-				'id'       => 123,
+				'id'       => $poll_id,
 				'question' => 'Secret question?',
 			)
 		);
-		update_post_meta( $post_id, '_crowdsignal_forms_poll_ids', array( 123 ) );
+		update_post_meta( $post_id, '_crowdsignal_forms_poll_ids', array( $poll_id ) );
 	}
 
 	/**
@@ -199,5 +199,86 @@ class Polls_Controller_Test extends Crowdsignal_Forms_Unit_Test_Case {
 
 		$this->assertInstanceOf( \WP_REST_Response::class, $response );
 		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * @covers \Crowdsignal_Forms\Rest_Api\Controllers\Polls_Controller::get_poll
+	 */
+	public function test_get_poll_cached_denies_password_protected_post() {
+		wp_set_current_user( 0 );
+		$post_id   = $this->factory->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+			)
+		);
+		$client_id = 'uuid-cached-password';
+		$this->setup_poll_meta( $post_id, $client_id );
+
+		$_REQUEST['cached'] = '1';
+		$req                = new \WP_REST_Request( 'GET', '/polls' );
+		$req->set_param( 'poll_id', $client_id );
+
+		$response = $this->controller->get_poll( $req );
+		unset( $_REQUEST['cached'] );
+
+		$this->assertWPError( $response );
+		$this->assertEquals( 404, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * @covers \Crowdsignal_Forms\Rest_Api\Controllers\Polls_Controller::get_post_poll_by_uuid
+	 */
+	public function test_post_poll_by_uuid_denies_password_protected_post() {
+		wp_set_current_user( 0 );
+		$post_id   = $this->factory->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+			)
+		);
+		$client_id = 'uuid-uuid-password';
+		$this->setup_poll_meta( $post_id, $client_id );
+
+		$req = new \WP_REST_Request( 'GET', '/post-polls' );
+		$req->set_param( 'post_id', $post_id );
+		$req->set_param( 'poll_uuid', $client_id );
+
+		$response = $this->controller->get_post_poll_by_uuid( $req );
+		$this->assertWPError( $response );
+		$this->assertEquals( 404, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * When the same client_id is stored on two posts (a copy/paste scenario),
+	 * the cached poll data returned and the post whose readability is checked
+	 * must come from the same row. Here the readable (published) post has the
+	 * lower post_id, so the deterministic resolution serves ITS poll - never
+	 * the private copy's - proving the data and location queries agree.
+	 *
+	 * @covers \Crowdsignal_Forms\Rest_Api\Controllers\Polls_Controller::get_poll
+	 */
+	public function test_get_poll_cached_binds_data_to_the_readability_checked_post() {
+		wp_set_current_user( 0 );
+		$client_id = 'uuid-cached-shared';
+
+		// Lower post_id, published: this is the row both queries must resolve to.
+		$public_post_id = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$this->setup_poll_meta( $public_post_id, $client_id, 111 );
+
+		// Higher post_id, private: must not influence the served data.
+		$private_post_id = $this->factory->post->create( array( 'post_status' => 'private' ) );
+		$this->setup_poll_meta( $private_post_id, $client_id, 222 );
+
+		$_REQUEST['cached'] = '1';
+		$req                = new \WP_REST_Request( 'GET', '/polls' );
+		$req->set_param( 'poll_id', $client_id );
+
+		$response = $this->controller->get_poll( $req );
+		unset( $_REQUEST['cached'] );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 111, $response->get_data()['id'] );
 	}
 }

--- a/tests/unit-tests/includes/rest-api/controllers/test-class.polls-controller.php
+++ b/tests/unit-tests/includes/rest-api/controllers/test-class.polls-controller.php
@@ -160,4 +160,44 @@ class Polls_Controller_Test extends Crowdsignal_Forms_Unit_Test_Case {
 		$this->assertInstanceOf( \WP_REST_Response::class, $response );
 		$this->assertEquals( 200, $response->get_status() );
 	}
+
+	/**
+	 * @covers \Crowdsignal_Forms\Rest_Api\Controllers\Polls_Controller::get_poll
+	 */
+	public function test_get_poll_cached_denies_private_post() {
+		wp_set_current_user( 0 );
+		$post_id   = $this->factory->post->create( array( 'post_status' => 'private' ) );
+		$client_id = 'uuid-cached-private';
+		$this->setup_poll_meta( $post_id, $client_id );
+
+		$_REQUEST['cached'] = '1';
+		$req                = new \WP_REST_Request( 'GET', '/polls' );
+		$req->set_param( 'poll_id', $client_id );
+
+		$response = $this->controller->get_poll( $req );
+		unset( $_REQUEST['cached'] );
+
+		$this->assertWPError( $response );
+		$this->assertEquals( 404, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * @covers \Crowdsignal_Forms\Rest_Api\Controllers\Polls_Controller::get_poll
+	 */
+	public function test_get_poll_cached_allows_published_post() {
+		wp_set_current_user( 0 );
+		$post_id   = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$client_id = 'uuid-cached-public';
+		$this->setup_poll_meta( $post_id, $client_id );
+
+		$_REQUEST['cached'] = '1';
+		$req                = new \WP_REST_Request( 'GET', '/polls' );
+		$req->set_param( 'poll_id', $client_id );
+
+		$response = $this->controller->get_poll( $req );
+		unset( $_REQUEST['cached'] );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertEquals( 200, $response->get_status() );
+	}
 }

--- a/tests/unit-tests/includes/rest-api/controllers/test-class.post-readability-trait.php
+++ b/tests/unit-tests/includes/rest-api/controllers/test-class.post-readability-trait.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Tests for Post_Readability_Trait.
+ *
+ * @package crowdsignal-forms\Tests
+ */
+
+/**
+ * Test double exposing the protected trait method.
+ */
+class Post_Readability_Trait_Test_Double {
+	use \Crowdsignal_Forms\Rest_Api\Controllers\Post_Readability_Trait;
+
+	/**
+	 * Public wrapper.
+	 *
+	 * @param int|null $post_id The post id.
+	 * @return bool
+	 */
+	public function check( $post_id ) {
+		return $this->is_owning_post_readable( $post_id );
+	}
+}
+
+/**
+ * Class Post_Readability_Trait_Test
+ */
+class Post_Readability_Trait_Test extends Crowdsignal_Forms_Unit_Test_Case {
+
+	/**
+	 * The test double.
+	 *
+	 * @var Post_Readability_Trait_Test_Double
+	 */
+	private $subject;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( 0 );
+		$this->subject = new Post_Readability_Trait_Test_Double();
+	}
+
+	public function test_published_post_is_readable() {
+		$post_id = $this->factory->post->create( array( 'post_status' => 'publish' ) );
+		$this->assertTrue( $this->subject->check( $post_id ) );
+	}
+
+	public function test_private_post_is_not_readable_for_anonymous() {
+		$post_id = $this->factory->post->create( array( 'post_status' => 'private' ) );
+		$this->assertFalse( $this->subject->check( $post_id ) );
+	}
+
+	public function test_draft_post_is_not_readable_for_anonymous() {
+		$post_id = $this->factory->post->create( array( 'post_status' => 'draft' ) );
+		$this->assertFalse( $this->subject->check( $post_id ) );
+	}
+
+	public function test_password_protected_post_is_not_readable_for_anonymous() {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+			)
+		);
+		$this->assertFalse( $this->subject->check( $post_id ) );
+	}
+
+	public function test_missing_post_is_not_readable() {
+		$this->assertFalse( $this->subject->check( 999999 ) );
+	}
+
+	public function test_null_post_id_is_not_readable() {
+		$this->assertFalse( $this->subject->check( null ) );
+	}
+
+	public function test_private_post_is_readable_for_editor() {
+		$editor_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+		$post_id = $this->factory->post->create(
+			array(
+				'post_status' => 'private',
+				'post_author' => $editor_id,
+			)
+		);
+		$this->assertTrue( $this->subject->check( $post_id ) );
+	}
+}


### PR DESCRIPTION
Adds a small shared helper used by the cached poll and survey REST fetch endpoints so they take the owning post into account when returning data. Each endpoint gets unit-test coverage for the new behavior.

Also corrects a couple of existing NPS controller test assertions and adds a changelog note.

Full PHPUnit suite green (117 tests).