### PR TITLE
Update account link to app.crowdsignal.com

### DIFF
--- a/includes/admin/views/html-admin-settings.php
+++ b/includes/admin/views/html-admin-settings.php
@@ -33,7 +33,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				/* translators: Placeholder is the text "Crowdsignal acount page". */
 				esc_html__( 'Visit your %s to find out more about your settings.', 'crowdsignal-forms' ),
 				sprintf(
-					'<a href="https://crowdsignal.com/account/">%s</a>',
+					'<a href="https://app.crowdsignal.com/account/">%s</a>',
 					esc_html__( 'Crowdsignal account page', 'crowdsignal-forms' )
 				)
 			);

--- a/includes/admin/views/html-admin-settings.php
+++ b/includes/admin/views/html-admin-settings.php
@@ -30,7 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<br />
 			<?php
 			printf(
-				/* translators: Placeholder is the text "Crowdsignal acount page". */
+				/* translators: Placeholder is the text "Crowdsignal account page". */
 				esc_html__( 'Visit your %s to find out more about your settings.', 'crowdsignal-forms' ),
 				sprintf(
 					'<a href="https://app.crowdsignal.com/account/">%s</a>',


### PR DESCRIPTION
## Summary

Updates the "Crowdsignal account page" link on the admin settings screen to point to `https://app.crowdsignal.com/account/` instead of `https://crowdsignal.com/account/`.

Fixes #249

## Changes

- `includes/admin/views/html-admin-settings.php` — one line, updated the account page link URL.

**Before**

<img width="3726" height="1462" alt="SCR-20260710-minf" src="https://github.com/user-attachments/assets/c2230493-7b45-4ce7-af5d-c6154fa2a460" />


**After**

<img width="3650" height="1244" alt="SCR-20260710-mjnc" src="https://github.com/user-attachments/assets/5a38b9cc-d333-4efc-afab-586794208d37" />


## Testing

- Visit **Settings → Crowdsignal Forms** in wp-admin and confirm the "Crowdsignal account page" link now points to `https://app.crowdsignal.com/account/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)