### PR TITLE
Release Crowdsignal Forms 1.8.2

### DIFF
--- a/crowdsignal-forms.php
+++ b/crowdsignal-forms.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Crowdsignal Forms
  * Plugin URI:        https://crowdsignal.com/crowdsignal-forms/
  * Description:       Crowdsignal Form Blocks
- * Version:           1.8.1
+ * Version: 1.8.2
  * Author:            Automattic
  * Author URI:        https://automattic.com/
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die;
 }
 
-define( 'CROWDSIGNAL_FORMS_VERSION', '1.8.1' );
+define( 'CROWDSIGNAL_FORMS_VERSION', '1.8.2' );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_FILE', __FILE__ );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 

--- a/languages/crowdsignal-forms.pot
+++ b/languages/crowdsignal-forms.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Crowdsignal Forms 1.8.0\n"
+"Project-Id-Version: Crowdsignal Forms 1.8.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/crowdsignal-forms\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-02-10T14:30:36+00:00\n"
+"POT-Creation-Date: 2026-07-06T13:26:50+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: crowdsignal-forms\n"
@@ -241,7 +241,7 @@ msgstr ""
 msgid "Do you want to know more about Crowdsignal and our blocks? <a href=\"%1$s\" target=\"_blank\">Learn more</a>."
 msgstr ""
 
-#: includes/class-crowdsignal-forms.php:480
+#: includes/class-crowdsignal-forms.php:491
 msgid "Crowdsignal"
 msgstr ""
 
@@ -310,23 +310,29 @@ msgstr ""
 msgid "Poll not found"
 msgstr ""
 
-#: includes/rest-api/controllers/class-feedback-controller.php:88
-#: includes/rest-api/controllers/class-nps-controller.php:88
+#: includes/rest-api/controllers/class-feedback-controller.php:90
+#: includes/rest-api/controllers/class-nps-controller.php:90
 msgid "Invalid survey client ID"
 msgstr ""
 
-#: includes/rest-api/controllers/class-feedback-controller.php:100
-#: includes/rest-api/controllers/class-nps-controller.php:100
-#: includes/rest-api/controllers/class-polls-controller.php:278
+#: includes/rest-api/controllers/class-feedback-controller.php:102
+#: includes/rest-api/controllers/class-feedback-controller.php:114
+#: includes/rest-api/controllers/class-nps-controller.php:102
+#: includes/rest-api/controllers/class-nps-controller.php:114
+#: includes/rest-api/controllers/class-polls-controller.php:292
 msgid "Resource not found"
 msgstr ""
 
-#: includes/rest-api/controllers/class-polls-controller.php:138
-#: includes/rest-api/controllers/class-polls-controller.php:201
+#: includes/rest-api/controllers/class-nps-controller.php:166
+msgid "Forbidden"
+msgstr ""
+
+#: includes/rest-api/controllers/class-polls-controller.php:140
+#: includes/rest-api/controllers/class-polls-controller.php:215
 msgid "Invalid poll ID"
 msgstr ""
 
-#: includes/rest-api/controllers/class-polls-controller.php:187
+#: includes/rest-api/controllers/class-polls-controller.php:197
 msgid "Invalid post ID"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: polls, forms, surveys, gutenberg, block
 Requires at least: 6.0
 Requires PHP: 5.6.20
 Tested up to: 7.0
-Stable tag: 1.8.1
+Stable tag: 1.8.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION


> [!IMPORTANT]
> Merging this PR will build and publish the new version automatically as a GitHub release, then deploy the new version on the WordPress.org plugin repository.
>

## Crowdsignal Forms 1.8.2

> [!NOTE]
> These release notes between the two `---` lines will be the final changelog entry for the release. Edit them freely here before merging.
>

### Release Notes

---
* Add a filter that users can use to prevent redirect on activation. (#293)
* Migrate to React 19-compatible render APIs [#309]
* Refine cached poll and survey REST fetch handling [#319]
---

### Release

> [!NOTE]
> Click 'Ready for Review', ping the team, review the PR and merge. Upon merging, automation will:
> - Write the release notes above to the changelog
> - Create and tag a new GitHub release
> - Deploy the release to WordPress.org
