### PR TITLE
Release install: use --no-frozen-lockfile

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -52,7 +52,9 @@ jobs:
         with:
           version: '9'
       - name: Install JS dependencies
-        run: pnpm install
+        # --no-frozen-lockfile so CI can reconcile the release-tooling devDeps
+        # that aren't yet in pnpm-lock.yaml. (In CI, pnpm defaults frozen=true.)
+        run: pnpm install --no-frozen-lockfile
       - name: Setup Git
         run: |
           git config user.name "Crowdsignal Bot"


### PR DESCRIPTION
The 1.8.2 release run got past the pnpm-version fix but then failed at `pnpm install` with `ERR_PNPM_OUTDATED_LOCKFILE`: CI defaults `frozen-lockfile=true`, and `pnpm-lock.yaml` is missing the release-tooling devDeps added in #320 (`zx`, `inquirer`, `dotenv`, `chalk`).

This adds `--no-frozen-lockfile` to the release install so CI reconciles them, as #320 intended.

**Follow-up (not blocking):** the stale lockfile also breaks `nightly-build.yml` (same `pnpm install`). The clean fix is to commit a `pnpm-lock.yaml` regenerated with the CI pnpm version and restore frozen installs everywhere.