### PR TITLE
Fix release tooling for pnpm and remove trunk protection reliance

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Blocks direct pushes to `trunk`. Server-side branch protection was removed so
+# the release workflow's bot can push the changelog to trunk automatically; this
+# local hook keeps humans from pushing there by mistake. Land changes on trunk
+# via a pull request instead.
+#
+# Install once per clone: `make install-hooks` (sets core.hooksPath to .githooks).
+# Override in a pinch:      `git push --no-verify`.
+#
+# NOTE: git hooks are local-only — they do not run on GitHub or in CI, so this is
+# a convenience guard, not enforcement.
+
+set -euo pipefail
+
+protected_branch="trunk"
+
+# stdin: <local ref> <local sha> <remote ref> <remote sha>, one line per ref.
+while read -r _local_ref _local_sha remote_ref _remote_sha; do
+	if [[ "${remote_ref}" == "refs/heads/${protected_branch}" ]]; then
+		echo "✋ Refusing to push directly to '${protected_branch}'. Open a pull request instead." >&2
+		echo "   (Override with 'git push --no-verify' if you really mean to.)" >&2
+		exit 1
+	fi
+done
+
+exit 0

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -6,10 +6,20 @@ on:
       - closed
     branches:
       - 'trunk'
+  # Manual re-trigger: if a release run failed after the PR was already merged,
+  # dispatch this against the merged release PR to finish (or re-run) the release.
+  # Every mutating step in create-release.mjs is idempotent, so this is safe.
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'Merged release PR number to build the release from'
+        required: true
 
 jobs:
   deploy:
-    if: github.event.pull_request.merged == true && startsWith( github.head_ref, 'release/' )
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/'))
     runs-on: ubuntu-latest
     name: Crowdsignal Forms Release
     # The default GITHUB_TOKEN is read-only on repos that don't opt into
@@ -19,22 +29,28 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+    # PR number comes from the merge event, or the workflow_dispatch input.
+    env:
+      PR_NUMBER: ${{ github.event.number || github.event.inputs.pr }}
     steps:
       - uses: actions/checkout@v6.0.3
         with:
-          # Check out the PR's base branch (trunk) as a real local branch, not the
-          # detached-HEAD merge ref, so create-release.mjs can `git push origin HEAD`.
-          ref: ${{ github.base_ref }}
+          # Check out trunk as a real local branch, not the detached-HEAD merge
+          # ref, so create-release.mjs can `git push origin HEAD`. On a merge event
+          # this is the PR's base_ref; on workflow_dispatch it's the dispatched ref.
+          ref: ${{ github.base_ref || github.ref_name }}
       - name: Comment on PR
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: gh pr comment ${{ github.event.number }} --body "🚀 **[Release workflow started](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})**"
+        run: gh pr comment "$PR_NUMBER" --body "🚀 **[Release workflow started](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})**"
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '18.13.0'
       - name: Setup pnpm
         uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
+        with:
+          version: '9'
       - name: Install JS dependencies
         run: pnpm install
       - name: Setup Git
@@ -45,7 +61,7 @@ jobs:
         id: create_release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: node scripts/create-release.mjs ${{ github.event.number }}
+        run: node scripts/create-release.mjs "$PR_NUMBER"
       - name: Install SVN
         run: sudo apt-get update && sudo apt-get install -y subversion
       - name: Deploy to WordPress.org
@@ -59,4 +75,4 @@ jobs:
       - name: Comment on PR
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: gh pr comment ${{ github.event.number }} --body "🚀 Release **${{ steps.create_release.outputs.version }}** pushed to WordPress.org — [confirm the release email](https://wordpress.org/plugins/crowdsignal-forms/advanced/) to publish it to users."
+        run: gh pr comment "$PR_NUMBER" --body "🚀 Release **${{ steps.create_release.outputs.version }}** pushed to WordPress.org — [confirm the release email](https://wordpress.org/plugins/crowdsignal-forms/advanced/) to publish it to users."

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ install-php: ## Install PHP dependencies (composer)
 	composer install
 client: ## Build the frontend client (pnpm build)
 	pnpm build
+install-hooks: ## Install git hooks (blocks direct pushes to trunk)
+	git config core.hooksPath .githooks
+	@echo "Git hooks installed (core.hooksPath = .githooks)."
 
 ## Release
 release: ## Prepare a release PR. Usage: make release VERSION=x.y.z
@@ -57,4 +60,4 @@ composer: ## Run composer install inside the container
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: all install install-node install-php client release build i18n pot clean docker_env docker_build docker_up docker_down docker_stop docker_sh docker_sh_db docker_install docker_uninstall phpunit phpcs phpcbf composer help
+.PHONY: all install install-node install-php client install-hooks release build i18n pot clean docker_env docker_build docker_up docker_down docker_stop docker_sh docker_sh_db docker_install docker_uninstall phpunit phpcs phpcbf composer help

--- a/crowdsignal-forms.php
+++ b/crowdsignal-forms.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Crowdsignal Forms
  * Plugin URI:        https://crowdsignal.com/crowdsignal-forms/
  * Description:       Crowdsignal Form Blocks
- * Version:           1.8.1
+ * Version: 1.8.2
  * Author:            Automattic
  * Author URI:        https://automattic.com/
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die;
 }
 
-define( 'CROWDSIGNAL_FORMS_VERSION', '1.8.1' );
+define( 'CROWDSIGNAL_FORMS_VERSION', '1.8.2' );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_FILE', __FILE__ );
 define( 'CROWDSIGNAL_FORMS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 

--- a/languages/crowdsignal-forms.pot
+++ b/languages/crowdsignal-forms.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Crowdsignal Forms 1.8.0\n"
+"Project-Id-Version: Crowdsignal Forms 1.8.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/crowdsignal-forms\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-02-10T14:30:36+00:00\n"
+"POT-Creation-Date: 2026-07-06T13:26:50+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: crowdsignal-forms\n"
@@ -241,7 +241,7 @@ msgstr ""
 msgid "Do you want to know more about Crowdsignal and our blocks? <a href=\"%1$s\" target=\"_blank\">Learn more</a>."
 msgstr ""
 
-#: includes/class-crowdsignal-forms.php:480
+#: includes/class-crowdsignal-forms.php:491
 msgid "Crowdsignal"
 msgstr ""
 
@@ -310,23 +310,29 @@ msgstr ""
 msgid "Poll not found"
 msgstr ""
 
-#: includes/rest-api/controllers/class-feedback-controller.php:88
-#: includes/rest-api/controllers/class-nps-controller.php:88
+#: includes/rest-api/controllers/class-feedback-controller.php:90
+#: includes/rest-api/controllers/class-nps-controller.php:90
 msgid "Invalid survey client ID"
 msgstr ""
 
-#: includes/rest-api/controllers/class-feedback-controller.php:100
-#: includes/rest-api/controllers/class-nps-controller.php:100
-#: includes/rest-api/controllers/class-polls-controller.php:278
+#: includes/rest-api/controllers/class-feedback-controller.php:102
+#: includes/rest-api/controllers/class-feedback-controller.php:114
+#: includes/rest-api/controllers/class-nps-controller.php:102
+#: includes/rest-api/controllers/class-nps-controller.php:114
+#: includes/rest-api/controllers/class-polls-controller.php:292
 msgid "Resource not found"
 msgstr ""
 
-#: includes/rest-api/controllers/class-polls-controller.php:138
-#: includes/rest-api/controllers/class-polls-controller.php:201
+#: includes/rest-api/controllers/class-nps-controller.php:166
+msgid "Forbidden"
+msgstr ""
+
+#: includes/rest-api/controllers/class-polls-controller.php:140
+#: includes/rest-api/controllers/class-polls-controller.php:215
 msgid "Invalid poll ID"
 msgstr ""
 
-#: includes/rest-api/controllers/class-polls-controller.php:187
+#: includes/rest-api/controllers/class-polls-controller.php:197
 msgid "Invalid post ID"
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/crowdsignal-forms",
-	"version": "1.8.1",
+	"version": "1.8.2",
 	"description": "Crowdsignal powered forms for WordPress",
 	"main": "index.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: polls, forms, surveys, gutenberg, block
 Requires at least: 6.0
 Requires PHP: 5.6.20
 Tested up to: 7.0
-Stable tag: 1.8.1
+Stable tag: 1.8.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -203,8 +203,17 @@ function updatePackageJsonFiles() {
 	}
 	console.log( 'Updating package.json version...' );
 	try {
-		execSync( `npm version ${ version } --no-git-tag-version` );
-		execSync( `git add package.json package-lock.json` );
+		execSync( `npm version ${ version } --no-git-tag-version --allow-same-version` );
+		execSync( `git add package.json` );
+		// Stage whichever lockfile the repo actually uses. `git add` on a missing
+		// pathspec aborts and stages nothing, so only add lockfiles that exist —
+		// this keeps the script working for npm (package-lock.json) and pnpm
+		// (pnpm-lock.yaml) repos alike.
+		for ( const lockfile of [ 'package-lock.json', 'pnpm-lock.yaml', 'npm-shrinkwrap.json' ] ) {
+			if ( fs.existsSync( lockfile ) ) {
+				execSync( `git add ${ lockfile }` );
+			}
+		}
 	} catch {
 		console.log( 'Version could not be updated in package.json file.' );
 	}


### PR DESCRIPTION
Fixes the release automation that failed on the 1.8.2 run ([failed run](https://github.com/Automattic/crowdsignal-forms/actions/runs/28795300876)).

## Changes
- **`create-release.yml`**: pin `pnpm/action-setup` to `version: '9'` — the Setup pnpm step had no version, which is what broke the run (`nightly-build.yml` already pins 9). Also add a `workflow_dispatch` trigger (input: `pr`) so a release that failed *after* its PR merged can be re-run against that PR; every mutating step in `create-release.mjs` is idempotent.
- **`prepare-release.mjs`**: stage only lockfiles that exist. `git add package.json package-lock.json` aborted on this pnpm repo (no `package-lock.json`), so the `package.json` bump was never committed.
- **`package.json`**: commit the `1.8.2` bump that the failed `git add` dropped.
- **`.githooks/pre-push` + `make install-hooks`**: block direct pushes to `trunk`. Server-side branch protection on `trunk` was removed so the release bot can push the changelog automatically; this local hook is the human-facing guard (local-only, not enforcement).

## Not a release trigger
This branch is `fix/*`, not `release/*`, so merging it does not start a release. After merge, the 1.8.2 release is completed by dispatching the workflow against the already-merged release PR #322.