### PR TITLE
Guard empty PR body before CRLF normalization

### DIFF
--- a/scripts/create-release.mjs
+++ b/scripts/create-release.mjs
@@ -79,7 +79,9 @@ if ( ! alreadyReleased ) {
 function getReleaseNotes() {
 	// Normalize CRLF to LF: GitHub stores PR bodies edited in the web UI with
 	// CRLF line endings, which would break the `\n`-based fence regex below.
-	const prDescription = JSON.parse( execSync( `gh pr view ${ prNumber } -R ${ cfg.repo } --json body` ).toString() ).body.replace( /\r\n/g, '\n' );
+	// `|| ''` guards an empty/null PR body so the "missing fences" error below
+	// fires instead of a null TypeError.
+	const prDescription = ( JSON.parse( execSync( `gh pr view ${ prNumber } -R ${ cfg.repo } --json body` ).toString() ).body || '' ).replace( /\r\n/g, '\n' );
 	// Both fences must sit on their own lines, and the capture is GREEDY so it
 	// runs to the LAST `---` line — the real closing fence. A non-greedy match
 	// would stop at the first interior `---` (e.g. a Markdown horizontal rule in


### PR DESCRIPTION
A reviewer flagged that `getReleaseNotes()` calls `.replace()` on `.body` without a null check. If a release PR body is empty/null, that throws a generic `Cannot read properties of null` TypeError, bypassing the intended 'missing fences' error path.

Fix: coerce with `( ... || '' )` before CRLF normalization, so an empty body falls through to the explicit error.

Note: this one-liner was pushed to #327's branch *after* #327 had already merged, so it never reached trunk — this PR lands it. The same fix is going to the sibling copies (crowdsignal-plugin #163, wp-super-cache #1069, WP-Job-Manager #3001).