### PR TITLE
Handle CRLF in release-notes parsing

### DIFF
--- a/scripts/create-release.mjs
+++ b/scripts/create-release.mjs
@@ -65,7 +65,9 @@ await success();
  * @return {string} The release notes.
  */
 function getReleaseNotes() {
-	const prDescription = JSON.parse( execSync( `gh pr view ${ prNumber } -R ${ cfg.repo } --json body` ).toString() ).body;
+	// Normalize CRLF to LF: GitHub stores PR bodies edited in the web UI with
+	// CRLF line endings, which would break the `\n`-based fence regex below.
+	const prDescription = JSON.parse( execSync( `gh pr view ${ prNumber } -R ${ cfg.repo } --json body` ).toString() ).body.replace( /\r\n/g, '\n' );
 	// Both fences must sit on their own lines, and the capture is GREEDY so it
 	// runs to the LAST `---` line — the real closing fence. A non-greedy match
 	// would stop at the first interior `---` (e.g. a Markdown horizontal rule in


### PR DESCRIPTION
The 1.8.2 release run got through install and build setup, then `create-release.mjs` failed to parse PR #322's body: `Could not parse release notes from the PR body`.

Cause: the `### Release Notes` fence regex is `\n`-based, but GitHub stores PR bodies **edited in the web UI** with CRLF line endings — and editing the changelog in the PR body is the intended workflow. Verified against #322's actual body: fails before, matches after.

Fix: normalize `\r\n` → `\n` before matching. (The same shared script in blog-voyeur/WP Job Manager has this latent bug; worth porting the fix.)