### PR TITLE
Harden shared release tooling (sync with jetpack-crm)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,7 +19,7 @@ jobs:
   deploy:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/'))
+      (github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     name: Crowdsignal Forms Release
     # The default GITHUB_TOKEN is read-only on repos that don't opt into
@@ -33,7 +33,7 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.number || github.event.inputs.pr }}
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Check out trunk as a real local branch, not the detached-HEAD merge
           # ref, so create-release.mjs can `git push origin HEAD`. On a merge event
@@ -44,7 +44,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: gh pr comment "$PR_NUMBER" --body "🚀 **[Release workflow started](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})**"
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '18.13.0'
       - name: Setup pnpm

--- a/.github/workflows/lint-next-version.yml
+++ b/.github/workflows/lint-next-version.yml
@@ -7,7 +7,7 @@ jobs:
   next-version-tags:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
       - name: Check $$next-version$$ usage in added lines

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -47,6 +47,14 @@ if ( ! /^\d+(\.\d+)+(-(a|alpha|beta)([-.]?\d+)?)?$/.test( version ) ) {
 	process.exit( 1 );
 }
 
+// A release must be cut from a clean tree. The branch is created from the
+// current HEAD and `replaceNextVersionPlaceholder()` stages with `git add -u`,
+// which would sweep any modified tracked files into the release commit. Scope
+// the check to tracked changes: untracked files are never staged by the release
+// steps, so blocking on them would be a false positive. Fail fast, before the
+// confirmation prompt or any branch creation.
+assertCleanWorkingTree();
+
 const ghPrs = `gh pr list -R ${ cfg.repo } --state merged --base ${ BASE_BRANCH } --limit 500 --search "milestone:${ version }"`;
 
 // Confirm release through CLI.
@@ -97,6 +105,23 @@ function readFileContents( filepath ) {
 		return fs.readFileSync( filepath, 'utf8' );
 	} catch ( err ) {
 		throw new Error( `File (${ filepath }) could not be read.` );
+	}
+}
+
+/**
+ * Abort unless the working tree has no uncommitted changes to tracked files.
+ *
+ * A dirty tree is unsafe for a release: the release branch is cut from the
+ * current HEAD and `replaceNextVersionPlaceholder()` runs `git add -u`, which
+ * stages every modified tracked file — so stray edits would land in the release
+ * PR. Untracked files are excluded because no release step stages them.
+ */
+function assertCleanWorkingTree() {
+	const status = execSync( 'git status --porcelain --untracked-files=no' ).toString().trim();
+	if ( status ) {
+		console.log( chalk.bold.red( 'Error: the working tree has uncommitted changes to tracked files. Commit, stash or discard them before preparing a release.' ) );
+		console.log( status );
+		process.exit( 1 );
 	}
 }
 
@@ -322,6 +347,10 @@ function pushBranch() {
 /**
  * Revert the workspace to its original state.
  *
+ * Also deletes the release branch on the remote if it was already pushed (e.g.
+ * `createPR()` failed after `pushBranch()` succeeded) — otherwise the orphaned
+ * remote branch would block a retry, which recreates the same branch name.
+ *
  * @param {string} originalBranch The original branch name.
  * @param {string} branchToDelete The release branch to delete.
  */
@@ -330,4 +359,20 @@ function revertOnError( originalBranch, branchToDelete ) {
 	execSync( `git checkout . && git checkout ${ originalBranch }` );
 	console.log( `Deleting '${ branchToDelete }'....` );
 	execSync( `git branch -D ${ branchToDelete }` );
+
+	// Delete the remote branch too, but only if it exists. `git ls-remote
+	// --exit-code` exits non-zero when the branch isn't on the remote, so a
+	// throw here means "nothing to clean up".
+	try {
+		execSync( `git ls-remote --exit-code --heads ${ REMOTE } ${ branchToDelete }`, { stdio: 'ignore' } );
+	} catch {
+		return;
+	}
+	console.log( `Deleting '${ branchToDelete }' on ${ REMOTE }....` );
+	try {
+		execSync( `git push ${ REMOTE } --delete ${ branchToDelete }` );
+	} catch {
+		// Best-effort: don't let a failed remote cleanup mask the original error.
+		console.log( chalk.yellow( `Could not delete '${ branchToDelete }' on ${ REMOTE }; delete it manually before retrying.` ) );
+	}
 }


### PR DESCRIPTION
Ports four release-tooling hardening fixes from `Automattic/jetpack-crm` to keep the shared, config-driven release system identical across the plugin family.

## Changes

1. **Clean-tree guard** (`scripts/prepare-release.mjs`): new `assertCleanWorkingTree()` refuses to prepare a release from a dirty tree. The release branch is cut from HEAD and `replaceNextVersionPlaceholder()` runs `git add -u`, which would otherwise sweep unrelated modified tracked files into the release commit. Runs before the confirmation prompt / any branch creation. Untracked files are excluded (no release step stages them).

2. **Remote-branch rollback cleanup** (`scripts/prepare-release.mjs`): `revertOnError()` now also deletes the release branch on the remote if it was already pushed (e.g. `createPR()` failed after `pushBranch()` succeeded), so a stale remote branch can't block a retry. Best-effort; a failed remote cleanup won't mask the original error.

3. **Fork-merge deploy guard** (`.github/workflows/create-release.yml`): the `deploy` job `if:` now also requires `github.event.pull_request.head.repo.full_name == github.repository`, so the deploy path only runs for same-repo (non-fork) `release/*` merges. `workflow_dispatch` is unaffected.

4. **SHA-pin actions** (`create-release.yml`, `lint-next-version.yml`): pinned every action `uses:` that wasn't already a 40-hex commit SHA, keeping the original ref as a trailing comment (supply-chain hardening):
   - `actions/checkout@v6.0.3` → `df4cb1c…`
   - `actions/setup-node@v4` → `49933ea…`
   - `actions/checkout@v4` → `11d5960…`

Fix #5 (pre-push hook + `make install-hooks`) was skipped: this repo already has `.githooks/pre-push` and an `install-hooks` Makefile target.

These changes sync the shared release scripts with `Automattic/jetpack-crm`.