### PR TITLE
Rebuild on rerun so a failed WordPress.org deploy can recover

### DIFF
--- a/scripts/create-release.mjs
+++ b/scripts/create-release.mjs
@@ -41,21 +41,33 @@ const prNumber = process.argv[ 2 ];
 // changelog fence aborts the run before it tags or ships anything.
 const releaseNotes = getReleaseNotes();
 
-// If the release already completed on a prior run, do nothing but emit the
-// version so the SVN deploy step can self-skip the existing tag.
-if ( remoteTagExists() && githubReleaseExists() ) {
-	console.log( chalk.yellow( `Release ${ pluginVersion } is already tagged and published on GitHub — nothing to do.` ) );
-	setWorkflowStepOutput();
-	process.exit( 0 );
+// If the release already completed on a prior run, skip the changelog/tag/GitHub
+// steps. Don't exit early, though: the SVN deploy step runs regardless and reads
+// from BUILD_DIR, which is absent on a fresh rerun runner — so we still rebuild
+// below so a rerun can recover a failed WordPress.org deploy. On a rerun the
+// changelog is already committed to the checked-out branch, so the rebuilt
+// package includes it.
+const alreadyReleased = remoteTagExists() && githubReleaseExists();
+
+if ( alreadyReleased ) {
+	console.log( chalk.yellow( `Release ${ pluginVersion } is already tagged and published on GitHub — rebuilding for the deploy step.` ) );
+} else {
+	updateChangelog();
+	commitChangelog();
+	tagRelease();
 }
 
-updateChangelog();
-commitChangelog();
-tagRelease();
 buildPluginZip();
-await createGithubRelease();
+
+if ( ! alreadyReleased ) {
+	await createGithubRelease();
+}
+
 setWorkflowStepOutput();
-await success();
+
+if ( ! alreadyReleased ) {
+	await success();
+}
 
 /**
  * Extract the release notes from the release PR body. Throws an explicit error


### PR DESCRIPTION
An AI reviewer flagged this P1 in the shared release tooling.

`create-release.mjs` exited early (`process.exit(0)`) when the git tag and GitHub release already existed — **before** `buildPluginZip()`. But the `Deploy to WordPress.org` workflow step runs regardless and reads from `BUILD_DIR`, which is absent on a fresh rerun runner. So a run that tagged + created the release but then **failed during SVN deploy** could not be re-run to recover — the rerun skipped the build, leaving `BUILD_DIR` empty.

Fix: don't exit early. Skip only the changelog/tag/GitHub-release steps on a rerun, but still `buildPluginZip()` so the deploy has its artifact. On a rerun the changelog is already committed to the checked-out branch, so the rebuilt package includes it; the happy-path order (changelog → build) is unchanged.

Ported to the other affected copies: crowdsignal-plugin #163, wp-super-cache #1069. WP-Job-Manager's older copy has no early-exit, so it's unaffected.